### PR TITLE
chore: zod env validation and health endpoint (issue #46)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "shadcn": "^4.10.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "shadcn": "^4.10.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { isDemoMode } from "@/lib/env";
+
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
+    mode: isDemoMode() ? "demo" : "production",
+    providers: {
+      lumaai: !!process.env.LUMAAI_API_KEY,
+      runwayml: !!process.env.RUNWAYML_API_KEY,
+      anthropic: !!process.env.ANTHROPIC_API_KEY,
+    },
+  });
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  // AI video providers — at least one should be set for real generation
+  LUMAAI_API_KEY: z.string().optional(),
+  RUNWAYML_API_KEY: z.string().optional(),
+
+  // AI chat editing
+  ANTHROPIC_API_KEY: z.string().optional(),
+
+  // Auth
+  NEXTAUTH_SECRET: z.string().min(1, "NEXTAUTH_SECRET is required"),
+  NEXTAUTH_URL: z.string().url().optional(),
+  AUTH_GITHUB_ID: z.string().optional(),
+  AUTH_GITHUB_SECRET: z.string().optional(),
+  AUTH_GOOGLE_ID: z.string().optional(),
+  AUTH_GOOGLE_SECRET: z.string().optional(),
+
+  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+});
+
+const _env = envSchema.safeParse(process.env);
+
+if (!_env.success) {
+  console.error("❌ Invalid environment variables:\n", _env.error.flatten().fieldErrors);
+  throw new Error("Invalid environment variables. Check server logs for details.");
+}
+
+export const env = _env.data;
+
+export function isDemoMode(): boolean {
+  return !env.LUMAAI_API_KEY && !env.RUNWAYML_API_KEY;
+}


### PR DESCRIPTION
Closes #46

## Summary
- `src/lib/env.ts` — validates all env vars with zod at startup; throws with a clear message if `NEXTAUTH_SECRET` is missing; AI provider keys are optional (demo mode when absent)
- `GET /api/health` — returns `{ status, mode, providers }` for uptime monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)