### PR TITLE
fix: preserve aspect ratio in canvas frame rendering (issue #4)

### DIFF
--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -89,7 +89,10 @@ export async function POST(req: NextRequest) {
       function drawFrame(index) {
         const img = images[index];
         if (!img || !img.complete) return;
-        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        const scale = Math.max(canvas.width / img.naturalWidth, canvas.height / img.naturalHeight);
+        const w = img.naturalWidth * scale;
+        const h = img.naturalHeight * scale;
+        ctx.drawImage(img, (canvas.width - w) / 2, (canvas.height - h) / 2, w, h);
       }
 
       function preload() {

--- a/src/components/ScrollEngine.tsx
+++ b/src/components/ScrollEngine.tsx
@@ -22,14 +22,17 @@ export default function ScrollEngine({ frames, totalScrollHeight = 5000, classNa
     if (!canvas || !img || !img.complete) return;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
-    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    const scale = Math.max(canvas.width / img.naturalWidth, canvas.height / img.naturalHeight);
+    const w = img.naturalWidth * scale;
+    const h = img.naturalHeight * scale;
+    ctx.drawImage(img, (canvas.width - w) / 2, (canvas.height - h) / 2, w, h);
   }, []);
 
   const preloadImages = useCallback(() => {
     const images: HTMLImageElement[] = [];
     let loaded = 0;
 
-    frames.forEach((src, i) => {
+    frames.forEach((src) => {
       const img = new Image();
       img.src = src;
       img.onload = () => {


### PR DESCRIPTION
Closes #4

## Summary
- Replace `ctx.drawImage(img, 0, 0, w, h)` stretch with cover-fit scaling in `ScrollEngine.tsx`
- Apply the same fix to `drawFrame()` in the exported ZIP's HTML bundle
- Also removes unused loop index `i` from `preloadImages` forEach (part of issue #7)

## How it works
Computes a uniform scale factor = `max(canvasW/imgW, canvasH/imgH)` so the image fills the canvas without distortion, centered. This matches CSS `object-fit: cover` behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)