### PR TITLE
fix: resolve #138 #139 #140 — IndexedDB frames, canvas div-by-zero, sticky sections

### DIFF
--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -91,13 +91,17 @@ export async function POST(req: NextRequest) {
     const validatedFps = Math.min(Math.max(Number(fps) || 24, 1), 60);
 
     // Generate sections HTML (server-side for XSS safety)
+    // Each section is a tall container; content is sticky so it stays pinned
+    // in the viewport while the background canvas scrubs underneath.
     const sectionsHtml = (sections as Section[]).map((s: Section) => `
-    <section class="scroll-section" style="height:${Number(s.scrollHeight) || 1000}px; position:relative; z-index:10; display:flex; align-items:${safeCss(s.align || "center")}; justify-content:${safeCss(s.justify || "center")};">
-      <div class="section-content" style="text-align:${safeCss(s.textAlign || "center")}; padding:2rem; max-width:800px;">
-        ${s.eyebrow ? `<p class="eyebrow" style="font-size:0.875rem; font-weight:600; letter-spacing:0.1em; text-transform:uppercase; color:${safeCss(s.accentColor || "#a78bfa")}; margin-bottom:0.75rem;">${esc(s.eyebrow)}</p>` : ""}
-        ${s.heading ? `<h2 style="font-size:clamp(2rem,5vw,4rem); font-weight:900; line-height:1; letter-spacing:-0.03em; color:${safeCss(s.headingColor || "#ffffff")}; margin-bottom:1rem;">${esc(s.heading)}</h2>` : ""}
-        ${s.body ? `<p style="font-size:1.125rem; line-height:1.7; color:${safeCss(s.bodyColor || "rgba(255,255,255,0.7)")}; max-width:600px; margin:0 auto 1.5rem;">${esc(s.body)}</p>` : ""}
-        ${s.ctaLabel ? `<a href="${safeHref(s.ctaHref || "#")}" style="display:inline-block; background:${safeCss(s.accentColor || "#7c3aed")}; color:white; padding:0.875rem 2rem; border-radius:0.5rem; font-weight:600; text-decoration:none; font-size:1rem;">${esc(s.ctaLabel)}</a>` : ""}
+    <section class="scroll-section" style="height:${Number(s.scrollHeight) || 1000}px; position:relative; z-index:10;">
+      <div class="section-sticky" style="position:sticky; top:0; height:100vh; display:flex; align-items:${safeCss(s.align || "center")}; justify-content:${safeCss(s.justify || "center")}; overflow:hidden;">
+        <div class="section-content" style="text-align:${safeCss(s.textAlign || "center")}; padding:2rem; max-width:800px; opacity:0; transform:translateY(32px); transition:opacity 0.6s cubic-bezier(0.25,0.46,0.45,0.94),transform 0.6s cubic-bezier(0.25,0.46,0.45,0.94);">
+          ${s.eyebrow ? `<p class="eyebrow" style="font-size:0.875rem; font-weight:600; letter-spacing:0.1em; text-transform:uppercase; color:${safeCss(s.accentColor || "#a78bfa")}; margin-bottom:0.75rem;">${esc(s.eyebrow)}</p>` : ""}
+          ${s.heading ? `<h2 style="font-size:clamp(2rem,5vw,4rem); font-weight:900; line-height:1; letter-spacing:-0.03em; color:${safeCss(s.headingColor || "#ffffff")}; margin-bottom:1rem;">${esc(s.heading)}</h2>` : ""}
+          ${s.body ? `<p style="font-size:1.125rem; line-height:1.7; color:${safeCss(s.bodyColor || "rgba(255,255,255,0.7)")}; max-width:600px; margin:0 auto 1.5rem;">${esc(s.body)}</p>` : ""}
+          ${s.ctaLabel ? `<a href="${safeHref(s.ctaHref || "#")}" style="display:inline-block; background:${safeCss(s.accentColor || "#7c3aed")}; color:white; padding:0.875rem 2rem; border-radius:0.5rem; font-weight:600; text-decoration:none; font-size:1rem;">${esc(s.ctaLabel)}</a>` : ""}
+        </div>
       </div>
     </section>`).join("\n");
 
@@ -115,9 +119,10 @@ export async function POST(req: NextRequest) {
     body { background: #000; color: #fff; font-family: system-ui, sans-serif; overflow-x: hidden; }
     #scroll-canvas { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
     #scroll-container { position: relative; height: ${totalScrollHeight}px; z-index: 1; pointer-events: none; }
-    .scroll-section { pointer-events: auto; opacity: 0; transform: translateY(32px); transition: opacity 0.6s cubic-bezier(0.25,0.46,0.45,0.94), transform 0.6s cubic-bezier(0.25,0.46,0.45,0.94); }
-    .scroll-section.visible { opacity: 1; transform: translateY(0); }
+    .scroll-section { pointer-events: none; }
+    .section-sticky { pointer-events: none; }
     .section-content { pointer-events: auto; }
+    .section-content.visible { opacity: 1 !important; transform: translateY(0) !important; }
     #scroll-hint {
       position: fixed; bottom: 2rem; left: 50%; transform: translateX(-50%);
       display: flex; flex-direction: column; align-items: center; gap: 0.5rem;
@@ -183,6 +188,7 @@ export async function POST(req: NextRequest) {
         var images = getImages();
         var img = images[index];
         if (!img || !img.complete) return;
+        if (!img.naturalWidth || !img.naturalHeight) return;
         var cssW = window.innerWidth, cssH = window.innerHeight;
         var scale = Math.max(cssW / img.naturalWidth, cssH / img.naturalHeight);
         var w = img.naturalWidth * scale, h = img.naturalHeight * scale;
@@ -305,14 +311,15 @@ export async function POST(req: NextRequest) {
     })();
     ` : ""}
     (function() {
-      const sections = document.querySelectorAll('.scroll-section');
+      // Observe the section-content divs (inside sticky wrappers) for entrance animations.
+      const contents = document.querySelectorAll('.section-content');
       const observer = new IntersectionObserver(function(entries) {
         entries.forEach(function(entry) {
           if (entry.isIntersecting) entry.target.classList.add('visible');
           else entry.target.classList.remove('visible');
         });
-      }, { threshold: 0.15 });
-      sections.forEach(function(s) { observer.observe(s); });
+      }, { threshold: 0.1 });
+      contents.forEach(function(el) { observer.observe(el); });
     })();
   </script>
 </body>

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, ArrowRight, Sparkles, Upload, CheckCircle2, Loader2, Layers,
 import Link from "next/link";
 import { toast } from "sonner";
 import { generate2DFrames, type Style2D } from "@/lib/generate2DFrames";
