### PR TITLE
feat: scroll-linked section entrance animations (issue #50)

### DIFF
--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -70,7 +70,8 @@ export async function POST(req: NextRequest) {
     body { background: #000; color: #fff; font-family: system-ui, sans-serif; overflow-x: hidden; }
     #scroll-canvas { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
     #scroll-container { position: relative; height: ${totalScrollHeight}px; z-index: 1; pointer-events: none; }
-    .scroll-section { pointer-events: auto; }
+    .scroll-section { pointer-events: auto; opacity: 0; transform: translateY(32px); transition: opacity 0.6s cubic-bezier(0.25,0.46,0.45,0.94), transform 0.6s cubic-bezier(0.25,0.46,0.45,0.94); }
+    .scroll-section.visible { opacity: 1; transform: translateY(0); }
     .section-content { pointer-events: auto; }
     #scroll-hint {
       position: fixed; bottom: 2rem; left: 50%; transform: translateX(-50%);
@@ -150,6 +151,18 @@ export async function POST(req: NextRequest) {
       window.addEventListener('resize', resize);
       resize();
       preload();
+    })();
+
+    // Scroll-linked section entrance animations
+    (function() {
+      const sections = document.querySelectorAll('.scroll-section');
+      const observer = new IntersectionObserver(function(entries) {
+        entries.forEach(function(entry) {
+          if (entry.isIntersecting) entry.target.classList.add('visible');
+          else entry.target.classList.remove('visible');
+        });
+      }, { threshold: 0.15 });
+      sections.forEach(function(s) { observer.observe(s); });
     })();
   </script>
 </body>

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -17,6 +17,7 @@ import { toast } from "sonner";
 import dynamic from "next/dynamic";
 
 const ScrollEngine = dynamic(() => import("@/components/ScrollEngine"), { ssr: false });
+const ScrollSection = dynamic(() => import("@/components/ScrollSection"), { ssr: false });
 
 interface Section {
   id: string;
@@ -293,7 +294,7 @@ function EditorInner() {
                 <div className="relative z-10" style={{ height: totalScrollHeight }}>
                   <div style={{ height: "100vh" }} />
                   {sections.filter(s => s.visible).map((s) => (
-                    <div
+                    <ScrollSection
                       key={s.id}
                       onClick={() => setSelectedSection(s.id)}
                       style={{
@@ -327,7 +328,7 @@ function EditorInner() {
                           </span>
                         )}
                       </div>
-                    </div>
+                    </ScrollSection>
                   ))}
                 </div>
               </div>

--- a/src/components/ScrollSection.tsx
+++ b/src/components/ScrollSection.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useRef } from "react";
+import { motion, useInView } from "framer-motion";
+
+interface ScrollSectionProps {
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+  onClick?: () => void;
+  delay?: number;
+}
+
+export default function ScrollSection({ children, className, style, onClick, delay = 0 }: ScrollSectionProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: false, margin: "-15% 0px -15% 0px" });
+
+  return (
+    <motion.div
+      ref={ref}
+      className={className}
+      style={style}
+      onClick={onClick}
+      initial={{ opacity: 0, y: 32 }}
+      animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 32 }}
+      transition={{ duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94], delay }}
+    >
+      {children}
+    </motion.div>
+  );
+}


### PR DESCRIPTION
Closes #50

## Summary
- **`ScrollSection.tsx`** — framer-motion component that fades sections up (opacity 0→1, translateY 32→0, 0.6s ease) when they enter the viewport via `useInView`; reverses on exit
- **Editor preview** — section overlays replaced with `<ScrollSection>` so animations are visible while editing
- **Exported ZIP** — CSS transition on `.scroll-section` + vanilla `IntersectionObserver` adds/removes `.visible` class, so animations work without framer-motion in the exported bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)