### PR TITLE
feat: responsive mobile/desktop viewport support (#51)

### DIFF
--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -18,7 +18,7 @@ function safeHref(s: string): string {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { frames, sections, siteName, customHead = "", customCss = "" } = body;
+    const { frames, mobileFrames, sections, siteName, customHead = "", customCss = "" } = body;
 
     if (!Array.isArray(frames) || frames.length === 0) {
       return NextResponse.json({ error: "frames must be a non-empty array" }, { status: 400 });
@@ -35,13 +35,24 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const hasMobileFrames = Array.isArray(mobileFrames) && mobileFrames.length > 0 && mobileFrames[0].startsWith("data:image/");
+
     const zip = new JSZip();
     const framesFolder = zip.folder("frames")!;
 
-    // Add each frame
+    // Add desktop frames
     for (let i = 0; i < frames.length; i++) {
       const base64 = frames[i].replace(/^data:image\/[a-zA-Z+.-]+;base64,/, "");
       framesFolder.file(`frame_${String(i).padStart(4, "0")}.jpg`, base64, { base64: true });
+    }
+
+    // Add mobile frames if present
+    if (hasMobileFrames) {
+      const mobileFolder = zip.folder("frames-mobile")!;
+      for (let i = 0; i < mobileFrames.length; i++) {
+        const base64 = mobileFrames[i].replace(/^data:image\/[a-zA-Z+.-]+;base64,/, "");
+        mobileFolder.file(`frame_${String(i).padStart(4, "0")}.jpg`, base64, { base64: true });
+      }
     }
 
     // Generate sections HTML
@@ -99,11 +110,18 @@ export async function POST(req: NextRequest) {
     (function() {
       const canvas = document.getElementById('scroll-canvas');
       const ctx = canvas.getContext('2d');
-      const frameCount = ${frames.length};
-      const images = new Array(frameCount);
-      let loaded = 0;
-      let currentFrame = 0;
+      const desktopCount = ${frames.length};
+      const mobileCount = ${hasMobileFrames ? (mobileFrames as string[]).length : 0};
+      const hasMobile = ${hasMobileFrames ? "true" : "false"};
       const totalScrollHeight = ${totalScrollHeight};
+
+      let isMobile = hasMobile && window.matchMedia('(max-width: 767px)').matches;
+      let frameCount = isMobile ? mobileCount : desktopCount;
+      const desktopImages = new Array(desktopCount);
+      const mobileImages = hasMobile ? new Array(mobileCount) : null;
+      let currentFrame = 0;
+
+      function getImages() { return (isMobile && mobileImages) ? mobileImages : desktopImages; }
 
       function resize() {
         canvas.width = window.innerWidth;
@@ -112,6 +130,7 @@ export async function POST(req: NextRequest) {
       }
 
       function drawFrame(index) {
+        const images = getImages();
         const img = images[index];
         if (!img || !img.complete) return;
         const scale = Math.max(canvas.width / img.naturalWidth, canvas.height / img.naturalHeight);
@@ -120,30 +139,47 @@ export async function POST(req: NextRequest) {
         ctx.drawImage(img, (canvas.width - w) / 2, (canvas.height - h) / 2, w, h);
       }
 
-      function preload() {
-        for (let i = 0; i < frameCount; i++) {
-          const img = new Image();
-          img.src = 'frames/frame_' + String(i).padStart(4, '0') + '.jpg';
-          img.onload = function() {
-            loaded++;
-            if (loaded === 1) drawFrame(0);
-          };
-          images[i] = img;
+      function preloadSet(count, folder, target) {
+        for (var i = 0; i < count; i++) {
+          (function(idx) {
+            var img = new Image();
+            img.src = folder + '/frame_' + String(idx).padStart(4, '0') + '.jpg';
+            img.onload = function() {
+              target[idx] = img;
+              if (idx === 0 && (!isMobile || target === mobileImages)) drawFrame(0);
+            };
+            target[idx] = img;
+          })(i);
         }
       }
 
-      let rafId;
+      function preload() {
+        preloadSet(desktopCount, 'frames', desktopImages);
+        if (hasMobile) preloadSet(mobileCount, 'frames-mobile', mobileImages);
+      }
+
+      if (hasMobile) {
+        var mq = window.matchMedia('(max-width: 767px)');
+        mq.addEventListener('change', function(e) {
+          isMobile = e.matches;
+          frameCount = isMobile ? mobileCount : desktopCount;
+          currentFrame = 0;
+          drawFrame(0);
+        });
+      }
+
+      var rafId;
       function onScroll() {
-        const scrollTop = window.scrollY;
-        const maxScroll = totalScrollHeight - window.innerHeight;
-        const progress = Math.min(Math.max(scrollTop / maxScroll, 0), 1);
-        const frameIndex = Math.min(Math.floor(progress * (frameCount - 1)), frameCount - 1);
+        var scrollTop = window.scrollY;
+        var maxScroll = totalScrollHeight - window.innerHeight;
+        var progress = Math.min(Math.max(scrollTop / maxScroll, 0), 1);
+        var frameIndex = Math.min(Math.floor(progress * (frameCount - 1)), frameCount - 1);
         if (frameIndex !== currentFrame) {
           currentFrame = frameIndex;
           cancelAnimationFrame(rafId);
           rafId = requestAnimationFrame(function() { drawFrame(frameIndex); });
         }
-        const hint = document.getElementById('scroll-hint');
+        var hint = document.getElementById('scroll-hint');
         if (hint) hint.style.opacity = scrollTop > 100 ? '0' : '1';
       }
 

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -36,8 +36,10 @@ function CreatePageInner() {
   const [selectedStyle, setSelectedStyle] = useState<Style2D>("gradient");
   const [colors, setColors] = useState<[string, string, string]>(["#7c3aed", "#2563eb", "#0f172a"]);
   const [frameCount, setFrameCount] = useState(120);
+  const [generateMobile, setGenerateMobile] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [progressLabel, setProgressLabel] = useState("");
   const fileRef = useRef<HTMLInputElement>(null);
 
   const handleGenerate = async () => {
@@ -45,15 +47,35 @@ function CreatePageInner() {
     setIsGenerating(true);
     setProgress(0);
     try {
+      const opts = { style: selectedStyle, color1: colors[0], color2: colors[1], color3: colors[2], frameCount };
+
+      setProgressLabel(generateMobile ? "Generating desktop frames…" : "Generating frames…");
       const frames = await generate2DFrames(
-        { style: selectedStyle, color1: colors[0], color2: colors[1], color3: colors[2], frameCount },
-        setProgress
+        { ...opts, width: 1280, height: 720 },
+        (p) => setProgress(generateMobile ? Math.round(p * 0.5) : p)
       );
+
+      if (generateMobile) {
+        setProgressLabel("Generating mobile portrait frames…");
+        const mobileFrames = await generate2DFrames(
+          { ...opts, width: 720, height: 1280 },
+          (p) => setProgress(50 + Math.round(p * 0.5))
+        );
+        try {
+          sessionStorage.setItem("scrollcraft_mobile_frames", JSON.stringify(mobileFrames));
+        } catch {
+          // sessionStorage full — skip mobile frames silently
+        }
+      } else {
+        sessionStorage.removeItem("scrollcraft_mobile_frames");
+      }
+
       const params = new URLSearchParams({
         frames: JSON.stringify(frames),
         frameCount: String(frames.length),
         fps: "24",
         prompt: STYLES.find(s => s.id === selectedStyle)?.label ?? selectedStyle,
+        ...(generateMobile ? { hasMobileFrames: "1" } : {}),
       });
       router.push(`/editor?${params.toString()}`);
     } catch (err) {
@@ -214,6 +236,21 @@ function CreatePageInner() {
                 />
                 <p className="text-xs text-muted-foreground">More frames = smoother scroll. 120 is the sweet spot.</p>
               </div>
+
+              <div className="flex items-center justify-between pt-1">
+                <div>
+                  <p className="font-medium text-sm">Generate mobile variant</p>
+                  <p className="text-xs text-muted-foreground">Also create portrait 9:16 frames for phones</p>
+                </div>
+                <button
+                  onClick={() => setGenerateMobile(m => !m)}
+                  className={`relative w-10 h-6 rounded-full transition-colors ${generateMobile ? "bg-primary" : "bg-white/10"}`}
+                  role="switch"
+                  aria-checked={generateMobile}
+                >
+                  <span className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${generateMobile ? "translate-x-5" : "translate-x-1"}`} />
+                </button>
+              </div>
             </div>
 
             {/* Upload your own video */}
@@ -249,7 +286,7 @@ function CreatePageInner() {
             </div>
             <div>
               <h2 className="text-2xl font-bold mb-2">Generating frames…</h2>
-              <p className="text-muted-foreground">{isGenerating ? "Drawing your scroll animation" : "Processing…"}</p>
+              <p className="text-muted-foreground">{isGenerating ? (progressLabel || "Drawing your scroll animation") : "Processing…"}</p>
             </div>
             <div className="space-y-2">
               <Progress value={progress} className="h-2" />

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -10,7 +10,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   ArrowLeft, Download, Plus, Trash2, Eye, EyeOff, ChevronUp, ChevronDown,
   Sparkles, Layers, Settings, Type, Loader2, AlignLeft, AlignCenter, AlignRight,
-  MessageSquare, Send, X, Bot
+  MessageSquare, Send, X, Bot, Monitor, Tablet, Smartphone
 } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
@@ -90,6 +90,19 @@ function EditorInner() {
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [customHead, setCustomHead] = useState("");
   const [customCss, setCustomCss] = useState("");
+  const [mobileFrames, setMobileFrames] = useState<string[]>([]);
+  const [viewportMode, setViewportMode] = useState<"desktop" | "tablet" | "mobile">("desktop");
+
+  // Load mobile frames from sessionStorage if the create page generated them
+  useEffect(() => {
+    const hasMobile = searchParams.get("hasMobileFrames") === "1";
+    if (!hasMobile) return;
+    try {
+      const stored = sessionStorage.getItem("scrollcraft_mobile_frames");
+      if (stored) setMobileFrames(JSON.parse(stored));
+    } catch { /* sessionStorage unavailable */ }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Show demo toast once on mount — side-effect only, no state mutation
   useEffect(() => {
@@ -139,7 +152,7 @@ function EditorInner() {
       const res = await fetch("/api/export-site", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ frames, sections, siteName, fps, customHead, customCss }),
+        body: JSON.stringify({ frames, mobileFrames: mobileFrames.length ? mobileFrames : undefined, sections, siteName, fps, customHead, customCss }),
       });
       if (!res.ok) throw new Error(await res.text());
       const blob = await res.blob();
@@ -205,6 +218,19 @@ function EditorInner() {
         </div>
 
         <div className="flex items-center gap-2">
+          {/* Viewport toggle */}
+          <div className="flex items-center bg-white/5 rounded-md p-0.5 gap-0.5">
+            {([["desktop", Monitor], ["tablet", Tablet], ["mobile", Smartphone]] as const).map(([mode, Icon]) => (
+              <button
+                key={mode}
+                onClick={() => setViewportMode(mode)}
+                title={mode.charAt(0).toUpperCase() + mode.slice(1)}
+                className={`p-1 rounded transition-colors ${viewportMode === mode ? "bg-primary/30 text-primary" : "text-muted-foreground hover:text-foreground"}`}
+              >
+                <Icon className="w-3.5 h-3.5" />
+              </button>
+            ))}
+          </div>
           <div className="text-xs text-muted-foreground bg-white/5 px-2 py-1 rounded">
             Frame {currentFrame + 1}/{frameCount}
           </div>
@@ -281,11 +307,23 @@ function EditorInner() {
 
         {/* Center: preview canvas */}
         {showPreview && (
-          <div className="flex-1 relative overflow-hidden">
+          <div className="flex-1 relative overflow-hidden bg-black/20 flex items-center justify-center">
             {frames.length > 0 && (
-              <div ref={previewScrollRef} className="absolute inset-0" style={{ height: totalScrollHeight, overflowY: "scroll" }}>
+              <div
+                ref={previewScrollRef}
+                style={{
+                  height: totalScrollHeight,
+                  overflowY: "scroll",
+                  ...(viewportMode === "mobile"
+                    ? { width: 390, maxHeight: "85vh", position: "relative", borderRadius: 24, border: "2px solid rgba(255,255,255,0.1)", overflow: "hidden" }
+                    : viewportMode === "tablet"
+                    ? { width: 768, maxHeight: "85vh", position: "relative", borderRadius: 16, border: "2px solid rgba(255,255,255,0.1)", overflow: "hidden" }
+                    : { position: "absolute", inset: 0 }),
+                }}
+              >
                 <ScrollEngine
                   frames={frames}
+                  mobileFrames={mobileFrames.length ? mobileFrames : undefined}
                   totalScrollHeight={totalScrollHeight}
                   onFrameChange={setCurrentFrame}
                   scrollContainer={previewScrollRef}

--- a/src/components/ScrollEngine.tsx
+++ b/src/components/ScrollEngine.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useState } from "react";
 
 interface ScrollEngineProps {
   frames: string[];
+  mobileFrames?: string[];
   totalScrollHeight?: number;
   className?: string;
   onFrameChange?: (index: number) => void;
@@ -10,13 +11,16 @@ interface ScrollEngineProps {
   altText?: string;
 }
 
-export default function ScrollEngine({ frames, totalScrollHeight = 5000, className = "", onFrameChange, scrollContainer, altText = "Animated scroll background" }: ScrollEngineProps) {
+export default function ScrollEngine({ frames, mobileFrames, totalScrollHeight = 5000, className = "", onFrameChange, scrollContainer, altText = "Animated scroll background" }: ScrollEngineProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const imagesRef = useRef<HTMLImageElement[]>([]);
   const currentFrameRef = useRef(0);
   const rafRef = useRef<number>(0);
   const loadedRef = useRef(false);
+  const [isMobile, setIsMobile] = useState(false);
+
+  const activeFrames = isMobile && mobileFrames?.length ? mobileFrames : frames;
 
   const drawFrame = useCallback((index: number) => {
     const canvas = canvasRef.current;
@@ -30,35 +34,34 @@ export default function ScrollEngine({ frames, totalScrollHeight = 5000, classNa
     ctx.drawImage(img, (canvas.width - w) / 2, (canvas.height - h) / 2, w, h);
   }, []);
 
-  const preloadImages = useCallback(() => {
-    const images: HTMLImageElement[] = new Array(frames.length);
+  const preloadImages = useCallback((frameSrcs: string[]) => {
+    const images: HTMLImageElement[] = new Array(frameSrcs.length);
     let keyframesLoaded = 0;
-    const KEYFRAME_STEP = 5; // load every 5th frame first
+    const KEYFRAME_STEP = 5;
 
     const loadImage = (index: number) => {
       const img = new Image();
-      img.src = frames[index];
+      img.src = frameSrcs[index];
       img.onload = () => {
         images[index] = img;
-        if (index === 0) drawFrame(0); // draw immediately on first frame
+        if (index === 0) {
+          imagesRef.current = images;
+          drawFrame(0);
+        }
       };
       return img;
     };
 
-    // Phase 1: load keyframes (every KEYFRAME_STEP)
-    const keyframeIndices = frames
-      .map((_, i) => i)
-      .filter(i => i % KEYFRAME_STEP === 0);
+    const keyframeIndices = frameSrcs.map((_, i) => i).filter(i => i % KEYFRAME_STEP === 0);
 
     keyframeIndices.forEach(i => {
       const img = loadImage(i);
       img.onload = () => {
         images[i] = img;
         keyframesLoaded++;
-        if (i === 0) drawFrame(0);
-        // Phase 2: once all keyframes done, load the rest
+        if (i === 0) { imagesRef.current = images; drawFrame(0); }
         if (keyframesLoaded === keyframeIndices.length) {
-          frames.forEach((_, j) => {
+          frameSrcs.forEach((_, j) => {
             if (j % KEYFRAME_STEP !== 0) loadImage(j);
           });
           loadedRef.current = true;
@@ -67,11 +70,23 @@ export default function ScrollEngine({ frames, totalScrollHeight = 5000, classNa
     });
 
     imagesRef.current = images;
-  }, [frames, drawFrame]);
+  }, [drawFrame]);
+
+  // Detect mobile viewport
+  useEffect(() => {
+    if (!mobileFrames?.length) return;
+    const mq = window.matchMedia("(max-width: 767px)");
+    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    setIsMobile(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, [mobileFrames]);
 
   useEffect(() => {
-    preloadImages();
-  }, [preloadImages]);
+    loadedRef.current = false;
+    currentFrameRef.current = 0;
+    preloadImages(activeFrames);
+  }, [activeFrames, preloadImages]);
 
   useEffect(() => {
     const el = scrollContainer?.current ?? window;
@@ -84,7 +99,7 @@ export default function ScrollEngine({ frames, totalScrollHeight = 5000, classNa
         : window.innerHeight;
       const maxScroll = totalScrollHeight - viewHeight;
       const progress = Math.min(Math.max(scrollTop / maxScroll, 0), 1);
-      const frameIndex = Math.floor(progress * (frames.length - 1));
+      const frameIndex = Math.floor(progress * (activeFrames.length - 1));
 
       if (frameIndex !== currentFrameRef.current) {
         currentFrameRef.current = frameIndex;
@@ -96,15 +111,15 @@ export default function ScrollEngine({ frames, totalScrollHeight = 5000, classNa
 
     el.addEventListener("scroll", handleScroll, { passive: true });
     return () => el.removeEventListener("scroll", handleScroll);
-  }, [frames.length, totalScrollHeight, drawFrame, onFrameChange, scrollContainer]);
+  }, [activeFrames.length, totalScrollHeight, drawFrame, onFrameChange, scrollContainer]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
     const resize = () => {
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
+      canvas.width = canvas.offsetWidth || window.innerWidth;
+      canvas.height = canvas.offsetHeight || window.innerHeight;
       drawFrame(currentFrameRef.current);
     };
 
@@ -122,7 +137,6 @@ export default function ScrollEngine({ frames, totalScrollHeight = 5000, classNa
         role="img"
         aria-label={altText}
       />
-      {/* Visually hidden fallback for screen readers and search crawlers */}
       <span className="sr-only">{altText}</span>
     </div>
   );


### PR DESCRIPTION
## Summary

- **ScrollEngine**: new `mobileFrames` prop — auto-switches frame set via `window.matchMedia('(max-width: 767px)')` listener
- **Editor**: viewport toggle buttons (Desktop / Tablet / Mobile) in top bar — scales preview container to simulate each form factor
- **Create page**: "Generate mobile portrait variant" toggle in the Configure step — generates 720×1280 frames using the same style/palette, stores them in `sessionStorage`
- **Export**: when mobile frames are present, writes `frames-mobile/` folder alongside `frames/` and emits responsive JS that swaps the active frame set on viewport resize

## Test plan

- [ ] Toggle "Generate mobile portrait variant" on create page — progress shows two phases
- [ ] Editor viewport toggle switches preview to phone/tablet dimensions
- [ ] Export with mobile frames: zip contains both `frames/` and `frames-mobile/` folders
- [ ] Resizing exported site to <768 px swaps to portrait frames

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)