### PR TITLE
fix(#117): multiply annual price by 12 in create-order

### DIFF
--- a/src/app/api/payments/create-order/route.ts
+++ b/src/app/api/payments/create-order/route.ts
@@ -47,7 +47,8 @@ export async function POST(req: NextRequest) {
     const prices = PLAN_PRICES[plan];
     if (!prices) return NextResponse.json({ error: "Unknown plan" }, { status: 400 });
 
-    let baseAmount = billing === "annual" ? prices.annual : prices.monthly;
+    // Annual price is stored as the discounted per-month rate — multiply by 12 for the actual charge.
+    let baseAmount = billing === "annual" ? prices.annual * 12 : prices.monthly;
     let discountPct = 0;
     let validPromo: string | null = null;
 


### PR DESCRIPTION
## Problem
`PLAN_PRICES` stores the discounted **per-month** rate for annual plans (e.g. Pro annual = ₹3,999/mo). The checkout never multiplied by 12, so users were charged ₹3,999 instead of ₹47,988 for a full year — a ~92% revenue loss on every annual sale.

## Fix
One-line change in `create-order/route.ts`:
\`\`\`ts
// before
let baseAmount = billing === "annual" ? prices.annual : prices.monthly;
// after
let baseAmount = billing === "annual" ? prices.annual * 12 : prices.monthly;
\`\`\`

Promo code discounts still apply correctly on top of the corrected total.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)