+import { storeFrames, deleteFrames } from "@/lib/frameStorage";
 
 const STYLES: { id: Style2D; label: string; description: string; icon: React.ReactNode; colors: [string, string, string] }[] = [
   { id: "gradient",  label: "Gradient Flow",  description: "Smooth color morphing with floating light orbs", icon: <Circle className="w-5 h-5" />,  colors: ["#7c3aed", "#2563eb", "#0f172a"] },
@@ -61,13 +62,11 @@ function CreatePageInner() {
           { ...opts, width: 720, height: 1280 },
           (p) => setProgress(50 + Math.round(p * 0.5))
         );
-        try {
-          sessionStorage.setItem("scrollcraft_mobile_frames", JSON.stringify(mobileFrames));
-        } catch {
-          // sessionStorage full — skip mobile frames silently
-        }
+        // Mobile frames are ~8–12 MB — far beyond sessionStorage's 5 MB quota.
+        // Store in IndexedDB which supports hundreds of MB.
+        await storeFrames("scrollcraft_mobile_frames", mobileFrames);
       } else {
-        sessionStorage.removeItem("scrollcraft_mobile_frames");
+        await deleteFrames("scrollcraft_mobile_frames").catch(() => {});
       }
 
       // Store frames in sessionStorage — never in the URL (base64 payloads are 12-16 MB,

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useEffect, useRef, useCallback, Suspense } from "react";
 import JSZip from "jszip";
