### PR TITLE
feat: Vercel Blob storage for extracted frames (#44)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@sentry/nextjs": "^10.56.0",
         "@studio-freight/lenis": "^1.0.42",
         "@types/fluent-ffmpeg": "^2.1.28",
+        "@vercel/blob": "^2.4.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "fluent-ffmpeg": "^2.1.3",
@@ -4238,6 +4239,22 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.4.0.tgz",
+      "integrity": "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -4776,6 +4793,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -7449,6 +7475,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -10036,6 +10085,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rettime": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
@@ -11213,6 +11271,18 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -11580,6 +11650,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@sentry/nextjs": "^10.56.0",
     "@studio-freight/lenis": "^1.0.42",
     "@types/fluent-ffmpeg": "^2.1.28",
+    "@vercel/blob": "^2.4.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "fluent-ffmpeg": "^2.1.3",

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -27,15 +27,28 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "sections must be a non-empty array" }, { status: 400 });
     }
 
-    // Reject SVG demo-frame URLs — only real base64 data URIs are exportable
-    if (!frames[0].startsWith("data:image/")) {
+    const isBlobUrl = frames[0].startsWith("https://") || frames[0].startsWith("http://");
+    const isBase64 = frames[0].startsWith("data:image/");
+
+    if (!isBlobUrl && !isBase64) {
       return NextResponse.json(
         { error: "Cannot export demo frames. Generate real frames first using the AI or by uploading a video." },
         { status: 400 }
       );
     }
 
-    const hasMobileFrames = Array.isArray(mobileFrames) && mobileFrames.length > 0 && mobileFrames[0].startsWith("data:image/");
+    // Helper: get raw JPEG buffer from either base64 data URI or CDN URL
+    async function frameToBuffer(src: string): Promise<Buffer> {
+      if (src.startsWith("data:image/")) {
+        return Buffer.from(src.replace(/^data:image\/[a-zA-Z+.-]+;base64,/, ""), "base64");
+      }
+      const res = await fetch(src);
+      if (!res.ok) throw new Error(`Failed to fetch frame: ${res.status}`);
+      return Buffer.from(await res.arrayBuffer());
+    }
+
+    const hasMobileFrames = Array.isArray(mobileFrames) && mobileFrames.length > 0
+      && (mobileFrames[0].startsWith("data:image/") || mobileFrames[0].startsWith("http"));
 
     // Validate and extract audio
     const audioDataUriMatch = typeof audioSrc === "string"
@@ -49,18 +62,25 @@ export async function POST(req: NextRequest) {
     const zip = new JSZip();
     const framesFolder = zip.folder("frames")!;
 
-    // Add desktop frames
-    for (let i = 0; i < frames.length; i++) {
-      const base64 = frames[i].replace(/^data:image\/[a-zA-Z+.-]+;base64,/, "");
-      framesFolder.file(`frame_${String(i).padStart(4, "0")}.jpg`, base64, { base64: true });
+    // Add desktop frames in parallel batches
+    const BATCH = 10;
+    for (let i = 0; i < frames.length; i += BATCH) {
+      const batch = frames.slice(i, i + BATCH);
+      const buffers = await Promise.all(batch.map(frameToBuffer));
+      buffers.forEach((buf, j) => {
+        framesFolder.file(`frame_${String(i + j).padStart(4, "0")}.jpg`, buf);
+      });
     }
 
     // Add mobile frames if present
     if (hasMobileFrames) {
       const mobileFolder = zip.folder("frames-mobile")!;
-      for (let i = 0; i < mobileFrames.length; i++) {
-        const base64 = mobileFrames[i].replace(/^data:image\/[a-zA-Z+.-]+;base64,/, "");
-        mobileFolder.file(`frame_${String(i).padStart(4, "0")}.jpg`, base64, { base64: true });
+      for (let i = 0; i < mobileFrames.length; i += BATCH) {
+        const batch = mobileFrames.slice(i, i + BATCH);
+        const buffers = await Promise.all(batch.map(frameToBuffer));
+        buffers.forEach((buf, j) => {
+          mobileFolder.file(`frame_${String(i + j).padStart(4, "0")}.jpg`, buf);
+        });
       }
     }
 

--- a/src/app/api/extract-frames/route.ts
+++ b/src/app/api/extract-frames/route.ts
@@ -6,6 +6,7 @@ import { exec } from "child_process";
 import { promisify } from "util";
 import { readdir, readFile } from "fs/promises";
 import { rateLimit, getClientIp } from "@/lib/rateLimit";
+import { put } from "@vercel/blob";
 
 const execAsync = promisify(exec);
 
@@ -111,15 +112,26 @@ export async function POST(req: NextRequest) {
       ? Array.from({ length: MAX_FRAMES }, (_, i) => allFrameFiles[Math.min(Math.floor(i * step), allFrameFiles.length - 1)])
       : allFrameFiles;
 
+    const useBlobStorage = !!process.env.BLOB_READ_WRITE_TOKEN;
     const frames: string[] = [];
+    const sessionId = `scrollcraft/${Date.now()}`;
+
     for (const file of frameFiles) {
       const buf = await readFile(path.join(framesDir, file));
-      frames.push(`data:image/jpeg;base64,${buf.toString("base64")}`);
+      if (useBlobStorage) {
+        const { url } = await put(`${sessionId}/${file}`, buf, {
+          access: "public",
+          contentType: "image/jpeg",
+        });
+        frames.push(url);
+      } else {
+        frames.push(`data:image/jpeg;base64,${buf.toString("base64")}`);
+      }
     }
 
     await rm(tmpDir, { recursive: true, force: true });
 
-    return NextResponse.json({ frames, frameCount: frames.length });
+    return NextResponse.json({ frames, frameCount: frames.length, stored: useBlobStorage });
   } catch (err) {
     console.error("extract-frames error:", err);
     if (existsSync(tmpDir)) await rm(tmpDir, { recursive: true, force: true }).catch(() => {});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -16,6 +16,9 @@ const envSchema = z.object({
   AUTH_GOOGLE_ID: z.string().optional(),
   AUTH_GOOGLE_SECRET: z.string().optional(),
 
+  // Storage
+  BLOB_READ_WRITE_TOKEN: z.string().optional(),
+
   // Observability
   NEXT_PUBLIC_SENTRY_DSN: z.string().url().optional(),
   SENTRY_ORG: z.string().optional(),


### PR DESCRIPTION
## Summary

- **`extract-frames` route**: when `BLOB_READ_WRITE_TOKEN` is set, uploads each JPEG directly to Vercel Blob via `put()` and returns public CDN URLs instead of base64 strings — avoids the 4.5 MB serverless response limit
- **`export-site` route**: new `frameToBuffer()` helper accepts both base64 data URIs and `https://` CDN URLs; uses parallel batches of 10 for fast zip assembly
- **Mobile frames**: same dual-source support extended to `frames-mobile/` folder
- **Env schema**: `BLOB_READ_WRITE_TOKEN` added as optional field; app gracefully falls back to base64 when not set

## Test plan

- [ ] Without `BLOB_READ_WRITE_TOKEN`: frame extraction returns base64 as before
- [ ] With `BLOB_READ_WRITE_TOKEN`: frames returned as `https://...blob.vercel-storage.com/...` URLs
- [ ] Export works for both base64 and CDN URL frame sources

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)