### PR TITLE
fix: validate frames and sections payload in export-site (issue #21)

### DIFF
--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -17,10 +17,18 @@ function safeHref(s: string): string {
 
 export async function POST(req: NextRequest) {
   try {
-    const { frames, sections, siteName } = await req.json();
+    const body = await req.json();
+    const { frames, sections, siteName } = body;
+
+    if (!Array.isArray(frames) || frames.length === 0) {
+      return NextResponse.json({ error: "frames must be a non-empty array" }, { status: 400 });
+    }
+    if (!Array.isArray(sections) || sections.length === 0) {
+      return NextResponse.json({ error: "sections must be a non-empty array" }, { status: 400 });
+    }
 
     // Reject SVG demo-frame URLs — only real base64 data URIs are exportable
-    if (!frames?.length || !frames[0].startsWith("data:image/")) {
+    if (!frames[0].startsWith("data:image/")) {
       return NextResponse.json(
         { error: "Cannot export demo frames. Generate real frames first using the AI or by uploading a video." },
         { status: 400 }


### PR DESCRIPTION
Closes #21

## Summary
- Check `Array.isArray(frames)` and `Array.isArray(sections)` with length > 0 before any processing
- Return descriptive 400 responses instead of crashing with a 500 on missing/invalid fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)