### PR TITLE
fix(#110): guard buffer lengths before timingSafeEqual in Razorpay routes

### DIFF
--- a/src/app/api/payments/verify/route.ts
+++ b/src/app/api/payments/verify/route.ts
@@ -33,7 +33,9 @@ export async function POST(req: NextRequest) {
       .update(`${orderId}|${paymentId}`)
       .digest("hex");
 
-    if (!crypto.timingSafeEqual(Buffer.from(expectedSignature), Buffer.from(signature))) {
+    const expectedBuf = Buffer.from(expectedSignature, "hex");
+    const actualBuf = Buffer.from(typeof signature === "string" ? signature : "", "hex");
+    if (expectedBuf.length !== actualBuf.length || !crypto.timingSafeEqual(expectedBuf, actualBuf)) {
       return NextResponse.json({ error: "Invalid payment signature" }, { status: 400 });
     }
 

--- a/src/app/api/webhooks/razorpay/route.ts
+++ b/src/app/api/webhooks/razorpay/route.ts
@@ -20,7 +20,9 @@ export async function POST(req: NextRequest) {
     .update(rawBody)
     .digest("hex");
 
-  if (!crypto.timingSafeEqual(Buffer.from(expectedSignature), Buffer.from(signature))) {
+  const expectedBuf = Buffer.from(expectedSignature, "hex");
+  const actualBuf = Buffer.from(signature, "hex");
+  if (expectedBuf.length !== actualBuf.length || !crypto.timingSafeEqual(expectedBuf, actualBuf)) {
     return NextResponse.json({ error: "Invalid webhook signature" }, { status: 400 });
   }
 


### PR DESCRIPTION
## Problem
`crypto.timingSafeEqual()` requires both buffers to be exactly the same length — if a client sends a signature of a different length (empty string, truncated, malformed), it throws a `RangeError` that propagates as an unhandled 500 instead of a proper 400.

## Fix
Added `expectedBuf.length !== actualBuf.length` guard before `timingSafeEqual` in both `payments/verify/route.ts` and `webhooks/razorpay/route.ts`. Differing lengths now cleanly return `400 Invalid signature`.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)