### PR TITLE
fix: strip any image MIME type from base64 data URIs in export (issue #19)

### DIFF
--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -32,7 +32,7 @@ export async function POST(req: NextRequest) {
 
     // Add each frame
     for (let i = 0; i < frames.length; i++) {
-      const base64 = frames[i].replace(/^data:image\/jpeg;base64,/, "");
+      const base64 = frames[i].replace(/^data:image\/[a-zA-Z+.-]+;base64,/, "");
       framesFolder.file(`frame_${String(i).padStart(4, "0")}.jpg`, base64, { base64: true });
     }
 


### PR DESCRIPTION
Closes #19

## Summary
- Replace hardcoded `data:image/jpeg;base64,` prefix with `/^data:image\/[a-zA-Z+.-]+;base64,/` regex
- Now correctly strips the header for PNG, WebP, GIF, or any other image MIME type — not just JPEG

🤖 Generated with [Claude Code](https://claude.com/claude-code)