### PR TITLE
fix: read prompt query param on /create page

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -25,9 +25,11 @@ function CreatePageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const templateName = searchParams.get("template") || "";
+  const promptParam = searchParams.get("prompt") || "";
 
   const [step, setStep] = useState(0);
-  const [prompt, setPrompt] = useState(TEMPLATE_PROMPTS[templateName] || "");
+  // Prefer explicit prompt param (from presets page) over the static template map
+  const [prompt, setPrompt] = useState(promptParam || TEMPLATE_PROMPTS[templateName] || "");
   const [fps, setFps] = useState([24]);
   const [quality, setQuality] = useState([80]);
   const [isGenerating, setIsGenerating] = useState(false);


### PR DESCRIPTION
Closes #5

`/presets` links include `?prompt=...` but `/create` only checked `TEMPLATE_PROMPTS[templateName]`, so custom preset prompts were silently dropped.

**Fix:** Read `searchParams.get('prompt')` first; fall back to the static map.