### PR TITLE
fix: bind scroll listener to preview container not window (issue #20)

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect, Suspense } from "react";
+import { useState, useEffect, useRef, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -54,6 +54,7 @@ const defaultSection = (i: number): Section => ({
 
 function EditorInner() {
   const searchParams = useSearchParams();
+  const previewScrollRef = useRef<HTMLDivElement>(null);
 
   // Derive initial frame state from URL params at render time (no setState-in-effect)
   const framesParam = searchParams.get("frames");
@@ -279,11 +280,12 @@ function EditorInner() {
         {showPreview && (
           <div className="flex-1 relative overflow-hidden">
             {frames.length > 0 && (
-              <div className="absolute inset-0" style={{ height: totalScrollHeight, overflowY: "scroll" }}>
+              <div ref={previewScrollRef} className="absolute inset-0" style={{ height: totalScrollHeight, overflowY: "scroll" }}>
                 <ScrollEngine
                   frames={frames}
                   totalScrollHeight={totalScrollHeight}
                   onFrameChange={setCurrentFrame}
+                  scrollContainer={previewScrollRef}
                 />
                 {/* Section overlays */}
                 <div className="relative z-10" style={{ height: totalScrollHeight }}>

--- a/src/components/ScrollEngine.tsx
+++ b/src/components/ScrollEngine.tsx
@@ -6,9 +6,10 @@ interface ScrollEngineProps {
   totalScrollHeight?: number;
   className?: string;
   onFrameChange?: (index: number) => void;
+  scrollContainer?: React.RefObject<HTMLElement | null>;
 }
 
-export default function ScrollEngine({ frames, totalScrollHeight = 5000, className = "", onFrameChange }: ScrollEngineProps) {
+export default function ScrollEngine({ frames, totalScrollHeight = 5000, className = "", onFrameChange, scrollContainer }: ScrollEngineProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const imagesRef = useRef<HTMLImageElement[]>([]);
@@ -51,10 +52,15 @@ export default function ScrollEngine({ frames, totalScrollHeight = 5000, classNa
   }, [preloadImages]);
 
   useEffect(() => {
+    const el = scrollContainer?.current ?? window;
     const handleScroll = () => {
-      if (!containerRef.current) return;
-      const scrollTop = window.scrollY;
-      const maxScroll = totalScrollHeight - window.innerHeight;
+      const scrollTop = scrollContainer?.current
+        ? scrollContainer.current.scrollTop
+        : window.scrollY;
+      const viewHeight = scrollContainer?.current
+        ? scrollContainer.current.clientHeight
+        : window.innerHeight;
+      const maxScroll = totalScrollHeight - viewHeight;
       const progress = Math.min(Math.max(scrollTop / maxScroll, 0), 1);
       const frameIndex = Math.floor(progress * (frames.length - 1));
 
@@ -66,9 +72,9 @@ export default function ScrollEngine({ frames, totalScrollHeight = 5000, classNa
       }
     };
 
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, [frames.length, totalScrollHeight, drawFrame, onFrameChange]);
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, [frames.length, totalScrollHeight, drawFrame, onFrameChange, scrollContainer]);
 
   useEffect(() => {
     const canvas = canvasRef.current;


### PR DESCRIPTION
Closes #20

## Summary
- Added optional `scrollContainer` prop (`React.RefObject<HTMLElement>`) to `ScrollEngine`
- When provided, the scroll handler reads `el.scrollTop` / `el.clientHeight` instead of `window.scrollY` / `window.innerHeight`
- Editor passes `previewScrollRef` (attached to the `overflow-scroll` preview div) so scroll-frame mapping works correctly inside the editor panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)