### PR TITLE
chore: remove unused imports and variables (issue #7)

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useEffect, Suspense } from "react";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -54,7 +54,6 @@ const defaultSection = (i: number): Section => ({
 
 function EditorInner() {
   const searchParams = useSearchParams();
-  const router = useRouter();
 
   // Derive initial frame state from URL params at render time (no setState-in-effect)
   const framesParam = searchParams.get("frames");

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { ArrowLeft, Check, Minus, Sparkles, Zap } from "lucide-react";
+import { Check, Minus, Sparkles, Zap } from "lucide-react";
 
 const PLANS = [
   {


### PR DESCRIPTION
Closes #7

## Summary
- Remove unused `useRouter` import and `router` variable from `editor/page.tsx`
- Remove unused `ArrowLeft` import from `pricing/page.tsx`
- Unused loop index `i` in `ScrollEngine.tsx` was already removed in PR #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)