### PR TITLE
fix(#108,#109,#111,#112,#113): scroll, canvas, audio, and export fixes

### DIFF
--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -189,6 +189,7 @@ export async function POST(req: NextRequest) {
   </style>
   ${safeCustomCss ? `<style>\n${safeCustomCss}\n  </style>` : ""}
   ${safeCustomHead || ""}
+  <script src="https://cdn.jsdelivr.net/npm/@studio-freight/lenis@1.0.42/dist/lenis.min.js"></script>
 </head>
 <body>
   <canvas id="scroll-canvas"></canvas>
@@ -219,39 +220,58 @@ export async function POST(req: NextRequest) {
 
       function getImages() { return (isMobile && mobileImages) ? mobileImages : desktopImages; }
 
+      var dpr = Math.min(window.devicePixelRatio || 1, 2);
+
       function resize() {
-        canvas.width = window.innerWidth;
-        canvas.height = window.innerHeight;
+        var cssW = window.innerWidth, cssH = window.innerHeight;
+        canvas.width = cssW * dpr;
+        canvas.height = cssH * dpr;
+        canvas.style.width = cssW + 'px';
+        canvas.style.height = cssH + 'px';
+        ctx.scale(dpr, dpr);
         drawFrame(currentFrame);
       }
 
       function drawFrame(index) {
-        const images = getImages();
-        const img = images[index];
+        var images = getImages();
+        var img = images[index];
         if (!img || !img.complete) return;
-        const scale = Math.max(canvas.width / img.naturalWidth, canvas.height / img.naturalHeight);
-        const w = img.naturalWidth * scale;
-        const h = img.naturalHeight * scale;
-        ctx.drawImage(img, (canvas.width - w) / 2, (canvas.height - h) / 2, w, h);
+        var cssW = window.innerWidth, cssH = window.innerHeight;
+        var scale = Math.max(cssW / img.naturalWidth, cssH / img.naturalHeight);
+        var w = img.naturalWidth * scale, h = img.naturalHeight * scale;
+        ctx.clearRect(0, 0, cssW, cssH);
+        ctx.drawImage(img, (cssW - w) / 2, (cssH - h) / 2, w, h);
       }
 
-      function preloadSet(count, folder, target) {
-        for (var i = 0; i < count; i++) {
-          (function(idx) {
-            var img = new Image();
-            img.src = folder + '/frame_' + String(idx).padStart(4, '0') + '.jpg';
-            img.onload = function() {
-              target[idx] = img;
-              if (idx === 0 && (!isMobile || target === mobileImages)) drawFrame(0);
-            };
+      // Progressive preload: load keyframes first, then fill in the rest.
+      // This shows the first frame immediately and avoids 120 concurrent requests.
+      function preloadSet(count, folder, target, isPrimary) {
+        var STEP = 5;
+        var keyframes = [];
+        for (var i = 0; i < count; i += STEP) keyframes.push(i);
+        var loaded = 0;
+
+        function loadFrame(idx) {
+          var img = new Image();
+          img.src = folder + '/frame_' + String(idx).padStart(4, '0') + '.jpg';
+          img.onload = function() {
             target[idx] = img;
-          })(i);
+            if (idx === 0 && isPrimary) drawFrame(0);
+            loaded++;
+            if (loaded === keyframes.length) {
+              // All keyframes done — load remaining frames
+              for (var j = 0; j < count; j++) {
+                if (j % STEP !== 0) loadFrame(j);
+              }
+            }
+          };
         }
+        keyframes.forEach(loadFrame);
       }
 
       function preload() {
-        preloadSet(desktopCount, 'frames', desktopImages);
-        if (hasMobile) preloadSet(mobileCount, 'frames-mobile', mobileImages);
+        preloadSet(desktopCount, 'frames', desktopImages, !isMobile);
+        if (hasMobile) preloadSet(mobileCount, 'frames-mobile', mobileImages, isMobile);
       }
 
       if (hasMobile) {
@@ -279,7 +299,15 @@ export async function POST(req: NextRequest) {
         if (hint) hint.style.opacity = scrollTop > 100 ? '0' : '1';
       }
 
-      window.addEventListener('scroll', onScroll, { passive: true });
+      // Lenis smooth scroll — falls back to native scroll if the CDN fails to load
+      if (typeof window.Lenis !== 'undefined') {
+        var lenis = new window.Lenis({ lerp: 0.08, smoothWheel: true });
+        lenis.on('scroll', onScroll);
+        function raf(time) { lenis.raf(time); requestAnimationFrame(raf); }
+        requestAnimationFrame(raf);
+      } else {
+        window.addEventListener('scroll', onScroll, { passive: true });
+      }
       window.addEventListener('resize', resize);
       resize();
       preload();

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -470,13 +470,13 @@ function EditorInner() {
               <div
                 ref={previewScrollRef}
                 style={{
-                  height: totalScrollHeight,
-                  overflowY: "scroll",
+                  // Desktop: fill parent absolutely and scroll the *content* inside, not the container itself.
+                  // Mobile/tablet: fixed viewport size with overflow-y:scroll so the inner content scrolls.
                   ...(viewportMode === "mobile"
-                    ? { width: 390, maxHeight: "85vh", position: "relative", borderRadius: 24, border: "2px solid rgba(255,255,255,0.1)", overflow: "hidden" }
+                    ? { width: 390, height: "85vh", position: "relative", borderRadius: 24, border: "2px solid rgba(255,255,255,0.1)", overflowY: "scroll" }
                     : viewportMode === "tablet"
-                    ? { width: 768, maxHeight: "85vh", position: "relative", borderRadius: 16, border: "2px solid rgba(255,255,255,0.1)", overflow: "hidden" }
-                    : { position: "absolute", inset: 0 }),
+                    ? { width: 768, height: "85vh", position: "relative", borderRadius: 16, border: "2px solid rgba(255,255,255,0.1)", overflowY: "scroll" }
+                    : { position: "absolute", inset: 0, overflowY: "scroll" }),
                 }}
               >
                 <ScrollEngine

--- a/src/components/ScrollEngine.tsx
+++ b/src/components/ScrollEngine.tsx
@@ -118,8 +118,15 @@ export default function ScrollEngine({ frames, mobileFrames, totalScrollHeight =
     if (!canvas) return;
 
     const resize = () => {
-      canvas.width = canvas.offsetWidth || window.innerWidth;
-      canvas.height = canvas.offsetHeight || window.innerHeight;
+      const dpr = Math.min(window.devicePixelRatio || 1, 2); // cap at 2× — 3× gains nothing visible
+      const cssW = canvas.offsetWidth || window.innerWidth;
+      const cssH = canvas.offsetHeight || window.innerHeight;
+      canvas.width = cssW * dpr;
+      canvas.height = cssH * dpr;
+      canvas.style.width = cssW + "px";
+      canvas.style.height = cssH + "px";
+      const ctx = canvas.getContext("2d");
+      if (ctx) ctx.scale(dpr, dpr);
       drawFrame(currentFrameRef.current);
     };
 

--- a/src/lib/useScrollAudio.ts
+++ b/src/lib/useScrollAudio.ts
@@ -45,7 +45,7 @@ export function useScrollAudio({ audioSrc, scrollEl, muted = false }: ScrollAudi
       audio.src = "";
       audioRef.current = null;
     };
-  }, [audioSrc, muted]);
+  }, [audioSrc]); // intentionally excludes `muted` — toggling mute is handled by the effect below
 
   // Keep muted in sync without recreating
   useEffect(() => {


### PR DESCRIPTION
## Changes (5 issues, 1 PR)

**#108 — Editor preview scroll broken**
The preview container was set to `height: totalScrollHeight` (5000px+), which stretched the element to match its content — no overflow, no scrolling. Fixed by using `overflow-y: scroll` on all viewport modes and `position: absolute; inset: 0` on desktop.

**#109 — Audio restarts on mute/unmute**
`useScrollAudio` had `muted` in the init effect's dependency array, causing the entire `Audio` element to be destroyed and recreated on every toggle. Removed `muted` from that array — toggling is handled by the dedicated secondary effect that only calls `audio.muted = muted`.

**#113 — Blurry canvas on Retina screens**
`ScrollEngine.tsx` was setting `canvas.width = offsetWidth` (1× pixels). Fixed: read `devicePixelRatio` (capped at 2×), set canvas dimensions to `cssW * dpr`, apply `ctx.scale(dpr, dpr)`, keep CSS size at `cssW/cssH`.

**#111 — 120 concurrent HTTP requests on export page load**
Replaced the all-at-once `preloadSet` loop with a keyframe-first progressive loader: load every 5th frame first (~24 requests), show frame 0 immediately, then fill remaining frames in the background.

**#112 — No smooth scrolling in exported sites**
Injected Lenis 1.0.42 (CDN) into the exported `index.html` head and wired scroll events through `lenis.on('scroll', onScroll)`. Falls back to `window.addEventListener('scroll', ...)` if the CDN script fails.

## Verification
- ✅ `npm run build`
- ✅ `npx tsc --noEmit`
- ✅ `npm test` (8/8)

Closes #108
Closes #109
Closes #111
Closes #112
Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)