### PR TITLE
fix: detect SVG demo frames and block export

### DIFF
--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -3,7 +3,15 @@ import JSZip from "jszip";
 
 export async function POST(req: NextRequest) {
   try {
-    const { frames, sections, siteName, fps } = await req.json();
+    const { frames, sections, siteName } = await req.json();
+
+    // Reject SVG demo-frame URLs — only real base64 data URIs are exportable
+    if (!frames?.length || !frames[0].startsWith("data:image/")) {
+      return NextResponse.json(
+        { error: "Cannot export demo frames. Generate real frames first using the AI or by uploading a video." },
+        { status: 400 }
+      );
+    }
 
     const zip = new JSZip();
     const framesFolder = zip.folder("frames")!;

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -81,11 +81,17 @@ function EditorInner() {
     if (framesParam) {
       try {
         const parsed = JSON.parse(framesParam);
-        setFrames(parsed);
-        setFrameCount(parseInt(countParam || String(parsed.length)));
-        setFps(parseInt(fpsParam || "24"));
+        // Frames that don't start with data:image/ are SVG demo URLs — treat as demo
+        const hasRealFrames = parsed.length > 0 && parsed[0].startsWith("data:image/");
+        if (!hasRealFrames) {
+          setIsDemo(true);
+          loadDemoFrames();
+        } else {
+          setFrames(parsed);
+          setFrameCount(parseInt(countParam || String(parsed.length)));
+          setFps(parseInt(fpsParam || "24"));
+        }
       } catch {
-        // demo mode
         setIsDemo(true);
         loadDemoFrames();
       }


### PR DESCRIPTION
Closes #6

When FFmpeg is absent, `/api/extract-frames` returns `/api/demo-frame?i=...` SVG URLs. The editor wasn't detecting these as demo frames, so `isDemo` stayed `false` and the export tried to base64-decode URL strings — crashing the ZIP builder.

**Editor fix:** After parsing frames from URL params, checks `frames[0].startsWith('data:image/')`. If false, forces demo mode.

**Export route fix:** Returns a clear `400` if frames aren't base64 data URIs, before touching JSZip.