### PR TITLE
feat: scroll-linked background audio (#55)

### DIFF
--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -18,7 +18,7 @@ function safeHref(s: string): string {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { frames, mobileFrames, sections, siteName, customHead = "", customCss = "" } = body;
+    const { frames, mobileFrames, audioSrc, sections, siteName, customHead = "", customCss = "" } = body;
 
     if (!Array.isArray(frames) || frames.length === 0) {
       return NextResponse.json({ error: "frames must be a non-empty array" }, { status: 400 });
@@ -37,6 +37,15 @@ export async function POST(req: NextRequest) {
 
     const hasMobileFrames = Array.isArray(mobileFrames) && mobileFrames.length > 0 && mobileFrames[0].startsWith("data:image/");
 
+    // Validate and extract audio
+    const audioDataUriMatch = typeof audioSrc === "string"
+      ? audioSrc.match(/^data:(audio\/[a-zA-Z0-9+.-]+);base64,(.+)$/)
+      : null;
+    const hasAudio = !!audioDataUriMatch;
+    const audioMime = audioDataUriMatch?.[1] ?? "";
+    const audioExt = audioMime.split("/")[1]?.split(";")[0] ?? "mp3";
+    const audioBase64 = audioDataUriMatch?.[2] ?? "";
+
     const zip = new JSZip();
     const framesFolder = zip.folder("frames")!;
 
@@ -53,6 +62,11 @@ export async function POST(req: NextRequest) {
         const base64 = mobileFrames[i].replace(/^data:image\/[a-zA-Z+.-]+;base64,/, "");
         mobileFolder.file(`frame_${String(i).padStart(4, "0")}.jpg`, base64, { base64: true });
       }
+    }
+
+    // Add audio file if present
+    if (hasAudio) {
+      zip.file(`audio/track.${audioExt}`, audioBase64, { base64: true });
     }
 
     // Generate sections HTML
@@ -91,6 +105,14 @@ export async function POST(req: NextRequest) {
       text-transform: uppercase; z-index: 20; transition: opacity 0.5s;
     }
     #scroll-hint .arrow { width: 1px; height: 40px; background: linear-gradient(to bottom, transparent, rgba(255,255,255,0.4)); }
+    #audio-mute {
+      position: fixed; top: 1rem; right: 1rem; z-index: 30;
+      background: rgba(0,0,0,0.5); border: 1px solid rgba(255,255,255,0.15);
+      color: white; border-radius: 50%; width: 2rem; height: 2rem;
+      cursor: pointer; font-size: 1rem; display: flex; align-items: center; justify-content: center;
+      transition: background 0.2s;
+    }
+    #audio-mute:hover { background: rgba(255,255,255,0.1); }
   </style>
   ${customCss ? `<style>\n${customCss}\n  </style>` : ""}
   ${customHead || ""}
@@ -105,6 +127,7 @@ export async function POST(req: NextRequest) {
     <span>Scroll</span>
     <div class="arrow"></div>
   </div>
+  ${hasAudio ? `<button id="audio-mute" title="Toggle audio">🔊</button>` : ""}
 
   <script>
     (function() {
@@ -189,6 +212,46 @@ export async function POST(req: NextRequest) {
       preload();
     })();
 
+    ${hasAudio ? `
+    // Scroll-linked audio
+    (function() {
+      var audio = new Audio('audio/track.${audioExt}');
+      audio.loop = true;
+      audio.volume = 0;
+      var lastScrollY = 0, lastScrollTime = 0, idleTimer = null, fadeRaf = null;
+
+      function fadeVolume(target, duration) {
+        var start = audio.volume, startTime = performance.now();
+        cancelAnimationFrame(fadeRaf);
+        function tick(now) {
+          var t = Math.min((now - startTime) / duration, 1);
+          audio.volume = start + (target - start) * t;
+          if (t < 1) { fadeRaf = requestAnimationFrame(tick); }
+          else if (target === 0) { audio.pause(); }
+        }
+        fadeRaf = requestAnimationFrame(tick);
+      }
+
+      var muteBtn = document.getElementById('audio-mute');
+      if (muteBtn) muteBtn.addEventListener('click', function() {
+        audio.muted = !audio.muted;
+        muteBtn.textContent = audio.muted ? '🔇' : '🔊';
+      });
+
+      window.addEventListener('scroll', function() {
+        var now = performance.now();
+        var scrollY = window.scrollY;
+        var dt = now - lastScrollTime;
+        var velocity = dt > 0 ? Math.abs(scrollY - lastScrollY) / dt : 0;
+        lastScrollY = scrollY; lastScrollTime = now;
+        var targetVol = Math.min(Math.max(velocity / 0.5, 0.08), 1);
+        if (audio.paused) { audio.volume = targetVol; audio.play().catch(function(){}); }
+        else { cancelAnimationFrame(fadeRaf); audio.volume = targetVol; }
+        clearTimeout(idleTimer);
+        idleTimer = setTimeout(function() { fadeVolume(0, 600); }, 2000);
+      }, { passive: true });
+    })();
+    ` : ""}
     // Scroll-linked section entrance animations
     (function() {
       const sections = document.querySelectorAll('.scroll-section');

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -10,8 +10,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   ArrowLeft, Download, Plus, Trash2, Eye, EyeOff, ChevronUp, ChevronDown,
   Sparkles, Layers, Settings, Type, Loader2, AlignLeft, AlignCenter, AlignRight,
-  MessageSquare, Send, X, Bot, Monitor, Tablet, Smartphone
+  MessageSquare, Send, X, Bot, Monitor, Tablet, Smartphone, Music, Volume2, VolumeX
 } from "lucide-react";
+import { useScrollAudio } from "@/lib/useScrollAudio";
 import Link from "next/link";
 import { toast } from "sonner";
 import dynamic from "next/dynamic";
@@ -92,6 +93,11 @@ function EditorInner() {
   const [customCss, setCustomCss] = useState("");
   const [mobileFrames, setMobileFrames] = useState<string[]>([]);
   const [viewportMode, setViewportMode] = useState<"desktop" | "tablet" | "mobile">("desktop");
+  const [audioSrc, setAudioSrc] = useState<string | null>(null);
+  const [audioMuted, setAudioMuted] = useState(false);
+  const audioFileRef = useRef<HTMLInputElement>(null);
+
+  useScrollAudio({ audioSrc, scrollEl: previewScrollRef, muted: audioMuted });
 
   // Load mobile frames from sessionStorage if the create page generated them
   useEffect(() => {
@@ -152,7 +158,7 @@ function EditorInner() {
       const res = await fetch("/api/export-site", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ frames, mobileFrames: mobileFrames.length ? mobileFrames : undefined, sections, siteName, fps, customHead, customCss }),
+        body: JSON.stringify({ frames, mobileFrames: mobileFrames.length ? mobileFrames : undefined, audioSrc: audioSrc ?? undefined, sections, siteName, fps, customHead, customCss }),
       });
       if (!res.ok) throw new Error(await res.text());
       const blob = await res.blob();
@@ -218,6 +224,16 @@ function EditorInner() {
         </div>
 
         <div className="flex items-center gap-2">
+          {/* Audio mute toggle — only show when audio is loaded */}
+          {audioSrc && (
+            <button
+              onClick={() => setAudioMuted(m => !m)}
+              title={audioMuted ? "Unmute audio" : "Mute audio"}
+              className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {audioMuted ? <VolumeX className="w-3.5 h-3.5" /> : <Volume2 className="w-3.5 h-3.5 text-primary" />}
+            </button>
+          )}
           {/* Viewport toggle */}
           <div className="flex items-center bg-white/5 rounded-md p-0.5 gap-0.5">
             {([["desktop", Monitor], ["tablet", Tablet], ["mobile", Smartphone]] as const).map(([mode, Icon]) => (
@@ -451,6 +467,9 @@ function EditorInner() {
                   <TabsTrigger value="layout" className="flex-1 text-xs h-6">
                     <Settings className="w-3 h-3 mr-1" /> Layout
                   </TabsTrigger>
+                  <TabsTrigger value="audio" className="flex-1 text-xs h-6">
+                    <Music className="w-3 h-3 mr-1" /> Audio
+                  </TabsTrigger>
                   <TabsTrigger value="code" className="flex-1 text-xs h-6">
                     &lt;/&gt; Code
                   </TabsTrigger>
@@ -587,6 +606,46 @@ function EditorInner() {
                       </button>
                     ))}
                   </div>
+                </div>
+              </TabsContent>
+
+              <TabsContent value="audio" className="p-3 space-y-4 mt-0">
+                <div className="space-y-2">
+                  <label className="text-xs text-muted-foreground font-medium">Background audio</label>
+                  <p className="text-xs text-muted-foreground/70">Volume fades in on scroll, fades out when idle</p>
+                  <button
+                    onClick={() => audioFileRef.current?.click()}
+                    className={`w-full p-3 rounded-xl border-2 border-dashed transition-colors flex flex-col items-center gap-1.5 text-xs ${audioSrc ? "border-primary/40 bg-primary/5 text-primary" : "border-white/15 hover:border-primary/30 text-muted-foreground"}`}
+                  >
+                    <Music className="w-5 h-5" />
+                    {audioSrc ? "Audio loaded — scroll to play" : "Upload MP3 / WAV"}
+                  </button>
+                  <input
+                    ref={audioFileRef}
+                    type="file"
+                    accept="audio/*"
+                    className="hidden"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (!file) return;
+                      const reader = new FileReader();
+                      reader.onload = (ev) => setAudioSrc(ev.target?.result as string);
+                      reader.readAsDataURL(file);
+                    }}
+                  />
+                  {audioSrc && (
+                    <button
+                      onClick={() => { setAudioSrc(null); if (audioFileRef.current) audioFileRef.current.value = ""; }}
+                      className="w-full h-7 rounded border border-white/10 text-xs text-muted-foreground hover:text-destructive hover:border-destructive/40 transition-colors"
+                    >
+                      Remove audio
+                    </button>
+                  )}
+                </div>
+                <div className="text-xs text-muted-foreground/60 space-y-1">
+                  <p>• Audio plays when you scroll in the preview</p>
+                  <p>• Exported site includes the audio file</p>
+                  <p>• Use ambient loops for best results</p>
                 </div>
               </TabsContent>
 

--- a/src/lib/useScrollAudio.ts
+++ b/src/lib/useScrollAudio.ts
@@ -1,0 +1,95 @@
+"use client";
+import { useEffect, useRef, useCallback } from "react";
+
+interface ScrollAudioOptions {
+  audioSrc: string | null;
+  scrollEl: React.RefObject<HTMLElement | null> | null;
+  muted?: boolean;
+}
+
+export function useScrollAudio({ audioSrc, scrollEl, muted = false }: ScrollAudioOptions) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const lastScrollY = useRef(0);
+  const lastScrollTime = useRef(0);
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fadeRaf = useRef<number>(0);
+
+  const fadeVolume = useCallback((audio: HTMLAudioElement, target: number, duration = 400) => {
+    const start = audio.volume;
+    const startTime = performance.now();
+    cancelAnimationFrame(fadeRaf.current);
+    function tick(now: number) {
+      const t = Math.min((now - startTime) / duration, 1);
+      audio.volume = start + (target - start) * t;
+      if (t < 1) fadeRaf.current = requestAnimationFrame(tick);
+      else if (target === 0) audio.pause();
+    }
+    fadeRaf.current = requestAnimationFrame(tick);
+  }, []);
+
+  useEffect(() => {
+    if (!audioSrc) {
+      audioRef.current?.pause();
+      audioRef.current = null;
+      return;
+    }
+
+    const audio = new Audio(audioSrc);
+    audio.loop = true;
+    audio.volume = 0;
+    audio.muted = muted;
+    audioRef.current = audio;
+
+    return () => {
+      audio.pause();
+      audio.src = "";
+      audioRef.current = null;
+    };
+  }, [audioSrc, muted]);
+
+  // Keep muted in sync without recreating
+  useEffect(() => {
+    if (audioRef.current) audioRef.current.muted = muted;
+  }, [muted]);
+
+  useEffect(() => {
+    if (!audioSrc) return;
+    const el: EventTarget = scrollEl?.current ?? window;
+
+    const onScroll = () => {
+      const audio = audioRef.current;
+      if (!audio) return;
+
+      const now = performance.now();
+      const scrollY = scrollEl?.current ? scrollEl.current.scrollTop : window.scrollY;
+      const dt = now - lastScrollTime.current;
+      const velocity = dt > 0 ? Math.abs(scrollY - lastScrollY.current) / dt : 0;
+
+      lastScrollY.current = scrollY;
+      lastScrollTime.current = now;
+
+      // Map velocity (px/ms) to volume: 0.05 → quiet, 0.5 → full
+      const targetVolume = Math.min(Math.max(velocity / 0.5, 0.08), 1);
+
+      if (audio.paused) {
+        audio.volume = targetVolume;
+        audio.play().catch(() => {/* autoplay blocked — user must interact first */});
+      } else {
+        cancelAnimationFrame(fadeRaf.current);
+        audio.volume = targetVolume;
+      }
+
+      // Idle fade-out after 2s without scrolling
+      if (idleTimer.current) clearTimeout(idleTimer.current);
+      idleTimer.current = setTimeout(() => {
+        if (audioRef.current) fadeVolume(audioRef.current, 0);
+      }, 2000);
+    };
+
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      if (idleTimer.current) clearTimeout(idleTimer.current);
+    };
+  }, [audioSrc, scrollEl, fadeVolume]);
+}


### PR DESCRIPTION
## Summary

- **`useScrollAudio` hook**: attaches a scroll listener, plays the provided audio on scroll, maps scroll velocity to volume (fast scroll = louder), and fades out + pauses after 2 s of idle
- **Editor Audio tab**: file picker for MP3/WAV, drag-and-drop style button, status shows "Audio loaded — scroll to play", remove button, tip bullets
- **Mute toggle**: 🔊/🔇 button appears in the editor top bar whenever audio is loaded
- **Export**: audio written to `audio/track.<ext>` in the zip; scroll-linked JS injected into exported HTML; floating 🔊 mute button rendered in the exported page

## Test plan

- [ ] Upload an MP3 in the Audio tab — mute button appears in top bar
- [ ] Scroll in editor preview — audio starts and volume varies with speed
- [ ] Stop scrolling for 2 s — audio fades out
- [ ] Export with audio — zip contains `audio/` folder, mute button visible in exported page

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)