### PR TITLE
fix: pass plan context from pricing CTAs to create page (issue #10)

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -26,6 +26,7 @@ function CreatePageInner() {
   const searchParams = useSearchParams();
   const templateName = searchParams.get("template") || "";
   const promptParam = searchParams.get("prompt") || "";
+  const planName = searchParams.get("plan") || "";
 
   const [step, setStep] = useState(0);
   // Prefer explicit prompt param (from presets page) over the static template map
@@ -165,11 +166,18 @@ function CreatePageInner() {
               <h1 className="text-3xl font-black tracking-tighter mb-2">Describe your vision</h1>
               <p className="text-muted-foreground">Tell the AI what atmosphere, style, or scene you want for your scroll background</p>
             </div>
-            {templateName && (
-              <Badge className="bg-primary/20 text-primary border-primary/30">
-                Template: {templateName}
-              </Badge>
-            )}
+            <div className="flex flex-wrap gap-2">
+              {templateName && (
+                <Badge className="bg-primary/20 text-primary border-primary/30">
+                  Template: {templateName}
+                </Badge>
+              )}
+              {planName && (
+                <Badge className="bg-emerald-500/15 text-emerald-400 border-emerald-500/30">
+                  Plan: {planName}
+                </Badge>
+              )}
+            </div>
             <Textarea
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -277,7 +277,7 @@ export default function PricingPage() {
                 {plan.credits}
               </Badge>
 
-              <Link href="/create" className="mt-auto">
+              <Link href={`/create?plan=${encodeURIComponent(plan.name)}`} className="mt-auto">
                 <Button
                   className={`w-full font-semibold text-sm ${
                     plan.highlight


### PR DESCRIPTION
Closes #10

## Summary
- Pricing plan CTA links now include `?plan=<planName>` query param
- Create page reads the `plan` param and shows a green badge so users see which plan they came from

🤖 Generated with [Claude Code](https://claude.com/claude-code)