### PR TITLE
fix: add maxDuration=300 to generate-video route

### DIFF
--- a/src/app/api/generate-video/route.ts
+++ b/src/app/api/generate-video/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
+export const maxDuration = 300;
+
 export async function POST(req: NextRequest) {
   try {
     const { prompt } = await req.json();


### PR DESCRIPTION
Closes #8

Vercel's default function timeout is 10–15s. The video generation route polls for up to 5 minutes. Without `maxDuration = 300`, every request was killed mid-poll with a 504 gateway timeout.

**Change:** Added `export const maxDuration = 300` to the route file.