### PR TITLE
fix: run prisma generate before next build on Vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,5 @@ next-env.d.ts
 # temporary frame extraction files
 /tmp
 
-/src/generated/prisma
+# Prisma generated client is regenerated via postinstall/build — do not commit
+# /src/generated/prisma

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
+    "postinstall": "prisma generate",
     "start": "next start",
     "lint": "eslint"
   },


### PR DESCRIPTION
## Problem

Vercel build was failing with:

\`\`\`
Module not found: Can't resolve '@/generated/prisma/client'
\`\`\`

The Prisma v7 client is generated into \`src/generated/prisma/\` but:
1. That folder was in \`.gitignore\` so it was never committed
2. \`prisma generate\` was never called during the Vercel build

## Fix

- **`package.json` build script**: \`prisma generate && next build\`
- **`package.json` postinstall**: \`prisma generate\` — keeps local dev in sync after \`npm install\`
- **`.gitignore`**: commented out the exclusion of \`src/generated/prisma\`

## Verified

Local \`npm run build\` now shows:
\`\`\`
✔ Generated Prisma Client (7.8.0) to ./src/generated/prisma in 37ms
✓ Compiled successfully
✓ Generating static pages (25/25)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)