### PR TITLE
fix: redact internal error details from API responses (issue #15)

### DIFF
--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -158,7 +158,7 @@ Do NOT open index.html directly from your filesystem — use a local server.
     });
   } catch (err) {
     console.error("export-site error:", err);
-    return NextResponse.json({ error: String(err) }, { status: 500 });
+    return NextResponse.json({ error: "Export failed" }, { status: 500 });
   }
 }
 

--- a/src/app/api/extract-frames/route.ts
+++ b/src/app/api/extract-frames/route.ts
@@ -92,6 +92,6 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     console.error("extract-frames error:", err);
     if (existsSync(tmpDir)) await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-    return NextResponse.json({ error: String(err) }, { status: 500 });
+    return NextResponse.json({ error: "Frame extraction failed" }, { status: 500 });
   }
 }


### PR DESCRIPTION
Closes #15

## Summary
- Replace `String(err)` in catch blocks with generic messages (`"Frame extraction failed"`, `"Export failed"`) in `extract-frames` and `export-site` routes
- Full error (including stack traces and file paths) is still logged via `console.error` for server-side debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)