### PR TITLE
fix(#121, #118): middleware route guards + pricing sign-in redirect

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Check, Minus, Sparkles, Zap, Loader2, Tag, X } from "lucide-react";
@@ -191,6 +193,8 @@ function loadRazorpayScript(): Promise<void> {
 }
 
 export default function PricingPage() {
+  const router = useRouter();
+  const { status } = useSession();
   const [annual, setAnnual] = useState(true);
   const [openFaq, setOpenFaq] = useState<number | null>(null);
   const [checkingOut, setCheckingOut] = useState<string | null>(null);
@@ -219,6 +223,10 @@ export default function PricingPage() {
   };
 
   const handleCheckout = async (planName: string) => {
+    if (status !== "authenticated") {
+      router.push("/auth/signin?callbackUrl=/pricing");
+      return;
+    }
     setCheckingOut(planName);
     try {
       const res = await fetch("/api/payments/create-order", {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,19 @@
+import { auth } from "@/auth";
+import { NextResponse } from "next/server";
+
+const PROTECTED_PATHS = ["/create", "/editor", "/dashboard"];
+
+export default auth((req) => {
+  const { pathname } = req.nextUrl;
+  const isProtected = PROTECTED_PATHS.some(p => pathname === p || pathname.startsWith(p + "/"));
+
+  if (isProtected && !req.auth) {
+    const signIn = new URL("/auth/signin", req.url);
+    signIn.searchParams.set("callbackUrl", req.nextUrl.pathname + req.nextUrl.search);
+    return NextResponse.redirect(signIn);
+  }
+});
+
+export const config = {
+  matcher: ["/create", "/editor", "/dashboard/:path*"],
+};


### PR DESCRIPTION
## Changes

**#121 — Middleware route guards**
New `src/middleware.ts` using NextAuth v5's `auth()`. Unauthenticated requests to `/create`, `/editor`, or `/dashboard` are redirected to `/auth/signin?callbackUrl=<path>` before the page loads — no more losing work to a 401 mid-session.

**#118 — Pricing checkout redirect**
`handleCheckout` now checks `useSession()` status first. If the user isn't signed in, it redirects to `/auth/signin?callbackUrl=/pricing` immediately, so the flow becomes: sign in → return to pricing → checkout.

Closes #121
Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)