### PR TITLE
fix: add Postgres connection pool limit and dev query logging

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -3,15 +3,19 @@ import { PrismaPg } from "@prisma/adapter-pg";
 
 type GlobalWithPrisma = typeof globalThis & { prisma?: PrismaClient };
 
+// Cap connections per serverless instance so we don't exhaust Postgres under load.
+// Vercel spins up many concurrent functions; keeping this low prevents connection storms.
+const POOL_MAX = parseInt(process.env.DB_POOL_MAX ?? "5", 10);
+
 function createClient(): PrismaClient {
-  const connectionString = process.env.DATABASE_URL;
-  if (!connectionString) {
-    // No DB configured — return a client that will fail gracefully at runtime
-    const adapter = new PrismaPg({ connectionString: "postgresql://localhost/scrollcraft" });
-    return new PrismaClient({ adapter });
-  }
-  const adapter = new PrismaPg({ connectionString });
-  return new PrismaClient({ adapter });
+  const connectionString = process.env.DATABASE_URL ?? "postgresql://localhost/scrollcraft";
+  // Pass a PoolConfig so we control max connections per serverless instance.
+  // Keeps Postgres from being overwhelmed when Vercel scales horizontally.
+  const adapter = new PrismaPg({ connectionString, max: POOL_MAX });
+  return new PrismaClient({
+    adapter,
+    log: process.env.NODE_ENV === "development" ? ["query", "warn", "error"] : ["error"],
+  });
 }
 
 const globalForPrisma = globalThis as GlobalWithPrisma;


### PR DESCRIPTION
## Summary

- **Closes #77** — `PrismaPg` now receives `max: POOL_MAX` (default 5, overridable via `DB_POOL_MAX` env var). Prevents connection exhaustion when Vercel scales to many concurrent serverless instances.
- **Closes #98** — Prisma client enables `query`, `warn`, `error` log levels in development so N+1 queries and slow calls are visible in terminal output.

## Test plan
- [ ] App starts and DB queries work normally
- [ ] In development, queries are logged to console
- [ ] Set `DB_POOL_MAX=2` and confirm app still works with limited connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)