### PR TITLE
chore: add /tmp to .gitignore (issue #23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# temporary frame extraction files
+/tmp


### PR DESCRIPTION
Closes #23

## Summary
- Added `/tmp` to `.gitignore` so the temporary `frames-<timestamp>` directories created by `extract-frames` are never accidentally committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)