+import { loadFrames } from "@/lib/frameStorage";
 import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -109,15 +110,15 @@ function EditorInner() {
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [customHead, setCustomHead] = useState("");
   const [customCss, setCustomCss] = useState("");
-  const [mobileFrames, setMobileFrames] = useState<string[]>(() => {
-    if (typeof window === "undefined") return [];
-    if (searchParams.get("hasMobileFrames") !== "1") return [];
-    try {
-      const stored = sessionStorage.getItem("scrollcraft_mobile_frames");
-      if (stored) { const parsed = JSON.parse(stored); if (Array.isArray(parsed)) return parsed; }
-    } catch { /* unavailable */ }
-    return [];
-  });
+  const [mobileFrames, setMobileFrames] = useState<string[]>([]);
+  // Load mobile frames from IndexedDB (too large for sessionStorage's 5 MB quota)
+  useEffect(() => {
+    if (searchParams.get("hasMobileFrames") !== "1") return;
+    loadFrames("scrollcraft_mobile_frames").then((f) => {
+      if (f && f.length) setMobileFrames(f);
+    }).catch(() => {});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [viewportMode, setViewportMode] = useState<"desktop" | "tablet" | "mobile">("desktop");
   const [audioSrc, setAudioSrc] = useState<string | null>(null);
   const [siteId, setSiteId] = useState<string | null>(searchParams.get("siteId"));
@@ -570,41 +571,54 @@ function EditorInner() {
                 <div className="relative z-10" style={{ height: totalScrollHeight }}>
                   <div style={{ height: "100vh" }} />
                   {sections.filter(s => s.visible).map((s) => (
-                    <ScrollSection
+                    <div
                       key={s.id}
                       onClick={() => setSelectedSection(s.id)}
                       style={{
+                        position: "relative",
                         height: s.scrollHeight,
-                        display: "flex",
-                        alignItems: s.align || "center",
-                        justifyContent: s.justify || "center",
                         cursor: "pointer",
                         outline: selectedSection === s.id ? "1px solid rgba(124,58,237,0.5)" : "none",
                       }}
                     >
-                      <div style={{ textAlign: s.textAlign, padding: "2rem", maxWidth: "700px" }}>
-                        {s.eyebrow && (
-                          <p style={{ fontSize: "0.75rem", fontWeight: 600, letterSpacing: "0.1em", textTransform: "uppercase", color: s.accentColor, marginBottom: "0.5rem" }}>
-                            {s.eyebrow}
-                          </p>
-                        )}
-                        {s.heading && (
-                          <h2 style={{ fontSize: "clamp(1.5rem,4vw,3.5rem)", fontWeight: 900, lineHeight: 1, letterSpacing: "-0.03em", color: s.headingColor, marginBottom: "0.75rem" }}>
-                            {s.heading}
-                          </h2>
-                        )}
-                        {s.body && (
-                          <p style={{ fontSize: "1rem", lineHeight: 1.7, color: s.bodyColor, marginBottom: "1rem" }}>
-                            {s.body}
-                          </p>
-                        )}
-                        {s.ctaLabel && (
-                          <span style={{ display: "inline-block", background: s.accentColor, color: "white", padding: "0.625rem 1.5rem", borderRadius: "0.375rem", fontWeight: 600, fontSize: "0.875rem" }}>
-                            {s.ctaLabel}
-                          </span>
-                        )}
+                      {/* Sticky wrapper keeps content pinned in the viewport while the section's
+                          scroll height is consumed — the canvas scrubs beneath it */}
+                      <div style={{
+                        position: "sticky",
+                        top: 0,
+                        height: "100vh",
+                        display: "flex",
+                        alignItems: s.align || "center",
+                        justifyContent: s.justify || "center",
+                        overflow: "hidden",
+                        pointerEvents: "none",
+                      }}>
+                        <ScrollSection style={{ pointerEvents: "auto" }}>
+                          <div style={{ textAlign: s.textAlign, padding: "2rem", maxWidth: "700px" }}>
+                            {s.eyebrow && (
+                              <p style={{ fontSize: "0.75rem", fontWeight: 600, letterSpacing: "0.1em", textTransform: "uppercase", color: s.accentColor, marginBottom: "0.5rem" }}>
+                                {s.eyebrow}
+                              </p>
+                            )}
+                            {s.heading && (
+                              <h2 style={{ fontSize: "clamp(1.5rem,4vw,3.5rem)", fontWeight: 900, lineHeight: 1, letterSpacing: "-0.03em", color: s.headingColor, marginBottom: "0.75rem" }}>
+                                {s.heading}
+                              </h2>
+                            )}
+                            {s.body && (
+                              <p style={{ fontSize: "1rem", lineHeight: 1.7, color: s.bodyColor, marginBottom: "1rem" }}>
+                                {s.body}
+                              </p>
+                            )}
+                            {s.ctaLabel && (
+                              <span style={{ display: "inline-block", background: s.accentColor, color: "white", padding: "0.625rem 1.5rem", borderRadius: "0.375rem", fontWeight: 600, fontSize: "0.875rem" }}>
+                                {s.ctaLabel}
+                              </span>
+                            )}
+                          </div>
+                        </ScrollSection>
                       </div>
-                    </ScrollSection>
+                    </div>
                   ))}
                 </div>
               </div>

--- a/src/components/ScrollEngine.tsx
+++ b/src/components/ScrollEngine.tsx
@@ -30,6 +30,7 @@ export default function ScrollEngine({ frames, mobileFrames, totalScrollHeight =
     const canvas = canvasRef.current;
     const img = imagesRef.current[index];
     if (!canvas || !img || !img.complete) return;
+    if (!img.naturalWidth || !img.naturalHeight) return; // image failed to load (404/timeout)
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
     const scale = Math.max(canvas.width / img.naturalWidth, canvas.height / img.naturalHeight);

--- a/src/lib/frameStorage.ts
+++ b/src/lib/frameStorage.ts
@@ -1,0 +1,44 @@
+"use client";
+
+const DB_NAME = "scrollcraft";
+const STORE_NAME = "frames";
+const DB_VERSION = 1;
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => req.result.createObjectStore(STORE_NAME);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function storeFrames(key: string, frames: string[]): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    tx.objectStore(STORE_NAME).put(frames, key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function loadFrames(key: string): Promise<string[] | null> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const req = tx.objectStore(STORE_NAME).get(key);
+    req.onsuccess = () => resolve(Array.isArray(req.result) ? req.result : null);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function deleteFrames(key: string): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    tx.objectStore(STORE_NAME).delete(key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}


### PR DESCRIPTION
## Summary

**#139 (high) — Division by zero crashes canvas renderer**
A failed image load (404, network timeout) leaves `naturalWidth`/`naturalHeight` at `0` while `complete` is `true`. `Math.max(canvas.width / 0, ...)` produces `Infinity`, crashing all subsequent draws silently.
- Added `if (!img.naturalWidth || !img.naturalHeight) return;` in `ScrollEngine.tsx` `drawFrame()`
- Same guard added to the exported static HTML template

**#138 (high) — Mobile frames silently lost due to sessionStorage 5 MB quota**
120 portrait frames (720×1280 JPEG) stringify to 8–12 MB. `sessionStorage.setItem` throws `QuotaExceededError`, caught silently. Editor finds no mobile frames.
- Created `src/lib/frameStorage.ts` — thin async IndexedDB wrapper (`storeFrames` / `loadFrames` / `deleteFrames`)
- `create/page.tsx` writes mobile frames to IndexedDB instead of sessionStorage
- `editor/page.tsx` reads from IndexedDB via `useEffect` on mount

**#140 (medium) — Section text scrolls off immediately instead of staying pinned**
Text content was `position: static` inside a tall container. It scrolled away in the first viewport-height of scrolling, leaving the canvas animating with no visible overlay.
- Wrapped each section's content in `position: sticky; top: 0; height: 100vh` — text stays centered while canvas scrubs underneath
- Applied in editor preview (`editor/page.tsx`) and exported HTML template (`export-site/route.ts`)
- IntersectionObserver now targets `.section-content` inside the sticky wrapper for entrance animations

## Test plan
- [ ] Load a failed/404 frame URL — canvas should not crash or go blank
- [ ] Generate mobile frames → navigate to editor → mobile viewport shows mobile frames
- [ ] Scroll through editor preview — section text stays pinned while canvas animates behind it
- [ ] Export ZIP → open exported site → same sticky behavior in production

Closes #138, #139, #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)