### PR TITLE
fix(#107): store frames in sessionStorage instead of URL params

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -70,8 +70,12 @@ function CreatePageInner() {
         sessionStorage.removeItem("scrollcraft_mobile_frames");
       }
 
+      // Store frames in sessionStorage — never in the URL (base64 payloads are 12-16 MB,
+      // far beyond the ~2 MB browser URL limit, causing silent truncation / 414 errors).
+      sessionStorage.setItem("scrollcraft_desktop_frames", JSON.stringify(frames));
+
       const params = new URLSearchParams({
-        frames: JSON.stringify(frames),
+        framesKey: "scrollcraft_desktop_frames",
         frameCount: String(frames.length),
         fps: "24",
         prompt: STYLES.find(s => s.id === selectedStyle)?.label ?? selectedStyle,
@@ -98,8 +102,10 @@ function CreatePageInner() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Extraction failed");
       setProgress(100);
+      sessionStorage.setItem("scrollcraft_desktop_frames", JSON.stringify(data.frames));
+
       const params = new URLSearchParams({
-        frames: JSON.stringify(data.frames),
+        framesKey: "scrollcraft_desktop_frames",
         frameCount: String(data.frameCount),
         fps: "24",
         prompt: "Video upload",

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -58,14 +58,26 @@ function EditorInner() {
   const searchParams = useSearchParams();
   const previewScrollRef = useRef<HTMLDivElement>(null);
 
-  // Derive initial frame state from URL params at render time (no setState-in-effect)
-  const framesParam = searchParams.get("frames");
+  // Derive initial frame state — frames are now stored in sessionStorage (never in the URL).
+  // Legacy ?frames= param is still accepted for backward compatibility with any bookmarked URLs.
+  const framesKey = searchParams.get("framesKey");
+  const framesParam = searchParams.get("frames"); // legacy
   const countParam = searchParams.get("frameCount");
   const fpsParam = searchParams.get("fps");
 
   const parsedFrames: string[] | null = (() => {
-    if (!framesParam) return null;
-    try { return JSON.parse(framesParam); } catch { return null; }
+    // New path: read from sessionStorage via key
+    if (framesKey) {
+      try {
+        const stored = sessionStorage.getItem(framesKey);
+        if (stored) return JSON.parse(stored) as string[];
+      } catch { /* sessionStorage unavailable or corrupt — fall through to demo */ }
+    }
+    // Legacy path: frames were small enough to be in the URL (or direct navigation in tests)
+    if (framesParam) {
+      try { return JSON.parse(framesParam) as string[]; } catch { return null; }
+    }
+    return null;
   })();
 
   const DEMO_COUNT = 120;


### PR DESCRIPTION
## Problem
Passing 120 base64 canvas frames (~12–16 MB) as `?frames=` in the URL caused silent truncation (browsers cap URLs at ~2 MB / 64 KB) and `414 URI Too Long` errors. The truncated JSON crashed `JSON.parse`, silently falling back to demo frames — making local generation completely non-functional.

## Fix
- **`create/page.tsx`**: store desktop frames in `sessionStorage` under `scrollcraft_desktop_frames` before routing; pass only `?framesKey=scrollcraft_desktop_frames` in the URL. Same pattern as mobile frames already used.
- **`editor/page.tsx`**: read frames from `sessionStorage` via `framesKey` first; legacy `?frames=` param still works for backward compat; falls back to demo if neither is present.

## Verification
- ✅ `npm run build` passes
- ✅ `npx tsc --noEmit` clean

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)