### PR TITLE
fix: guard poll responses before parsing JSON (issue #11)

### DIFF
--- a/src/app/api/generate-video/route.ts
+++ b/src/app/api/generate-video/route.ts
@@ -5,8 +5,6 @@ export async function POST(req: NextRequest) {
     const { prompt } = await req.json();
     if (!prompt) return NextResponse.json({ error: "Prompt required" }, { status: 400 });
 
-    const apiKey = process.env.LUMAAI_API_KEY || process.env.RUNWAYML_API_KEY;
-
     // Luma AI (Dream Machine) path
     if (process.env.LUMAAI_API_KEY) {
       const genRes = await fetch("https://api.lumalabs.ai/dream-machine/v1/generations", {
@@ -35,6 +33,7 @@ export async function POST(req: NextRequest) {
         const pollRes = await fetch(`https://api.lumalabs.ai/dream-machine/v1/generations/${generationId}`, {
           headers: { "Authorization": `Bearer ${process.env.LUMAAI_API_KEY}` },
         });
+        if (!pollRes.ok) continue;
         const pollData = await pollRes.json();
         if (pollData.state === "completed") {
           videoUrl = pollData.assets?.video;
@@ -79,6 +78,7 @@ export async function POST(req: NextRequest) {
             "X-Runway-Version": "2024-11-06",
           },
         });
+        if (!pollRes.ok) continue;
         const pollData = await pollRes.json();
         if (pollData.status === "SUCCEEDED") {
           return NextResponse.json({ videoUrl: pollData.output?.[0] });


### PR DESCRIPTION
Closes #11

## Summary
- Added `if (!pollRes.ok) continue;` before both `.json()` calls in Luma AI and Runway ML polling loops
- On transient errors or 429 rate-limits the loop now skips that tick and retries on the next iteration instead of throwing
- Removed unused `apiKey` variable that was set but never referenced

## Test plan
- [ ] Confirm TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Trigger video generation; verify it still completes successfully when APIs are healthy
- [ ] Simulate a 429 from a poll endpoint — loop should survive and eventually complete or timeout cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)