### PR TITLE
fix(#122): require auth on extract-frames API route

### DIFF
--- a/src/app/api/extract-frames/route.ts
+++ b/src/app/api/extract-frames/route.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { execFile as _execFile } from "child_process";
 import { promisify } from "util";
 import { readdir, readFile } from "fs/promises";
+import { auth } from "@/auth";
 import { rateLimit, getClientIp } from "@/lib/rateLimit";
 import { put } from "@vercel/blob";
 
@@ -22,6 +23,11 @@ async function ffmpegAvailable(): Promise<boolean> {
 }
 
 export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const rl = await rateLimit(getClientIp(req), { limit: 10, windowMs: 60_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests. Try again in a minute." }, {


### PR DESCRIPTION
## Problem
The `/api/extract-frames` ffmpeg endpoint had no authentication check. Any anonymous request could trigger server-side video download + ffmpeg processing, enabling CPU/disk exhaustion DoS attacks.

## Fix
Added `auth()` session check at the top of the route handler — returns `401` before any rate limiting or processing for unauthenticated requests.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)