### PR TITLE
feat: custom head HTML and CSS injectors in editor (issue #54)

### DIFF
--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -18,7 +18,7 @@ function safeHref(s: string): string {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { frames, sections, siteName } = body;
+    const { frames, sections, siteName, customHead = "", customCss = "" } = body;
 
     if (!Array.isArray(frames) || frames.length === 0) {
       return NextResponse.json({ error: "frames must be a non-empty array" }, { status: 400 });
@@ -80,6 +80,8 @@ export async function POST(req: NextRequest) {
     }
     #scroll-hint .arrow { width: 1px; height: 40px; background: linear-gradient(to bottom, transparent, rgba(255,255,255,0.4)); }
   </style>
+  ${customCss ? `<style>\n${customCss}\n  </style>` : ""}
+  ${customHead || ""}
 </head>
 <body>
   <canvas id="scroll-canvas"></canvas>

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -87,6 +87,8 @@ function EditorInner() {
   const [chatInput, setChatInput] = useState("");
   const [chatLoading, setChatLoading] = useState(false);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [customHead, setCustomHead] = useState("");
+  const [customCss, setCustomCss] = useState("");
 
   // Show demo toast once on mount — side-effect only, no state mutation
   useEffect(() => {
@@ -136,7 +138,7 @@ function EditorInner() {
       const res = await fetch("/api/export-site", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ frames, sections, siteName, fps }),
+        body: JSON.stringify({ frames, sections, siteName, fps, customHead, customCss }),
       });
       if (!res.ok) throw new Error(await res.text());
       const blob = await res.blob();
@@ -410,6 +412,9 @@ function EditorInner() {
                   <TabsTrigger value="layout" className="flex-1 text-xs h-6">
                     <Settings className="w-3 h-3 mr-1" /> Layout
                   </TabsTrigger>
+                  <TabsTrigger value="code" className="flex-1 text-xs h-6">
+                    &lt;/&gt; Code
+                  </TabsTrigger>
                 </TabsList>
               </div>
 
@@ -543,6 +548,29 @@ function EditorInner() {
                       </button>
                     ))}
                   </div>
+                </div>
+              </TabsContent>
+
+              <TabsContent value="code" className="p-3 space-y-4 mt-0">
+                <div className="space-y-1.5">
+                  <label className="text-xs text-muted-foreground font-medium">Custom &lt;head&gt; HTML</label>
+                  <p className="text-xs text-muted-foreground/70">Inject analytics, fonts, or meta tags into &lt;head&gt;</p>
+                  <Textarea
+                    value={customHead}
+                    onChange={(e) => setCustomHead(e.target.value)}
+                    placeholder={'<!-- e.g. Google Analytics, custom meta -->\n<script async src="..."></script>'}
+                    className="min-h-[100px] font-mono text-xs bg-black/30 border-white/10 resize-none"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <label className="text-xs text-muted-foreground font-medium">Custom CSS</label>
+                  <p className="text-xs text-muted-foreground/70">Extra styles injected after the default stylesheet</p>
+                  <Textarea
+                    value={customCss}
+                    onChange={(e) => setCustomCss(e.target.value)}
+                    placeholder={".scroll-section { ... }\n.section-content { ... }"}
+                    className="min-h-[100px] font-mono text-xs bg-black/30 border-white/10 resize-none"
+                  />
                 </div>
               </TabsContent>
             </Tabs>


### PR DESCRIPTION
Closes #54

## Summary
- **Editor**: new **Code** tab (after Layout) with two textareas:
  - *Custom `<head>` HTML* — for analytics, fonts, custom meta tags
  - *Custom CSS* — extra styles appended after the default stylesheet
- **Export API**: `customCss` injected as a `<style>` block; `customHead` injected verbatim before `</head>` in the exported ZIP's `index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)