### PR TITLE
fix: wire up Preview button on presets page (issue #9)

### DIFF
--- a/src/app/presets/page.tsx
+++ b/src/app/presets/page.tsx
@@ -241,9 +241,11 @@ export default function PresetsPage() {
                         Use preset <ArrowRight className="ml-1 w-3 h-3" />
                       </Button>
                     </Link>
-                    <Button size="sm" variant="outline" className="border-white/20 bg-white/10 backdrop-blur-sm hover:bg-white/20">
-                      <Eye className="w-3 h-3 mr-1" /> Preview
-                    </Button>
+                    <Link href={`/editor?prompt=${encodeURIComponent(preset.prompt)}`}>
+                      <Button size="sm" variant="outline" className="border-white/20 bg-white/10 backdrop-blur-sm hover:bg-white/20">
+                        <Eye className="w-3 h-3 mr-1" /> Preview
+                      </Button>
+                    </Link>
                   </div>
                 </div>
 


### PR DESCRIPTION
Closes #9

## Summary
- Preview button now links to `/editor?prompt=<preset-prompt>`, opening the editor in demo mode with the preset's prompt pre-loaded
- Users can see the scroll layout and section structure before committing to a full AI generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)