### PR TITLE
fix: payment idempotency and webhook error propagation

### DIFF
--- a/src/app/api/payments/verify/route.ts
+++ b/src/app/api/payments/verify/route.ts
@@ -45,6 +45,11 @@ export async function POST(req: NextRequest) {
     if (!payment) return NextResponse.json({ error: "Order not found" }, { status: 404 });
     if (payment.userId !== user.id) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
+    // Idempotency: if already captured (e.g. webhook arrived first), return success
+    if (payment.status === "CAPTURED") {
+      return NextResponse.json({ success: true, paymentId });
+    }
+
     // Mark payment captured and upgrade plan
     const planMap: Record<string, "BASIC" | "BASIC_PLUS" | "PRO" | "PREMIUM"> = {
       Basic: "BASIC", "Basic Plus": "BASIC_PLUS", Pro: "PRO", Premium: "PREMIUM",

--- a/src/app/api/webhooks/razorpay/route.ts
+++ b/src/app/api/webhooks/razorpay/route.ts
@@ -31,24 +31,22 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
+  try {
   switch (event.event) {
     case "payment.captured": {
       const entity = event.payload?.payment?.entity;
       if (entity?.order_id) {
-        try {
-          const payment = await db.payment.findUnique({ where: { razorpayOrderId: entity.order_id } });
-          if (payment && payment.status !== "CAPTURED") {
-            await db.payment.update({
-              where: { id: payment.id },
-              data: { razorpayPaymentId: entity.id, status: "CAPTURED" },
-            });
-            const newPlan = PLAN_MAP[payment.plan];
-            if (newPlan) {
-              await db.user.update({ where: { id: payment.userId }, data: { plan: newPlan } });
-            }
+        // Idempotency: skip if already captured (verify endpoint may have run first)
+        const payment = await db.payment.findUnique({ where: { razorpayOrderId: entity.order_id } });
+        if (payment && payment.status !== "CAPTURED") {
+          await db.payment.update({
+            where: { id: payment.id },
+            data: { razorpayPaymentId: entity.id, status: "CAPTURED" },
+          });
+          const newPlan = PLAN_MAP[payment.plan];
+          if (newPlan) {
+            await db.user.update({ where: { id: payment.userId }, data: { plan: newPlan } });
           }
-        } catch (err) {
-          console.error("Webhook DB update failed:", err);
         }
       }
       break;
@@ -56,15 +54,20 @@ export async function POST(req: NextRequest) {
     case "payment.failed": {
       const entity = event.payload?.payment?.entity;
       if (entity?.order_id) {
+        // Let errors propagate — a 5xx tells Razorpay to retry the webhook
         await db.payment.updateMany({
           where: { razorpayOrderId: entity.order_id, status: "PENDING" },
           data: { status: "FAILED" },
-        }).catch(() => {});
+        });
       }
       break;
     }
     default:
       break;
+  }
+  } catch (err) {
+    console.error("Webhook processing failed:", err);
+    return NextResponse.json({ error: "Webhook processing failed" }, { status: 500 });
   }
 
   return NextResponse.json({ received: true });


### PR DESCRIPTION
## Summary

- **Closes #78** — `/api/payments/verify` now checks if the payment is already `CAPTURED` before updating. If it is (e.g. the webhook arrived first), returns success immediately — no double write, no double plan upgrade.
- **Closes #79** — `/api/webhooks/razorpay` `payment.failed` handler no longer uses `.catch(() => {})`. Errors now propagate, returning a 500 so Razorpay retries the webhook instead of silently dropping the failure.
- Wrapped the entire webhook `switch` in a try/catch so any unexpected DB error also returns 500.

## Test plan
- [ ] Calling `/api/payments/verify` twice with the same orderId returns success both times but only upgrades the plan once
- [ ] If DB is down during `payment.failed` webhook, endpoint returns 500 (not 200)
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)