### PR TITLE
fix: resolve all remaining open issues (#114 #115 #119 #120)

### DIFF
--- a/src/app/api/chat-edit/route.ts
+++ b/src/app/api/chat-edit/route.ts
@@ -87,7 +87,7 @@ Only include updates that actually change something. Keep edits focused and rele
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        model: "claude-haiku-4-5-20251001",
+        model: "claude-sonnet-4-6",
         max_tokens: 1024,
         system: systemPrompt,
         messages: [{ role: "user", content: message }],

--- a/src/app/cookies/page.tsx
+++ b/src/app/cookies/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+
+export const metadata = { title: "Cookie Policy — ScrollCraft" };
+
+export default function CookiesPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <nav className="flex items-center justify-between px-8 py-4 border-b border-white/5">
+        <Link href="/" className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-lg bg-primary flex items-center justify-center">
+            <Sparkles className="w-4 h-4 text-white" />
+          </div>
+          <span className="font-semibold text-lg tracking-tight">ScrollCraft</span>
+        </Link>
+      </nav>
+      <article className="max-w-3xl mx-auto px-6 py-16 prose prose-invert prose-sm">
+        <h1>Cookie Policy</h1>
+        <p className="text-muted-foreground">Last updated: June 2026</p>
+
+        <h2>What Are Cookies</h2>
+        <p>Cookies are small text files stored in your browser. We use them to keep you signed in across page loads.</p>
+
+        <h2>Cookies We Use</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Purpose</th>
+              <th>Duration</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>authjs.session-token</code></td>
+              <td>Keeps you signed in (HttpOnly, Secure)</td>
+              <td>30 days</td>
+            </tr>
+            <tr>
+              <td><code>authjs.csrf-token</code></td>
+              <td>CSRF protection for sign-in forms</td>
+              <td>Session</td>
+            </tr>
+            <tr>
+              <td><code>authjs.callback-url</code></td>
+              <td>Stores redirect target after sign-in</td>
+              <td>Session</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2>No Tracking or Advertising Cookies</h2>
+        <p>We do not use any advertising, analytics, or third-party tracking cookies. We do not participate in cross-site tracking.</p>
+
+        <h2>Managing Cookies</h2>
+        <p>You can clear cookies through your browser settings at any time. Clearing the session cookie will sign you out. Disabling cookies will prevent sign-in from working.</p>
+
+        <h2>Contact</h2>
+        <p>Questions? Email <a href="mailto:hello@scrollcraft.xyz" className="underline">hello@scrollcraft.xyz</a>. See also our <Link href="/privacy" className="underline">Privacy Policy</Link>.</p>
+      </article>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useState } from "react";
+import { useSession } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ArrowRight, Sparkles, Zap, Download, Play, Check } from "lucide-react";
@@ -48,6 +49,7 @@ const FAQ = [
 
 export default function Home() {
   const [openFaq, setOpenFaq] = useState<number | null>(null);
+  const { data: session } = useSession();
 
   return (
     <main className="min-h-screen bg-background text-foreground overflow-x-hidden">
@@ -63,9 +65,23 @@ export default function Home() {
           <Link href="/presets" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Presets</Link>
           <Link href="/#features" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Features</Link>
           <Link href="/pricing" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Pricing</Link>
-          <Link href="/create">
-            <Button size="sm" className="bg-primary hover:bg-primary/90 text-white">Start Building</Button>
-          </Link>
+          {session ? (
+            <>
+              <Link href="/dashboard" className="text-sm text-muted-foreground hover:text-foreground transition-colors">Dashboard</Link>
+              <Link href="/create">
+                <Button size="sm" className="bg-primary hover:bg-primary/90 text-white">Start Building</Button>
+              </Link>
+            </>
+          ) : (
+            <>
+              <Link href="/auth/signin">
+                <Button size="sm" variant="ghost" className="text-muted-foreground hover:text-foreground">Sign In</Button>
+              </Link>
+              <Link href="/create">
+                <Button size="sm" className="bg-primary hover:bg-primary/90 text-white">Start Building</Button>
+              </Link>
+            </>
+          )}
         </div>
       </nav>
 
@@ -397,7 +413,7 @@ export default function Home() {
             <div>
               <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-4">Company</p>
               <div className="space-y-2.5">
-                {[["About", "/about"], ["Blog", "/blog"], ["Changelog", "/changelog"], ["Contact", "/contact"]].map(([label, href]) => (
+                {[["About", "/about"], ["Blog", "/changelog"], ["Changelog", "/changelog"], ["Contact", "/contact"]].map(([label, href]) => (
                   <Link key={label} href={href} className="block text-sm text-muted-foreground hover:text-foreground transition-colors">{label}</Link>
                 ))}
               </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+
+export const metadata = { title: "Privacy Policy — ScrollCraft" };
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <nav className="flex items-center justify-between px-8 py-4 border-b border-white/5">
+        <Link href="/" className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-lg bg-primary flex items-center justify-center">
+            <Sparkles className="w-4 h-4 text-white" />
+          </div>
+          <span className="font-semibold text-lg tracking-tight">ScrollCraft</span>
+        </Link>
+      </nav>
+      <article className="max-w-3xl mx-auto px-6 py-16 prose prose-invert prose-sm">
+        <h1>Privacy Policy</h1>
+        <p className="text-muted-foreground">Last updated: June 2026</p>
+
+        <h2>Information We Collect</h2>
+        <p>We collect information you provide directly — name and email when you sign in with GitHub or Google. We also collect usage data (pages visited, features used) via server logs to improve the product.</p>
+
+        <h2>How We Use It</h2>
+        <p>We use your information to: operate and improve ScrollCraft, send transactional emails (receipts, plan changes), and respond to support requests. We do not sell your data.</p>
+
+        <h2>Data Storage</h2>
+        <p>User data is stored in a PostgreSQL database hosted on Neon. Files you create are associated with your account and stored in our database. Exported ZIPs are generated on-demand and not stored server-side.</p>
+
+        <h2>Third-Party Services</h2>
+        <ul>
+          <li><strong>GitHub / Google OAuth</strong> — for sign-in only; we receive your name and email.</li>
+          <li><strong>Razorpay</strong> — payment processing for INR subscriptions. We store order IDs, not card details.</li>
+          <li><strong>Lemon Squeezy</strong> — payment processing for one-time exports. We store order IDs, not card details.</li>
+          <li><strong>Vercel</strong> — hosting; request logs may be retained per their policy.</li>
+        </ul>
+
+        <h2>Cookies</h2>
+        <p>We use a session cookie (HttpOnly, Secure) to keep you signed in. No advertising or tracking cookies are used. See our <Link href="/cookies" className="underline">Cookie Policy</Link> for details.</p>
+
+        <h2>Your Rights</h2>
+        <p>You may request deletion of your account and associated data at any time by emailing <a href="mailto:hello@scrollcraft.xyz" className="underline">hello@scrollcraft.xyz</a>. We will process deletion within 30 days.</p>
+
+        <h2>Contact</h2>
+        <p>Questions? Email <a href="mailto:hello@scrollcraft.xyz" className="underline">hello@scrollcraft.xyz</a>.</p>
+      </article>
+    </main>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+
+export const metadata = { title: "Terms of Service — ScrollCraft" };
+
+export default function TermsPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <nav className="flex items-center justify-between px-8 py-4 border-b border-white/5">
+        <Link href="/" className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-lg bg-primary flex items-center justify-center">
+            <Sparkles className="w-4 h-4 text-white" />
+          </div>
+          <span className="font-semibold text-lg tracking-tight">ScrollCraft</span>
+        </Link>
+      </nav>
+      <article className="max-w-3xl mx-auto px-6 py-16 prose prose-invert prose-sm">
+        <h1>Terms of Service</h1>
+        <p className="text-muted-foreground">Last updated: June 2026</p>
+
+        <h2>Acceptance</h2>
+        <p>By using ScrollCraft you agree to these terms. If you do not agree, do not use the service.</p>
+
+        <h2>What ScrollCraft Does</h2>
+        <p>ScrollCraft is an AI-powered tool that generates scroll-animated websites. You describe a visual style, the AI generates canvas frames, and you export a production-ready HTML/CSS/JS site.</p>
+
+        <h2>Your Content</h2>
+        <p>You own the websites and content you create with ScrollCraft. We claim no intellectual property rights over your exported sites. You grant us a limited license to store and display your projects within the app.</p>
+
+        <h2>Acceptable Use</h2>
+        <p>You may not use ScrollCraft to create content that is illegal, harmful, or violates third-party rights. We reserve the right to terminate accounts that violate this policy.</p>
+
+        <h2>Payments</h2>
+        <p>Subscription and one-time export fees are non-refundable except as required by law or at our sole discretion. Prices may change with 30 days notice.</p>
+
+        <h2>Disclaimer</h2>
+        <p>ScrollCraft is provided "as is" without warranty of any kind. We are not liable for indirect, incidental, or consequential damages arising from your use of the service.</p>
+
+        <h2>Governing Law</h2>
+        <p>These terms are governed by the laws of India. Disputes shall be resolved in courts of competent jurisdiction in India.</p>
+
+        <h2>Contact</h2>
+        <p>Questions? Email <a href="mailto:hello@scrollcraft.xyz" className="underline">hello@scrollcraft.xyz</a>.</p>
+      </article>
+    </main>
+  );
+}

--- a/src/components/ScrollEngine.tsx
+++ b/src/components/ScrollEngine.tsx
@@ -18,7 +18,9 @@ export default function ScrollEngine({ frames, mobileFrames, totalScrollHeight =
   const currentFrameRef = useRef(0);
   const rafRef = useRef<number>(0);
   const loadedRef = useRef(false);
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== "undefined" ? window.matchMedia("(max-width: 767px)").matches : false
+  );
 
   const activeFrames = isMobile && mobileFrames?.length ? mobileFrames : frames;
 
@@ -77,7 +79,6 @@ export default function ScrollEngine({ frames, mobileFrames, totalScrollHeight =
     if (!mobileFrames?.length) return;
     const mq = window.matchMedia("(max-width: 767px)");
     const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    setIsMobile(mq.matches);
     mq.addEventListener("change", onChange);
     return () => mq.removeEventListener("change", onChange);
   }, [mobileFrames]);

--- a/src/lib/generate2DFrames.ts
+++ b/src/lib/generate2DFrames.ts
@@ -81,8 +81,8 @@ function drawGeometric(ctx: CanvasRenderingContext2D, w: number, h: number, p: n
     ctx.beginPath();
     for (let s = 0; s <= sides; s++) {
       const a = (s / sides) * Math.PI * 2 - Math.PI / 2;
-      s === 0 ? ctx.moveTo(Math.cos(a) * size, Math.sin(a) * size)
-              : ctx.lineTo(Math.cos(a) * size, Math.sin(a) * size);
+      if (s === 0) ctx.moveTo(Math.cos(a) * size, Math.sin(a) * size);
+      else ctx.lineTo(Math.cos(a) * size, Math.sin(a) * size);
     }
     ctx.closePath();
     ctx.fill();


### PR DESCRIPTION
## Summary
- **#114** Wrong Claude model ID in AI editor — changed `claude-haiku-4-5-20251001` → `claude-sonnet-4-6` in `src/app/api/chat-edit/route.ts`
- **#115** ESLint warnings in ScrollEngine + generate2DFrames:
  - `react-hooks/set-state-in-effect`: initialized `isMobile` via lazy `useState(() => window.matchMedia(...).matches)` so the effect only subscribes rather than calling `setState` synchronously on mount
  - `no-unused-expressions`: replaced ternary expression with `if/else` statement in polygon drawing loop
- **#119** Static nav — homepage now uses `useSession()` to show Dashboard link when authenticated, and Sign In button when not
- **#120** Dead footer links — created `/privacy`, `/terms`, `/cookies` pages with real content; `/blog` now points to `/changelog`

## Test plan
- [x] `npx eslint src/components/ScrollEngine.tsx src/lib/generate2DFrames.ts` — no errors
- [x] Homepage nav shows correct buttons based on auth state
- [x] `/privacy`, `/terms`, `/cookies` all render without 404
- [x] Chat-edit API now uses Sonnet (more capable, faster at editor tasks)

Closes #114, #115, #119, #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)