### PR TITLE
feat: wire Upstash Redis rate limiter for cross-instance correctness

### DIFF
--- a/src/__tests__/rateLimit.test.ts
+++ b/src/__tests__/rateLimit.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-// Reset module between tests to get a fresh store
 let rateLimit: typeof import("../lib/rateLimit").rateLimit;
 
 beforeEach(async () => {
@@ -8,44 +7,44 @@ beforeEach(async () => {
   ({ rateLimit } = await import("../lib/rateLimit"));
 });
 
-describe("rateLimit", () => {
-  it("allows requests within the limit", () => {
-    const result = rateLimit("1.2.3.4", { limit: 3, windowMs: 60_000 });
+describe("rateLimit (in-memory fallback)", () => {
+  it("allows requests within the limit", async () => {
+    const result = await rateLimit("1.2.3.4", { limit: 3, windowMs: 60_000 });
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(2);
   });
 
-  it("tracks count across calls", () => {
-    rateLimit("1.2.3.4", { limit: 3, windowMs: 60_000 });
-    rateLimit("1.2.3.4", { limit: 3, windowMs: 60_000 });
-    const third = rateLimit("1.2.3.4", { limit: 3, windowMs: 60_000 });
+  it("tracks count across calls", async () => {
+    await rateLimit("1.2.3.4", { limit: 3, windowMs: 60_000 });
+    await rateLimit("1.2.3.4", { limit: 3, windowMs: 60_000 });
+    const third = await rateLimit("1.2.3.4", { limit: 3, windowMs: 60_000 });
     expect(third.allowed).toBe(true);
     expect(third.remaining).toBe(0);
   });
 
-  it("blocks requests over the limit", () => {
-    rateLimit("1.2.3.4", { limit: 2, windowMs: 60_000 });
-    rateLimit("1.2.3.4", { limit: 2, windowMs: 60_000 });
-    const over = rateLimit("1.2.3.4", { limit: 2, windowMs: 60_000 });
+  it("blocks requests over the limit", async () => {
+    await rateLimit("1.2.3.4", { limit: 2, windowMs: 60_000 });
+    await rateLimit("1.2.3.4", { limit: 2, windowMs: 60_000 });
+    const over = await rateLimit("1.2.3.4", { limit: 2, windowMs: 60_000 });
     expect(over.allowed).toBe(false);
     expect(over.remaining).toBe(0);
   });
 
-  it("resets after window expires", () => {
+  it("resets after window expires", async () => {
     vi.useFakeTimers();
-    rateLimit("1.2.3.4", { limit: 1, windowMs: 1_000 });
-    const blocked = rateLimit("1.2.3.4", { limit: 1, windowMs: 1_000 });
+    await rateLimit("1.2.3.4", { limit: 1, windowMs: 1_000 });
+    const blocked = await rateLimit("1.2.3.4", { limit: 1, windowMs: 1_000 });
     expect(blocked.allowed).toBe(false);
 
     vi.advanceTimersByTime(1_001);
-    const after = rateLimit("1.2.3.4", { limit: 1, windowMs: 1_000 });
+    const after = await rateLimit("1.2.3.4", { limit: 1, windowMs: 1_000 });
     expect(after.allowed).toBe(true);
     vi.useRealTimers();
   });
 
-  it("isolates counts per IP", () => {
-    rateLimit("1.1.1.1", { limit: 1, windowMs: 60_000 });
-    const other = rateLimit("2.2.2.2", { limit: 1, windowMs: 60_000 });
+  it("isolates counts per IP", async () => {
+    await rateLimit("1.1.1.1", { limit: 1, windowMs: 60_000 });
+    const other = await rateLimit("2.2.2.2", { limit: 1, windowMs: 60_000 });
     expect(other.allowed).toBe(true);
   });
 });

--- a/src/app/api/chat-edit/route.ts
+++ b/src/app/api/chat-edit/route.ts
@@ -41,7 +41,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rl = rateLimit(getClientIp(req), { limit: 20, windowMs: 60_000 });
+  const rl = await rateLimit(getClientIp(req), { limit: 20, windowMs: 60_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests. Try again in a minute." }, { status: 429 });
   }

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rl = rateLimit(getClientIp(req), { limit: 10, windowMs: 60_000 });
+  const rl = await rateLimit(getClientIp(req), { limit: 10, windowMs: 60_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests. Try again in a minute." }, { status: 429 });
   }

--- a/src/app/api/extract-frames/route.ts
+++ b/src/app/api/extract-frames/route.ts
@@ -22,7 +22,7 @@ async function ffmpegAvailable(): Promise<boolean> {
 }
 
 export async function POST(req: NextRequest) {
-  const rl = rateLimit(getClientIp(req), { limit: 10, windowMs: 60_000 });
+  const rl = await rateLimit(getClientIp(req), { limit: 10, windowMs: 60_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests. Try again in a minute." }, {
       status: 429,

--- a/src/app/api/generate-video/route.ts
+++ b/src/app/api/generate-video/route.ts
@@ -10,7 +10,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rl = rateLimit(getClientIp(req), { limit: 5, windowMs: 60_000 });
+  const rl = await rateLimit(getClientIp(req), { limit: 5, windowMs: 60_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests. Try again in a minute." }, {
       status: 429,

--- a/src/app/api/payments/create-order/route.ts
+++ b/src/app/api/payments/create-order/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rl = rateLimit(getClientIp(req), { limit: 5, windowMs: 3_600_000 }); // 5 per hour
+  const rl = await rateLimit(getClientIp(req), { limit: 5, windowMs: 3_600_000 }); // 5 per hour
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many payment requests. Try again later." }, { status: 429 });
   }

--- a/src/app/api/payments/verify/route.ts
+++ b/src/app/api/payments/verify/route.ts
@@ -10,7 +10,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rl = rateLimit(getClientIp(req), { limit: 10, windowMs: 3_600_000 });
+  const rl = await rateLimit(getClientIp(req), { limit: 10, windowMs: 3_600_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests. Try again later." }, { status: 429 });
   }

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,8 +1,38 @@
-// Uses Upstash Redis when UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN are set,
-// falls back to in-memory sliding window (resets on deploy — sufficient for single-region).
-// To enable Redis: add UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN to env vars.
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
 
-// In-memory fallback store
+// Lazy-init Redis + per-config Ratelimit instances
+let redis: Redis | null = null;
+const limiters = new Map<string, Ratelimit>();
+
+function getRedis(): Redis | null {
+  if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) return null;
+  if (!redis) {
+    redis = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    });
+  }
+  return redis;
+}
+
+function getLimiter(limit: number, windowMs: number): Ratelimit | null {
+  const r = getRedis();
+  if (!r) return null;
+  const cacheKey = `${limit}:${windowMs}`;
+  if (!limiters.has(cacheKey)) {
+    // Convert ms to nearest whole seconds for Upstash duration string
+    const windowSec = Math.ceil(windowMs / 1000);
+    limiters.set(cacheKey, new Ratelimit({
+      redis: r,
+      limiter: Ratelimit.slidingWindow(limit, `${windowSec} s`),
+      prefix: "sc_rl",
+    }));
+  }
+  return limiters.get(cacheKey)!;
+}
+
+// In-memory fallback (single-instance only)
 const store = new Map<string, { count: number; resetAt: number }>();
 
 function pruneExpired() {
@@ -12,37 +42,44 @@ function pruneExpired() {
   }
 }
 
-interface RateLimitOptions {
-  limit: number;
-  windowMs: number;
-}
-
 function rateLimitMemory(
   ip: string,
-  { limit, windowMs }: RateLimitOptions
+  limit: number,
+  windowMs: number
 ): { allowed: boolean; remaining: number; resetAt: number } {
   if (store.size > 10_000) pruneExpired();
   const now = Date.now();
   const entry = store.get(ip);
-
   if (!entry || entry.resetAt <= now) {
     store.set(ip, { count: 1, resetAt: now + windowMs });
     return { allowed: true, remaining: limit - 1, resetAt: now + windowMs };
   }
-
   if (entry.count >= limit) {
     return { allowed: false, remaining: 0, resetAt: entry.resetAt };
   }
-
   entry.count++;
   return { allowed: true, remaining: limit - entry.count, resetAt: entry.resetAt };
 }
 
-export function rateLimit(
+export interface RateLimitOptions {
+  limit: number;
+  windowMs: number;
+}
+
+export async function rateLimit(
   ip: string,
-  options: RateLimitOptions
-): { allowed: boolean; remaining: number; resetAt: number } {
-  return rateLimitMemory(ip, options);
+  { limit, windowMs }: RateLimitOptions
+): Promise<{ allowed: boolean; remaining: number; resetAt: number }> {
+  const limiter = getLimiter(limit, windowMs);
+  if (limiter) {
+    const result = await limiter.limit(ip);
+    return {
+      allowed: result.success,
+      remaining: result.remaining,
+      resetAt: result.reset,
+    };
+  }
+  return rateLimitMemory(ip, limit, windowMs);
 }
 
 export function getClientIp(req: Request): string {


### PR DESCRIPTION
## Summary

Rate limits now persist across all Vercel serverless instances via Upstash Redis.

**How it works:**
- When `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` are set → uses `@upstash/ratelimit` sliding window (Redis-backed, atomic, correct under horizontal scale)
- When those vars are missing → falls back to in-memory Map (same as before, good for local dev)
- Redis clients and `Ratelimit` instances are cached at module level so we don't reconnect on every request
- All 6 routes that call `rateLimit()` updated to `await rateLimit()`

## Setup
Add to Vercel environment variables:
```
UPSTASH_REDIS_REST_URL=https://tight-pheasant-144767.upstash.io
UPSTASH_REDIS_REST_TOKEN=<token>
```

## Test plan
- [ ] With env vars set: hit an endpoint > limit times — 429 persists across cold starts
- [ ] Without env vars: app still works with in-memory fallback
- [ ] `npm test` — 8 tests pass
- [ ] `npx tsc --noEmit` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)