### PR TITLE
feat: SEO metadata, OpenGraph, sitemap, robots.txt (issue #48)

### DIFF
--- a/src/app/about/layout.tsx
+++ b/src/app/about/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "About",
+  description: "Learn about ScrollCraft — who we are and why we built the easiest animated scroll website builder.",
+  openGraph: {
+    title: "About | ScrollCraft",
+    description: "Why we built ScrollCraft and who is behind it.",
+  },
+};
+
+export default function AboutLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,9 +6,33 @@ import SessionProvider from "@/components/SessionProvider";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
+const BASE_URL = "https://scrollcraft.app";
+
 export const metadata: Metadata = {
-  title: "ScrollCraft — AI Scroll Sites",
-  description: "Build immersive 2D scroll websites with animated canvas backgrounds. No code needed.",
+  metadataBase: new URL(BASE_URL),
+  title: {
+    default: "ScrollCraft — AI Scroll Sites",
+    template: "%s | ScrollCraft",
+  },
+  description: "Build immersive 2D scroll websites with animated canvas backgrounds. Pick a style, customise sections, export as pure HTML. No code needed.",
+  keywords: ["scroll website builder", "animated canvas", "scrollytelling", "no-code", "AI website", "scroll animation"],
+  authors: [{ name: "ScrollCraft" }],
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: BASE_URL,
+    siteName: "ScrollCraft",
+    title: "ScrollCraft — AI Scroll Sites",
+    description: "Build immersive 2D scroll websites with animated canvas backgrounds. No code needed.",
+    images: [{ url: "/og-image.png", width: 1200, height: 630, alt: "ScrollCraft" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "ScrollCraft — AI Scroll Sites",
+    description: "Build immersive 2D scroll websites with animated canvas backgrounds. No code needed.",
+    images: ["/og-image.png"],
+  },
+  robots: { index: true, follow: true },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/presets/layout.tsx
+++ b/src/app/presets/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Presets",
+  description: "Explore ready-made scroll site presets. Pick one and launch in minutes.",
+  openGraph: {
+    title: "Presets | ScrollCraft",
+    description: "Ready-made animated scroll site presets for every industry.",
+  },
+};
+
+export default function PresetsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/pricing/layout.tsx
+++ b/src/app/pricing/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Pricing",
+  description: "Simple, transparent pricing for ScrollCraft. Start free, upgrade when you need more.",
+  openGraph: {
+    title: "Pricing | ScrollCraft",
+    description: "Simple, transparent pricing. Start free, no credit card required.",
+  },
+};
+
+export default function PricingLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,8 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [{ userAgent: "*", allow: "/" }],
+    sitemap: "https://scrollcraft.app/sitemap.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,15 @@
+import { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = "https://scrollcraft.app";
+  const now = new Date();
+
+  return [
+    { url: base,              lastModified: now, changeFrequency: "weekly",  priority: 1 },
+    { url: `${base}/create`,  lastModified: now, changeFrequency: "monthly", priority: 0.9 },
+    { url: `${base}/presets`, lastModified: now, changeFrequency: "weekly",  priority: 0.8 },
+    { url: `${base}/pricing`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/about`,   lastModified: now, changeFrequency: "monthly", priority: 0.5 },
+    { url: `${base}/contact`, lastModified: now, changeFrequency: "monthly", priority: 0.4 },
+  ];
+}


### PR DESCRIPTION
Closes #48

## Summary
- **`layout.tsx`** — full global metadata: title template, description, keywords, OpenGraph, Twitter card, robots
- **`sitemap.ts`** → `/sitemap.xml` — all public routes with priority + changeFrequency
- **`robots.ts`** → `/robots.txt` — allows all crawlers, points to sitemap
- **Per-route layouts** for `/pricing`, `/presets`, `/about` — each has its own title + OG description override (needed because those pages are `"use client"` and can't export metadata directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)