### PR TITLE
feat: Razorpay payment integration (#43)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "next": "16.2.7",
         "next-auth": "^5.0.0-beta.31",
         "next-themes": "^0.4.6",
+        "razorpay": "^2.9.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "shadcn": "^4.10.0",
@@ -4804,6 +4805,12 @@
         "retry": "0.13.1"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4828,6 +4835,52 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/axobject-query": {
@@ -5201,6 +5254,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -5544,6 +5609,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5838,7 +5912,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6705,6 +6778,26 @@
         "which": "bin/which"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -6719,6 +6812,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -7185,7 +7315,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9878,6 +10007,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/razorpay": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/razorpay/-/razorpay-2.9.6.tgz",
+      "integrity": "sha512-zsHAQzd6e1Cc6BNoCNZQaf65ElL6O6yw0wulxmoG5VQDr363fZC90Mp1V5EktVzG45yPyNomNXWlf4cQ3622gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.6.8"
       }
     },
     "node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "next": "16.2.7",
     "next-auth": "^5.0.0-beta.31",
     "next-themes": "^0.4.6",
+    "razorpay": "^2.9.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.10.0",

--- a/src/app/api/payments/create-order/route.ts
+++ b/src/app/api/payments/create-order/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import Razorpay from "razorpay";
+
+const PLAN_PRICES: Record<string, { monthly: number; annual: number }> = {
+  Basic:      { monthly: 25,  annual: 20  },
+  "Basic Plus": { monthly: 40,  annual: 32  },
+  Pro:        { monthly: 60,  annual: 48  },
+  Premium:    { monthly: 200, annual: 160 },
+};
+
+export async function POST(req: NextRequest) {
+  const keyId = process.env.RAZORPAY_KEY_ID;
+  const keySecret = process.env.RAZORPAY_KEY_SECRET;
+
+  if (!keyId || !keySecret) {
+    return NextResponse.json({ error: "Payment gateway not configured" }, { status: 503 });
+  }
+
+  try {
+    const { plan, billing } = await req.json();
+
+    const prices = PLAN_PRICES[plan as string];
+    if (!prices) {
+      return NextResponse.json({ error: "Unknown plan" }, { status: 400 });
+    }
+
+    const priceUsd = billing === "annual" ? prices.annual : prices.monthly;
+    // Razorpay expects amount in smallest currency unit (paise for INR)
+    // We store price in USD but charge in INR — use a fixed exchange rate placeholder
+    // Production should fetch live rates or store INR prices directly
+    const INR_RATE = 84; // approximate USD → INR
+    const amountPaise = priceUsd * INR_RATE * 100;
+
+    const rzp = new Razorpay({ key_id: keyId, key_secret: keySecret });
+
+    const order = await rzp.orders.create({
+      amount: Math.round(amountPaise),
+      currency: "INR",
+      notes: { plan, billing: billing ?? "monthly" },
+    });
+
+    return NextResponse.json({
+      orderId: order.id,
+      amount: order.amount,
+      currency: order.currency,
+      keyId,
+    });
+  } catch (err) {
+    console.error("create-order error:", err);
+    return NextResponse.json({ error: "Failed to create order" }, { status: 500 });
+  }
+}

