### PR TITLE
fix: validate videoUrl protocol to prevent SSRF (issue #22)

### DIFF
--- a/src/app/api/extract-frames/route.ts
+++ b/src/app/api/extract-frames/route.ts
@@ -49,8 +49,18 @@ export async function POST(req: NextRequest) {
       quality = clampQuality(q);
       if (!videoUrl) return NextResponse.json({ error: "No videoUrl" }, { status: 400 });
 
+      let parsedUrl: URL;
+      try {
+        parsedUrl = new URL(videoUrl);
+      } catch {
+        return NextResponse.json({ error: "Invalid videoUrl" }, { status: 400 });
+      }
+      if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+        return NextResponse.json({ error: "videoUrl must use http or https" }, { status: 400 });
+      }
+
       // Download the video
-      const response = await fetch(videoUrl);
+      const response = await fetch(parsedUrl.toString());
       if (!response.ok) throw new Error("Failed to download video");
       const buffer = Buffer.from(await response.arrayBuffer());
       videoPath = path.join(tmpDir, "input.mp4");


### PR DESCRIPTION
Closes #22

## Summary
- Parse `videoUrl` with `new URL()` — return 400 if it's not a valid URL
- Reject any protocol other than `http:` or `https:` — blocks `file://`, `ftp://`, `data:`, etc.
- Fetch uses `parsedUrl.toString()` (the normalised URL) rather than the raw user string

🤖 Generated with [Claude Code](https://claude.com/claude-code)