### PR TITLE
fix(#116): wire dashboard plan, credits, and exports to real DB values

### DIFF
--- a/src/app/api/user/stats/route.ts
+++ b/src/app/api/user/stats/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/lib/db";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const exportCount = await db.exportPurchase.count({
+    where: { userId: session.user.id, status: "PAID" },
+  });
+
+  return NextResponse.json({ exportCount });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -21,11 +21,12 @@ interface Site {
   updatedAt: string;
 }
 
-const PLANS: Record<string, { label: string; credits: number; color: string }> = {
-  free: { label: "Free Trial", credits: 100, color: "text-muted-foreground" },
-  basic: { label: "Basic", credits: 1500, color: "text-blue-400" },
-  pro: { label: "Pro", credits: 6000, color: "text-primary" },
-  premium: { label: "Premium", credits: 25000, color: "text-amber-400" },
+const PLANS: Record<string, { label: string; maxCredits: number; color: string }> = {
+  FREE:       { label: "Free Trial", maxCredits: 100,   color: "text-muted-foreground" },
+  BASIC:      { label: "Basic",      maxCredits: 1500,  color: "text-blue-400" },
+  BASIC_PLUS: { label: "Basic Plus", maxCredits: 3000,  color: "text-cyan-400" },
+  PRO:        { label: "Pro",        maxCredits: 6000,  color: "text-primary" },
+  PREMIUM:    { label: "Premium",    maxCredits: 25000, color: "text-amber-400" },
 };
 
 export default function DashboardPage() {
@@ -35,9 +36,13 @@ export default function DashboardPage() {
   const [sites, setSites] = useState<Site[]>([]);
   const [sitesLoading, setSitesLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
-  const plan = PLANS.free;
-  const usedCredits = 34;
-  const totalCredits = plan.credits;
+  const [exportCount, setExportCount] = useState(0);
+  const userPlanKey = (session?.user?.plan ?? "FREE") as string;
+  const plan = PLANS[userPlanKey] ?? PLANS.FREE;
+  const totalCredits = plan.maxCredits;
+  // credits in the DB is the *remaining* balance; used = max - remaining
+  const remainingCredits = session?.user?.credits ?? 0;
+  const usedCredits = Math.max(0, totalCredits - remainingCredits);
 
   useEffect(() => {
     if (status === "unauthenticated") router.push("/auth/signin");
@@ -45,10 +50,13 @@ export default function DashboardPage() {
 
   useEffect(() => {
     if (status !== "authenticated") return;
-    fetch("/api/sites")
-      .then(r => r.json())
-      .then(data => { if (data.sites) setSites(data.sites); })
-      .catch(() => toast.error("Failed to load sites"))
+    Promise.all([
+      fetch("/api/sites").then(r => r.json()),
+      fetch("/api/user/stats").then(r => r.json()).catch(() => ({})),
+    ]).then(([sitesData, statsData]) => {
+      if (sitesData.sites) setSites(sitesData.sites);
+      if (typeof statsData.exportCount === "number") setExportCount(statsData.exportCount);
+    }).catch(() => toast.error("Failed to load dashboard"))
       .finally(() => setSitesLoading(false));
   }, [status]);
 
@@ -152,7 +160,7 @@ export default function DashboardPage() {
               {user?.name?.split(" ")[0] || "there"} 👋
             </h1>
             <div className="flex items-center gap-3">
-              <Badge className="bg-primary/15 text-primary border-primary/30 px-3">
+              <Badge className={`bg-primary/15 border-primary/30 px-3 ${plan.color}`}>
                 {plan.label}
               </Badge>
               <Link href="/pricing">
@@ -167,10 +175,10 @@ export default function DashboardPage() {
           <div className="p-6 rounded-2xl border border-white/8 bg-card space-y-3">
             <div className="flex items-center justify-between">
               <p className="text-sm font-medium">AI Credits</p>
-              <span className="text-xs text-muted-foreground">{usedCredits} / {totalCredits}</span>
+              <span className="text-xs text-muted-foreground">{usedCredits.toLocaleString()} / {totalCredits.toLocaleString()}</span>
             </div>
-            <Progress value={(usedCredits / totalCredits) * 100} className="h-1.5" />
-            <p className="text-xs text-muted-foreground">{totalCredits - usedCredits} credits remaining this month</p>
+            <Progress value={totalCredits > 0 ? (usedCredits / totalCredits) * 100 : 0} className="h-1.5" />
+            <p className="text-xs text-muted-foreground">{remainingCredits.toLocaleString()} credits remaining this month</p>
             <Link href="/pricing">
               <Button size="sm" className="w-full bg-primary/15 hover:bg-primary/25 text-primary border-0 text-xs h-7 mt-1">
                 Get more credits
@@ -184,7 +192,7 @@ export default function DashboardPage() {
           {[
             { label: "Sites created", value: sites.length, icon: Globe },
             { label: "Total frames", value: sites.reduce((a, s) => a + s.frameCount, 0), icon: ExternalLink },
-            { label: "Exports", value: 0, icon: Download },
+            { label: "Exports", value: exportCount, icon: Download },
             { label: "Credits used", value: usedCredits, icon: Zap },
           ].map(stat => (
             <div key={stat.label} className="p-5 rounded-2xl border border-white/8 bg-card">

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -27,9 +27,12 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         session.user.id = user.id;
         const fresh = await db.user.findUnique({
           where: { id: user.id },
-          select: { plan: true },
+          select: { plan: true, credits: true },
         });
-        if (fresh) session.user.plan = fresh.plan;
+        if (fresh) {
+          session.user.plan = fresh.plan;
+          session.user.credits = fresh.credits;
+        }
       }
       return session;
     },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -5,6 +5,7 @@ declare module "next-auth" {
     user: {
       id: string;
       plan?: string;
+      credits?: number;
     } & DefaultSession["user"];
   }
 }


### PR DESCRIPTION
## Problem
The dashboard hardcoded `plan = PLANS.free`, `usedCredits = 34`, and `Exports = 0` — regardless of the user's actual subscription or credit balance.

## Fix
- **`src/auth.ts`** — session callback now selects both `plan` and `credits` from the DB.
- **`src/types/next-auth.d.ts`** — added `credits?: number` to the Session type.
- **`dashboard/page.tsx`** — reads `session.user.plan` and `session.user.credits`; derives used/remaining credits correctly; plan badge colour reflects tier.
- **`src/app/api/user/stats/route.ts`** — new endpoint returning `exportCount` (paid `ExportPurchase` records). Dashboard fetches and displays it.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)