--- a/src/app/api/payments/verify/route.ts
+++ b/src/app/api/payments/verify/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+
+export async function POST(req: NextRequest) {
+  const keySecret = process.env.RAZORPAY_KEY_SECRET;
+
+  if (!keySecret) {
+    return NextResponse.json({ error: "Payment gateway not configured" }, { status: 503 });
+  }
+
+  try {
+    const { orderId, paymentId, signature } = await req.json();
+
+    if (!orderId || !paymentId || !signature) {
+      return NextResponse.json({ error: "Missing payment details" }, { status: 400 });
+    }
+
+    const expectedSignature = crypto
+      .createHmac("sha256", keySecret)
+      .update(`${orderId}|${paymentId}`)
+      .digest("hex");
+
+    if (expectedSignature !== signature) {
+      return NextResponse.json({ error: "Invalid payment signature" }, { status: 400 });
+    }
+
+    // Payment is verified — in production, update the user's subscription in DB here
+    return NextResponse.json({ success: true, paymentId });
+  } catch (err) {
+    console.error("verify error:", err);
+    return NextResponse.json({ error: "Verification failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/webhooks/razorpay/route.ts
+++ b/src/app/api/webhooks/razorpay/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+
+export async function POST(req: NextRequest) {
+  const webhookSecret = process.env.RAZORPAY_WEBHOOK_SECRET;
+
+  if (!webhookSecret) {
+    return NextResponse.json({ error: "Webhook secret not configured" }, { status: 503 });
+  }
+
+  const rawBody = await req.text();
+  const signature = req.headers.get("x-razorpay-signature") ?? "";
+
+  const expectedSignature = crypto
+    .createHmac("sha256", webhookSecret)
+    .update(rawBody)
+    .digest("hex");
+
+  if (expectedSignature !== signature) {
+    return NextResponse.json({ error: "Invalid webhook signature" }, { status: 400 });
+  }
+
+  let event: { event: string; payload?: { payment?: { entity?: { id?: string; notes?: Record<string, string> } } } };
+  try {
+    event = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  switch (event.event) {
+    case "payment.captured": {
+      const payment = event.payload?.payment?.entity;
+      if (payment) {
+        const { plan, billing } = payment.notes ?? {};
+        // TODO: update user subscription in database using payment.id, plan, billing
+        console.log("Payment captured:", { paymentId: payment.id, plan, billing });
+      }
+      break;
+    }
+    case "payment.failed":
+      console.log("Payment failed:", event.payload?.payment?.entity?.id);
+      break;
+    default:
+      // Unhandled event type — acknowledge receipt
+      break;
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -3,7 +3,8 @@ import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Check, Minus, Sparkles, Zap } from "lucide-react";
+import { Check, Minus, Sparkles, Zap, Loader2 } from "lucide-react";
+import { toast } from "sonner";
 
 const PLANS = [
   {
@@ -172,9 +173,75 @@ const FAQ = [
   },
 ];
 
+declare global {
+  interface Window {
+    Razorpay: new (options: Record<string, unknown>) => { open(): void };
+  }
+}
+
+function loadRazorpayScript(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (window.Razorpay) { resolve(); return; }
+    const script = document.createElement("script");
+    script.src = "https://checkout.razorpay.com/v1/checkout.js";
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error("Failed to load Razorpay"));
+    document.head.appendChild(script);
+  });
+}
+
 export default function PricingPage() {
   const [annual, setAnnual] = useState(true);
   const [openFaq, setOpenFaq] = useState<number | null>(null);
+  const [checkingOut, setCheckingOut] = useState<string | null>(null);
+
+  const handleCheckout = async (planName: string) => {
+    setCheckingOut(planName);
+    try {
+      const res = await fetch("/api/payments/create-order", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan: planName, billing: annual ? "annual" : "monthly" }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to create order");
+
+      await loadRazorpayScript();
+
+      const rzp = new window.Razorpay({
+        key: data.keyId,
+        amount: data.amount,
+        currency: data.currency,
+        order_id: data.orderId,
+        name: "ScrollCraft",
+        description: `${planName} plan — ${annual ? "Annual" : "Monthly"}`,
+        theme: { color: "#7c3aed" },
+        handler: async (response: { razorpay_order_id: string; razorpay_payment_id: string; razorpay_signature: string }) => {
+          const verifyRes = await fetch("/api/payments/verify", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              orderId: response.razorpay_order_id,
+              paymentId: response.razorpay_payment_id,
+              signature: response.razorpay_signature,
+            }),
+          });
+          const verifyData = await verifyRes.json();
+          if (verifyData.success) {
+            toast.success(`${planName} activated! Welcome aboard.`);
+            window.location.href = `/create?plan=${encodeURIComponent(planName)}`;
+          } else {
+            toast.error("Payment verification failed. Contact support.");
+          }
+        },
+      });
+      rzp.open();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Checkout failed");
+    } finally {
+      setCheckingOut(null);
+    }
+  };
 
   return (
     <main className="min-h-screen bg-background text-foreground">
@@ -277,17 +344,31 @@ export default function PricingPage() {
                 {plan.credits}
               </Badge>
 
-              <Link href={`/create?plan=${encodeURIComponent(plan.name)}`} className="mt-auto">
-                <Button
-                  className={`w-full font-semibold text-sm ${
-                    plan.highlight
-                      ? "bg-primary hover:bg-primary/90 text-white shadow-md shadow-primary/25"
-                      : "bg-white/8 hover:bg-white/12 text-foreground border border-white/10"
-                  }`}
-                >
-                  {plan.cta}
-                </Button>
-              </Link>
+              <div className="mt-auto">
+                {plan.monthly === 0 ? (
+                  <Link href={`/create?plan=${encodeURIComponent(plan.name)}`}>
+                    <Button
+                      className={`w-full font-semibold text-sm bg-white/8 hover:bg-white/12 text-foreground border border-white/10`}
+                    >
+                      {plan.cta}
+                    </Button>
+                  </Link>
+                ) : (
+                  <Button
+                    onClick={() => handleCheckout(plan.name)}
+                    disabled={checkingOut === plan.name}
+                    className={`w-full font-semibold text-sm ${
+                      plan.highlight
+                        ? "bg-primary hover:bg-primary/90 text-white shadow-md shadow-primary/25"
+                        : "bg-white/8 hover:bg-white/12 text-foreground border border-white/10"
+                    }`}
+                  >
+                    {checkingOut === plan.name
+                      ? <><Loader2 className="w-3.5 h-3.5 animate-spin mr-1.5" /> Processing…</>
+                      : plan.cta}
+                  </Button>
+                )}
+              </div>
 
               <div className="border-t border-white/8 pt-4 space-y-2">
                 {plan.features.map((f) => (

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -19,6 +19,11 @@ const envSchema = z.object({
   // Storage
   BLOB_READ_WRITE_TOKEN: z.string().optional(),
 
+  // Payments
+  RAZORPAY_KEY_ID: z.string().optional(),
+  RAZORPAY_KEY_SECRET: z.string().optional(),
+  RAZORPAY_WEBHOOK_SECRET: z.string().optional(),
+
   // Observability
   NEXT_PUBLIC_SENTRY_DSN: z.string().url().optional(),
   SENTRY_ORG: z.string().optional(),


### PR DESCRIPTION
## Summary

- **`/api/payments/create-order`**: accepts `{ plan, billing }`, creates a Razorpay order using the SDK, returns `{ orderId, amount, currency, keyId }` to the frontend
- **`/api/payments/verify`**: HMAC-SHA256 validation of `orderId|paymentId` against `RAZORPAY_KEY_SECRET` — prevents forged success events
- **`/api/webhooks/razorpay`**: signature-verified webhook handler for `payment.captured` / `payment.failed` events; stubbed DB call for subscription update (wired once #42 DB is in)
- **Pricing page**: paid plan CTA buttons open Razorpay Standard Checkout directly; free plan still links to `/create`; loading spinner during checkout

## Test plan

- [ ] Without `RAZORPAY_KEY_ID`, create-order returns 503
- [ ] With test keys, clicking a paid plan opens Razorpay modal
- [ ] Successful test payment triggers `/api/payments/verify` and redirects to `/create?plan=...`
- [ ] Webhook endpoint rejects requests with wrong signature

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)