### PR TITLE
fix: unify auth env var names, enforce NEXTAUTH_SECRET, refresh plan in session

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,17 +3,18 @@ import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { db } from "@/lib/db";
+import { env } from "@/lib/env";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   adapter: PrismaAdapter(db),
   providers: [
     GitHub({
-      clientId: process.env.GITHUB_CLIENT_ID,
-      clientSecret: process.env.GITHUB_CLIENT_SECRET,
+      clientId: env.AUTH_GITHUB_ID,
+      clientSecret: env.AUTH_GITHUB_SECRET,
     }),
     Google({
-      clientId: process.env.GOOGLE_CLIENT_ID,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      clientId: env.AUTH_GOOGLE_ID,
+      clientSecret: env.AUTH_GOOGLE_SECRET,
     }),
   ],
   pages: {
@@ -24,6 +25,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     async session({ session, user }) {
       if (session.user && user?.id) {
         session.user.id = user.id;
+        const fresh = await db.user.findUnique({
+          where: { id: user.id },
+          select: { plan: true },
+        });
+        if (fresh) session.user.plan = fresh.plan;
       }
       return session;
     },

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -11,8 +11,8 @@ const envSchema = z.object({
   // Database
   DATABASE_URL: z.string().url().optional(),
 
-  // Auth — required at runtime but optional during build-time static generation
-  NEXTAUTH_SECRET: z.string().optional(),
+  // Auth — required at runtime, optional only during build phase
+  NEXTAUTH_SECRET: z.string().min(1).optional(),
   NEXTAUTH_URL: z.string().url().optional(),
   AUTH_GITHUB_ID: z.string().optional(),
   AUTH_GITHUB_SECRET: z.string().optional(),
@@ -55,6 +55,11 @@ export const env = (_env.success ? _env.data : envSchema.parse({
   NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET ?? "build-placeholder",
   NODE_ENV: process.env.NODE_ENV ?? "production",
 }));
+
+// At runtime (not build time), NEXTAUTH_SECRET is required for session security
+if (!isBuildPhase && !env.NEXTAUTH_SECRET) {
+  throw new Error("NEXTAUTH_SECRET is required in production. Set it in your environment variables.");
+}
 
 export function isDemoMode(): boolean {
   return !env.LUMAAI_API_KEY && !env.RUNWAYML_API_KEY;

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,10 @@
+import type { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+      plan?: string;
+    } & DefaultSession["user"];
+  }
+}


### PR DESCRIPTION
## Summary

- **Closes #75** — `src/auth.ts` was reading `GITHUB_CLIENT_ID` / `GOOGLE_CLIENT_ID` but `env.ts` defines `AUTH_GITHUB_ID` / `AUTH_GOOGLE_ID`. OAuth would silently fail because providers received `undefined`. Now reads from the validated `env` object.
- **Closes #80** — Session callback now fetches `plan` from the DB on every session read, so plan upgrades reflect immediately without re-login.
- **Closes #81** — `NEXTAUTH_SECRET` now throws at runtime if missing (build phase still uses placeholder to allow Vercel builds).
- New `src/types/next-auth.d.ts` extends the `Session` type with `id` and `plan`.

## Test plan
- [ ] GitHub OAuth sign-in completes successfully
- [ ] Google OAuth sign-in completes successfully
- [ ] After plan upgrade, refreshing any page shows the new plan without re-login
- [ ] Deploying without `NEXTAUTH_SECRET` set causes a clear startup error

🤖 Generated with [Claude Code](https://claude.com/claude-code)