### PR TITLE
fix(vercel): split NextAuth config for Edge Runtime compatibility

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,0 +1,21 @@
+// Lightweight auth config — no Prisma, no Node.js-only modules.
+// Used by middleware (Edge Runtime) and merged into the full auth.ts config.
+import type { NextAuthConfig } from "next-auth";
+import GitHub from "next-auth/providers/github";
+import Google from "next-auth/providers/google";
+
+export default {
+  providers: [
+    GitHub({
+      clientId: process.env.AUTH_GITHUB_ID,
+      clientSecret: process.env.AUTH_GITHUB_SECRET,
+    }),
+    Google({
+      clientId: process.env.AUTH_GOOGLE_ID,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET,
+    }),
+  ],
+  pages: {
+    signIn: "/auth/signin",
+  },
+} satisfies NextAuthConfig;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,25 +1,11 @@
 import NextAuth from "next-auth";
-import GitHub from "next-auth/providers/github";
-import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { db } from "@/lib/db";
-import { env } from "@/lib/env";
+import authConfig from "@/auth.config";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
+  ...authConfig,
   adapter: PrismaAdapter(db),
-  providers: [
-    GitHub({
-      clientId: env.AUTH_GITHUB_ID,
-      clientSecret: env.AUTH_GITHUB_SECRET,
-    }),
-    Google({
-      clientId: env.AUTH_GOOGLE_ID,
-      clientSecret: env.AUTH_GOOGLE_SECRET,
-    }),
-  ],
-  pages: {
-    signIn: "/auth/signin",
-  },
   session: { strategy: "database" },
   callbacks: {
     async session({ session, user }) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,15 +1,25 @@
-import { auth } from "@/auth";
+// Edge-compatible middleware — uses the lightweight auth config (no Prisma/Node modules).
+// The full auth.ts (with Prisma adapter) is only used in API routes / Server Components.
+import NextAuth from "next-auth";
+import authConfig from "@/auth.config";
 import { NextResponse } from "next/server";
+
+const { auth } = NextAuth(authConfig);
 
 const PROTECTED_PATHS = ["/create", "/editor", "/dashboard"];
 
 export default auth((req) => {
   const { pathname } = req.nextUrl;
-  const isProtected = PROTECTED_PATHS.some(p => pathname === p || pathname.startsWith(p + "/"));
+  const isProtected = PROTECTED_PATHS.some(
+    (p) => pathname === p || pathname.startsWith(p + "/")
+  );
 
   if (isProtected && !req.auth) {
     const signIn = new URL("/auth/signin", req.url);
-    signIn.searchParams.set("callbackUrl", req.nextUrl.pathname + req.nextUrl.search);
+    signIn.searchParams.set(
+      "callbackUrl",
+      req.nextUrl.pathname + req.nextUrl.search
+    );
     return NextResponse.redirect(signIn);
   }
 });


### PR DESCRIPTION
## Summary
- Created `src/auth.config.ts` — lightweight edge-safe config with only providers and pages (no Prisma, no Node.js modules)
- Updated `src/middleware.ts` to use `NextAuth(authConfig)` directly instead of importing from `@/auth.ts`
- Updated `src/auth.ts` to spread `...authConfig` instead of redeclaring providers

## Root Cause
Vercel was failing with:
```
The Edge Function "_middleware" is referencing unsupported modules:
node:util/types, node:path, node:module, node:process, node:fs, node:os, node:crypto
```
This was caused by `middleware.ts` importing `auth` from `@/auth.ts`, which in turn imports `PrismaAdapter` and `@prisma/adapter-pg` — both require Node.js runtime.

## Fix
NextAuth v5 split config pattern: edge-safe config used by middleware, full config (with Prisma adapter) used only in API routes and Server Components.

## Test plan
- [x] `npm run build` passes locally with no Edge Function warnings
- [x] Protected routes (`/create`, `/editor`, `/dashboard`) still redirect unauthenticated users
- [x] Auth still works normally (session callbacks load plan/credits from DB)

Fixes Vercel deployment failures on every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)