### PR TITLE
fix: editor shortcut stale closure, hero mobile detection, live preview loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,14 @@
 # Database (required) — PostgreSQL connection string
 DATABASE_URL="postgresql://user:password@localhost:5432/scrollcraft"
 
-# Auth (NEXTAUTH_SECRET required in production)
-# Generate one with: openssl rand -base64 32
+# Auth — NextAuth v5 uses AUTH_SECRET (NEXTAUTH_SECRET is the v4 alias, both work)
+# Generate with: openssl rand -base64 32
+# In Vercel: add AUTH_SECRET under Settings → Environment Variables
+AUTH_SECRET=""
+# Set to your production URL in Vercel (required for OAuth callbacks to work)
+# e.g. AUTH_URL="https://scrollcraft.app"
+AUTH_URL="http://localhost:3000"
+# Legacy aliases (still accepted by NextAuth v5)
 NEXTAUTH_SECRET=""
 NEXTAUTH_URL="http://localhost:3000"
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,12 +15,12 @@ const securityHeaders = [
     value: [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://checkout.razorpay.com",
-      "style-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "img-src 'self' data: blob: https:",
       "media-src 'self' blob:",
       "connect-src 'self' https://api.anthropic.com https://api.lumalabs.ai https://api.dev.runwayml.com https://checkout.razorpay.com https://*.sentry.io",
       "frame-src https://api.razorpay.com https://checkout.razorpay.com",
-      "font-src 'self'",
+      "font-src 'self' https://fonts.gstatic.com",
     ].join("; "),
   },
 ];

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,19 +1,47 @@
 "use client";
-import { useState } from "react";
-import { signIn } from "next-auth/react";
+import { useState, useEffect } from "react";
+import { signIn, getProviders } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Sparkles, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { Suspense } from "react";
 
+const GitHubIcon = () => (
+  <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
+  </svg>
+);
+
+const GoogleIcon = () => (
+  <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
+    <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+    <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+    <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+    <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+  </svg>
+);
+
+const PROVIDER_META: Record<string, { label: string; icon: () => React.ReactElement }> = {
+  github: { label: "Continue with GitHub", icon: GitHubIcon },
+  google: { label: "Continue with Google", icon: GoogleIcon },
+};
+
 function SignInForm() {
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl") || "/dashboard";
-  const [loading, setLoading] = useState<"github" | "google" | null>(null);
+  const [loading, setLoading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [providers, setProviders] = useState<string[] | null>(null);
 
-  const handleSignIn = async (provider: "github" | "google") => {
+  // Fetch only the providers that are actually configured server-side
+  useEffect(() => {
+    getProviders()
+      .then((p) => setProviders(p ? Object.keys(p) : []))
+      .catch(() => setProviders([]));
+  }, []);
+
+  const handleSignIn = async (provider: string) => {
     setLoading(provider);
     setError(null);
     try {
@@ -47,40 +75,32 @@ function SignInForm() {
             </div>
           )}
 
-          <Button
-            onClick={() => handleSignIn("github")}
-            disabled={loading !== null}
-            className="w-full bg-white/8 hover:bg-white/12 border border-white/10 text-foreground font-medium py-5"
-            variant="outline"
-          >
-            {loading === "github" ? (
-              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-            ) : (
-              <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
-              </svg>
-            )}
-            Continue with GitHub
-          </Button>
-
-          <Button
-            onClick={() => handleSignIn("google")}
-            disabled={loading !== null}
-            className="w-full bg-white/8 hover:bg-white/12 border border-white/10 text-foreground font-medium py-5"
-            variant="outline"
-          >
-            {loading === "google" ? (
-              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-            ) : (
-              <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
-                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-              </svg>
-            )}
-            Continue with Google
-          </Button>
+          {providers === null ? (
+            <div className="flex items-center justify-center py-6 text-muted-foreground">
+              <Loader2 className="w-5 h-5 animate-spin" />
+            </div>
+          ) : providers.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              No sign-in providers are configured yet.
+            </p>
+          ) : (
+            providers.map((id) => {
+              const meta = PROVIDER_META[id] ?? { label: `Continue with ${id}`, icon: () => null };
+              const Icon = meta.icon;
+              return (
+                <Button
+                  key={id}
+                  onClick={() => handleSignIn(id)}
+                  disabled={loading !== null}
+                  className="w-full bg-white/8 hover:bg-white/12 border border-white/10 text-foreground font-medium py-5"
+                  variant="outline"
+                >
+                  {loading === id ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Icon />}
+                  {meta.label}
+                </Button>
+              );
+            })
+          )}
         </div>
 
         <p className="text-center text-xs text-muted-foreground">

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,10 +1,29 @@
 "use client";
+import { useState } from "react";
 import { signIn } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Sparkles } from "lucide-react";
+import { Sparkles, Loader2 } from "lucide-react";
 import Link from "next/link";
+import { Suspense } from "react";
 
-export default function SignInPage() {
+function SignInForm() {
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl") || "/dashboard";
+  const [loading, setLoading] = useState<"github" | "google" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSignIn = async (provider: "github" | "google") => {
+    setLoading(provider);
+    setError(null);
+    try {
+      await signIn(provider, { callbackUrl });
+    } catch {
+      setError("Sign-in failed. Please check your connection and try again.");
+      setLoading(null);
+    }
+  };
+
   return (
     <main className="min-h-screen bg-background text-foreground flex items-center justify-center px-6">
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] rounded-full bg-primary/8 blur-[120px] pointer-events-none" />
@@ -22,28 +41,44 @@ export default function SignInPage() {
         </div>
 
         <div className="space-y-3 p-6 rounded-2xl border border-white/8 bg-card">
+          {error && (
+            <div className="text-xs text-destructive bg-destructive/10 border border-destructive/20 rounded-lg px-3 py-2">
+              {error}
+            </div>
+          )}
+
           <Button
-            onClick={() => signIn("github", { callbackUrl: "/dashboard" })}
+            onClick={() => handleSignIn("github")}
+            disabled={loading !== null}
             className="w-full bg-white/8 hover:bg-white/12 border border-white/10 text-foreground font-medium py-5"
             variant="outline"
           >
-            <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
-            </svg>
+            {loading === "github" ? (
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            ) : (
+              <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
+              </svg>
+            )}
             Continue with GitHub
           </Button>
 
           <Button
-            onClick={() => signIn("google", { callbackUrl: "/dashboard" })}
+            onClick={() => handleSignIn("google")}
+            disabled={loading !== null}
             className="w-full bg-white/8 hover:bg-white/12 border border-white/10 text-foreground font-medium py-5"
             variant="outline"
           >
-            <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
-              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-            </svg>
+            {loading === "google" ? (
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            ) : (
+              <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
+                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+              </svg>
+            )}
             Continue with Google
           </Button>
         </div>
@@ -56,5 +91,13 @@ export default function SignInPage() {
         </p>
       </div>
     </main>
+  );
+}
+
+export default function SignInPage() {
+  return (
+    <Suspense>
+      <SignInForm />
+    </Suspense>
   );
 }

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,5 +1,3 @@
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Sparkles } from "lucide-react";
 import Navbar from "@/components/Navbar";

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useState } from "react";
-import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -77,9 +77,9 @@ function CreatePageInner() {
         await deleteFrames("scrollcraft_mobile_frames").catch(() => {});
       }
 
-      // Store frames in sessionStorage — never in the URL (base64 payloads are 12-16 MB,
-      // far beyond the ~2 MB browser URL limit, causing silent truncation / 414 errors).
-      sessionStorage.setItem("scrollcraft_desktop_frames", JSON.stringify(frames));
+      // Store frames in IndexedDB — sessionStorage's 5 MB quota is too small for even one
+      // 120-frame set. IndexedDB handles hundreds of MB without issue.
+      await storeFrames("scrollcraft_desktop_frames", frames);
 
       const params = new URLSearchParams({
         framesKey: "scrollcraft_desktop_frames",
@@ -109,7 +109,7 @@ function CreatePageInner() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Extraction failed");
       setProgress(100);
-      sessionStorage.setItem("scrollcraft_desktop_frames", JSON.stringify(data.frames));
+      await storeFrames("scrollcraft_desktop_frames", data.frames);
 
       const params = new URLSearchParams({
         framesKey: "scrollcraft_desktop_frames",

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useRef, Suspense } from "react";
+import { useState, useRef, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { DEMO_SITES } from "@/lib/demoSites";
 import { Button } from "@/components/ui/button";
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { toast } from "sonner";
 import { generate2DFrames, type Style2D } from "@/lib/generate2DFrames";
 import { storeFrames, deleteFrames } from "@/lib/frameStorage";
+import StylePreview from "@/components/StylePreview";
 
 const STYLES: { id: Style2D; label: string; description: string; icon: React.ReactNode; colors: [string, string, string] }[] = [
   { id: "gradient",  label: "Gradient Flow",  description: "Smooth color morphing with floating light orbs", icon: <Circle className="w-5 h-5" />,  colors: ["#7c3aed", "#2563eb", "#0f172a"] },
@@ -49,6 +50,7 @@ function CreatePageInner() {
   const [isGenerating, setIsGenerating] = useState(false);
   const [progress, setProgress] = useState(0);
   const [progressLabel, setProgressLabel] = useState("");
+  const [dragActive, setDragActive] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
 
   const handleGenerate = async () => {
@@ -125,6 +127,30 @@ function CreatePageInner() {
     }
   };
 
+  // Enter advances Style → Configure → Generate (ignored while typing in a field)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Enter" || isGenerating) return;
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      if (step === 0) { e.preventDefault(); setStep(1); }
+      else if (step === 1) { e.preventDefault(); handleGenerate(); }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step, isGenerating]);
+
+  const VIDEO_RE = /^video\//;
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragActive(false);
+    const file = e.dataTransfer.files?.[0];
+    if (!file) return;
+    if (!VIDEO_RE.test(file.type)) { toast.error("Please drop a video file (MP4, MOV, WebM)"); return; }
+    handleUpload(file);
+  };
+
   return (
     <main className="min-h-screen bg-background text-foreground flex flex-col">
       {/* Header */}
@@ -181,17 +207,33 @@ function CreatePageInner() {
                 <button
                   key={s.id}
                   onClick={() => { setSelectedStyle(s.id); setColors(s.colors); }}
-                  className={`text-left p-4 rounded-2xl border transition-all ${
+                  className={`group text-left rounded-2xl border overflow-hidden transition-all ${
                     selectedStyle === s.id
-                      ? "border-primary/60 bg-primary/10 shadow-lg shadow-primary/10"
-                      : "border-white/8 bg-card hover:border-white/20"
+                      ? "border-primary/60 shadow-lg shadow-primary/10"
+                      : "border-white/8 hover:border-white/25"
                   }`}
                 >
-                  <div className={`w-8 h-8 rounded-lg flex items-center justify-center mb-3 ${selectedStyle === s.id ? "bg-primary/20 text-primary" : "bg-white/5 text-muted-foreground"}`}>
-                    {s.icon}
+                  {/* Live animated preview — the selected card animates; others show a static frame */}
+                  <div className="aspect-video relative bg-black">
+                    <StylePreview
+                      style={s.id}
+                      colors={selectedStyle === s.id ? colors : s.colors}
+                      paused={selectedStyle !== s.id}
+                      className="absolute inset-0 w-full h-full"
+                    />
+                    {selectedStyle === s.id && (
+                      <div className="absolute top-2 right-2 w-5 h-5 rounded-full bg-primary flex items-center justify-center shadow-lg">
+                        <CheckCircle2 className="w-3.5 h-3.5 text-white" />
+                      </div>
+                    )}
                   </div>
-                  <div className="font-semibold mb-0.5">{s.label}</div>
-                  <div className="text-xs text-muted-foreground">{s.description}</div>
+                  <div className="p-3 bg-card">
+                    <div className="flex items-center gap-2 mb-0.5">
+                      <span className={selectedStyle === s.id ? "text-primary" : "text-muted-foreground"}>{s.icon}</span>
+                      <span className="font-semibold text-sm">{s.label}</span>
+                    </div>
+                    <div className="text-xs text-muted-foreground">{s.description}</div>
+                  </div>
                 </button>
               ))}
             </div>
@@ -210,6 +252,18 @@ function CreatePageInner() {
             <div className="text-center">
               <h1 className="text-3xl font-black tracking-tighter mb-2">Configure</h1>
               <p className="text-muted-foreground">Pick a color palette and frame count</p>
+            </div>
+
+            {/* Live preview — reflects the selected style + current palette in real time */}
+            <div className="rounded-2xl overflow-hidden border border-white/10 relative aspect-video bg-black">
+              <StylePreview
+                style={selectedStyle}
+                colors={colors}
+                className="absolute inset-0 w-full h-full"
+              />
+              <div className="absolute bottom-3 left-3 text-xs font-medium text-white/70 bg-black/40 backdrop-blur-sm px-2.5 py-1 rounded-full">
+                Live preview · {STYLES.find(s => s.id === selectedStyle)?.label}
+              </div>
             </div>
 
             <div className="space-y-6 p-6 rounded-2xl border border-white/8 bg-card">
@@ -271,10 +325,17 @@ function CreatePageInner() {
               <p className="text-center text-sm text-muted-foreground">— or upload your own video —</p>
               <button
                 onClick={() => fileRef.current?.click()}
-                className="w-full p-5 rounded-2xl border-2 border-dashed border-white/15 hover:border-primary/40 transition-colors flex flex-col items-center gap-2 text-muted-foreground hover:text-foreground"
+                onDragOver={(e) => { e.preventDefault(); setDragActive(true); }}
+                onDragLeave={(e) => { e.preventDefault(); setDragActive(false); }}
+                onDrop={handleDrop}
+                className={`w-full p-5 rounded-2xl border-2 border-dashed transition-colors flex flex-col items-center gap-2 ${
+                  dragActive
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-white/15 hover:border-primary/40 text-muted-foreground hover:text-foreground"
+                }`}
               >
                 <Upload className="w-6 h-6" />
-                <p className="font-medium text-sm">Drop a video or click to upload</p>
+                <p className="font-medium text-sm">{dragActive ? "Drop to upload" : "Drop a video or click to upload"}</p>
                 <p className="text-xs">MP4, MOV, WebM — max 500MB</p>
               </button>
               <input ref={fileRef} type="file" accept="video/*" className="hidden" onChange={(e) => e.target.files?.[0] && handleUpload(e.target.files[0])} />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useSession, signOut } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Link from "next/link";
@@ -9,7 +9,7 @@ import { Progress } from "@/components/ui/progress";
 import { toast } from "sonner";
 import {
   Sparkles, Plus, ExternalLink, Trash2,
-  Zap, Globe, Download, LogOut, User, ChevronDown, Settings, Loader2
+  Zap, Globe, Download, Loader2
 } from "lucide-react";
 import Navbar from "@/components/Navbar";
 
@@ -33,7 +33,6 @@ const PLANS: Record<string, { label: string; maxCredits: number; color: string }
 export default function DashboardPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
-  const [menuOpen, setMenuOpen] = useState(false);
   const [sites, setSites] = useState<Site[]>([]);
   const [sitesLoading, setSitesLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);

--- a/src/app/demos/[slug]/page.tsx
+++ b/src/app/demos/[slug]/page.tsx
@@ -107,8 +107,8 @@ export default function DemoPage({ params }: { params: Promise<{ slug: string }>
       {/* Sticky nav bar */}
       <div className="fixed top-0 left-0 right-0 z-40 flex items-center justify-between px-6 py-3 bg-black/60 backdrop-blur-xl border-b border-white/8">
         <button
-          onClick={() => router.push("/showcase")}
-          className="flex items-center gap-2 text-sm text-white/60 hover:text-white transition-colors"
+          onClick={() => router.back()}
+          className="flex items-center gap-2 text-sm text-white/60 hover:text-white transition-colors cursor-pointer"
         >
           <ArrowLeft className="w-4 h-4" />
           <span className="hidden sm:inline">Back to showcase</span>

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState, useEffect, useRef, useCallback, Suspense } from "react";
 import JSZip from "jszip";
-import { loadFrames } from "@/lib/frameStorage";
+import { loadFrames, storeFrames } from "@/lib/frameStorage";
 import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -60,22 +60,15 @@ function EditorInner() {
   const searchParams = useSearchParams();
   const previewScrollRef = useRef<HTMLDivElement>(null);
 
-  // Derive initial frame state — frames are now stored in sessionStorage (never in the URL).
-  // Legacy ?frames= param is still accepted for backward compatibility with any bookmarked URLs.
+  // Derive initial frame state. Frames live in IndexedDB (primary) with sessionStorage as a
+  // legacy fallback for any in-flight sessions created before this change.
   const framesKey = searchParams.get("framesKey");
-  const framesParam = searchParams.get("frames"); // legacy
+  const framesParam = searchParams.get("frames"); // legacy URL param
   const countParam = searchParams.get("frameCount");
   const fpsParam = searchParams.get("fps");
 
+  // Synchronous fast path: check legacy sessionStorage only (may be empty for new sessions)
   const parsedFrames: string[] | null = (() => {
-    // New path: read from sessionStorage via key
-    if (framesKey) {
-      try {
-        const stored = sessionStorage.getItem(framesKey);
-        if (stored) return JSON.parse(stored) as string[];
-      } catch { /* sessionStorage unavailable or corrupt — fall through to demo */ }
-    }
-    // Legacy path: frames were small enough to be in the URL (or direct navigation in tests)
     if (framesParam) {
       try { return JSON.parse(framesParam) as string[]; } catch { return null; }
     }
@@ -84,11 +77,24 @@ function EditorInner() {
 
   const DEMO_COUNT = 120;
   const demoFrameUrls = Array.from({ length: DEMO_COUNT }, (_, i) => `/api/demo-frame?i=${i}&total=${DEMO_COUNT}`);
-  const initialIsDemo = !parsedFrames;
+  const initialIsDemo = !parsedFrames && !framesKey;
 
   const [frames, setFrames] = useState<string[]>(parsedFrames ?? demoFrameUrls);
   const [frameCount, setFrameCount] = useState(parsedFrames ? parseInt(countParam || String(parsedFrames.length)) : DEMO_COUNT);
   const [fps, setFps] = useState(parsedFrames ? parseInt(fpsParam || "24") : 24);
+
+  // Load desktop frames from IndexedDB (primary store; sessionStorage was too small at 5 MB)
+  useEffect(() => {
+    if (!framesKey || parsedFrames) return;
+    loadFrames(framesKey).then((f) => {
+      if (f && f.length) {
+        setFrames(f);
+        setFrameCount(f.length);
+        setIsDemo(false);
+      }
+    }).catch(() => {});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [sections, setSections] = useState<Section[]>([defaultSection(0)]);
   const [selectedSection, setSelectedSection] = useState<string>(sections[0].id);
   const [siteName, setSiteName] = useState("My ScrollCraft Site");
@@ -142,17 +148,12 @@ function EditorInner() {
         if (!res.ok) return;
         const { site } = await res.json();
         if (cancelled || !site) return;
-        // Check sessionStorage first (frames saved here to avoid server payload limits).
-        // Fall back to framesJson in DB for sites saved before this change.
-        const storedFrames = sessionStorage.getItem(`scrollcraft_frames_${sid}`);
-        const storedMobile = sessionStorage.getItem(`scrollcraft_mframes_${sid}`);
-        if (storedFrames) {
-          const f = JSON.parse(storedFrames);
-          if (Array.isArray(f) && f.length) { setFrames(f); setFrameCount(f.length); setIsDemo(false); }
-          if (storedMobile) {
-            const mf = JSON.parse(storedMobile);
-            if (Array.isArray(mf) && mf.length) setMobileFrames(mf);
-          }
+        // Load frames from IndexedDB (primary). Fall back to DB framesJson for old sites.
+        const storedFrames = await loadFrames(`scrollcraft_frames_${sid}`);
+        const storedMobile = await loadFrames(`scrollcraft_mframes_${sid}`).catch(() => null);
+        if (storedFrames && storedFrames.length) {
+          setFrames(storedFrames); setFrameCount(storedFrames.length); setIsDemo(false);
+          if (storedMobile && storedMobile.length) setMobileFrames(storedMobile);
         } else if (site.framesJson) {
           const f = JSON.parse(site.framesJson);
           if (Array.isArray(f) && f.length) { setFrames(f); setFrameCount(f.length); setIsDemo(false); }
@@ -370,13 +371,11 @@ function EditorInner() {
       const savedId = data.site.id as string;
       setSiteId(savedId);
 
-      // Persist frames in sessionStorage so they survive navigation within this session.
-      try {
-        sessionStorage.setItem(`scrollcraft_frames_${savedId}`, JSON.stringify(frames));
-        if (mobileFrames.length) {
-          sessionStorage.setItem(`scrollcraft_mframes_${savedId}`, JSON.stringify(mobileFrames));
-        }
-      } catch { /* quota exceeded — non-fatal, user can regenerate frames */ }
+      // Persist frames in IndexedDB so they survive navigation without hitting sessionStorage quota.
+      await storeFrames(`scrollcraft_frames_${savedId}`, frames).catch(() => {});
+      if (mobileFrames.length) {
+        await storeFrames(`scrollcraft_mframes_${savedId}`, mobileFrames).catch(() => {});
+      }
 
       if (!opts?.silent) toast.success("Site saved!");
       return savedId;

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -12,7 +12,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   ArrowLeft, Download, Plus, Trash2, Eye, EyeOff, ChevronUp, ChevronDown,
   Sparkles, Layers, Settings, Type, Loader2, AlignLeft, AlignCenter, AlignRight,
-  MessageSquare, Send, X, Bot, Monitor, Tablet, Smartphone, Music, Volume2, VolumeX, Save
+  MessageSquare, Send, X, Bot, Monitor, Tablet, Smartphone, Music, Volume2, VolumeX, Save,
+  Undo2, Redo2, Copy
 } from "lucide-react";
 import { useScrollAudio } from "@/lib/useScrollAudio";
 import Link from "next/link";
@@ -82,19 +83,6 @@ function EditorInner() {
   const [frames, setFrames] = useState<string[]>(parsedFrames ?? demoFrameUrls);
   const [frameCount, setFrameCount] = useState(parsedFrames ? parseInt(countParam || String(parsedFrames.length)) : DEMO_COUNT);
   const [fps, setFps] = useState(parsedFrames ? parseInt(fpsParam || "24") : 24);
-
-  // Load desktop frames from IndexedDB (primary store; sessionStorage was too small at 5 MB)
-  useEffect(() => {
-    if (!framesKey || parsedFrames) return;
-    loadFrames(framesKey).then((f) => {
-      if (f && f.length) {
-        setFrames(f);
-        setFrameCount(f.length);
-        setIsDemo(false);
-      }
-    }).catch(() => {});
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
   const [sections, setSections] = useState<Section[]>([defaultSection(0)]);
   const [selectedSection, setSelectedSection] = useState<string>(sections[0].id);
   const [siteName, setSiteName] = useState("My ScrollCraft Site");
@@ -130,6 +118,19 @@ function EditorInner() {
   const [siteId, setSiteId] = useState<string | null>(searchParams.get("siteId"));
   const [isSaving, setIsSaving] = useState(false);
   const [audioMuted, setAudioMuted] = useState(false);
+
+  // Load desktop frames from IndexedDB (primary store; sessionStorage was too small at 5 MB)
+  useEffect(() => {
+    if (!framesKey || parsedFrames) return;
+    loadFrames(framesKey).then((f) => {
+      if (f && f.length) {
+        setFrames(f);
+        setFrameCount(f.length);
+        setIsDemo(false);
+      }
+    }).catch(() => {});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const audioFileRef = useRef<HTMLInputElement>(null);
 
   useScrollAudio({ audioSrc, scrollEl: previewScrollRef, muted: audioMuted });
@@ -191,21 +192,97 @@ function EditorInner() {
 
   const selectedSectionData = sections.find(s => s.id === selectedSection);
 
+  // ── Undo / redo history ──────────────────────────────────────────────
+  // sectionsRef always mirrors the latest sections so async callers (AI chat)
+  // and history snapshots never read a stale value.
+  const sectionsRef = useRef(sections);
+  useEffect(() => { sectionsRef.current = sections; }, [sections]);
+
+  const undoStack = useRef<Section[][]>([]);
+  const redoStack = useRef<Section[][]>([]);
+  const lastEditKey = useRef<{ key: string; t: number } | null>(null);
+  // canUndo/canRedo are state (not derived from refs during render) so the
+  // toolbar buttons re-render correctly without reading refs at render time.
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  const syncHistoryFlags = useCallback(() => {
+    setCanUndo(undoStack.current.length > 0);
+    setCanRedo(redoStack.current.length > 0);
+  }, []);
+
+  // Apply a section mutation while recording an undo snapshot. Consecutive edits
+  // sharing the same historyKey within 800ms coalesce into one undo step (so
+  // typing a heading is a single undo, not one-per-keystroke).
+  const commitSections = useCallback((updater: (prev: Section[]) => Section[], historyKey?: string) => {
+    const baseline = sectionsRef.current;
+    const next = updater(baseline);
+    const now = Date.now();
+    const coalesce = !!historyKey
+      && lastEditKey.current?.key === historyKey
+      && now - (lastEditKey.current?.t ?? 0) < 800;
+    if (!coalesce) {
+      undoStack.current.push(baseline);
+      if (undoStack.current.length > 100) undoStack.current.shift();
+    }
+    lastEditKey.current = historyKey ? { key: historyKey, t: now } : null;
+    redoStack.current = [];
+    setSections(next);
+    setDirty(true);
+    syncHistoryFlags();
+  }, [syncHistoryFlags]);
+
+  const undo = useCallback(() => {
+    if (!undoStack.current.length) return;
+    redoStack.current.push(sectionsRef.current);
+    const prev = undoStack.current.pop()!;
+    lastEditKey.current = null;
+    setSections(prev);
+    setDirty(true);
+    setSelectedSection(sel => prev.some(s => s.id === sel) ? sel : prev[0]?.id ?? sel);
+    syncHistoryFlags();
+  }, [syncHistoryFlags]);
+
+  const redo = useCallback(() => {
+    if (!redoStack.current.length) return;
+    undoStack.current.push(sectionsRef.current);
+    const next = redoStack.current.pop()!;
+    lastEditKey.current = null;
+    setSections(next);
+    setDirty(true);
+    setSelectedSection(sel => next.some(s => s.id === sel) ? sel : next[0]?.id ?? sel);
+    syncHistoryFlags();
+  }, [syncHistoryFlags]);
+
   const updateSection = (id: string, updates: Partial<Section>) => {
-    setSections(prev => prev.map(s => s.id === id ? { ...s, ...updates } : s));
+    commitSections(prev => prev.map(s => s.id === id ? { ...s, ...updates } : s), `${id}:${Object.keys(updates).join(",")}`);
   };
 
   const addSection = () => {
     const newSection = defaultSection(sections.length);
-    setSections(prev => [...prev, newSection]);
+    commitSections(prev => [...prev, newSection]);
     setSelectedSection(newSection.id);
+  };
+
+  const duplicateSection = (id: string) => {
+    const src = sectionsRef.current.find(s => s.id === id);
+    if (!src) return;
+    const copy: Section = { ...src, id: `section-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`, heading: src.heading ? `${src.heading} (copy)` : src.heading };
+    commitSections(prev => {
+      const idx = prev.findIndex(s => s.id === id);
+      const next = [...prev];
+      next.splice(idx + 1, 0, copy);
+      return next;
+    });
+    setSelectedSection(copy.id);
   };
 
   const removeSection = (id: string) => {
     if (sections.length === 1) { toast.error("Need at least one section"); return; }
     if (pendingDeleteId !== id) { setPendingDeleteId(id); return; }
     setPendingDeleteId(null);
-    setSections(prev => prev.filter(s => s.id !== id));
+    commitSections(prev => prev.filter(s => s.id !== id));
     if (selectedSection === id) setSelectedSection(sections.find(s => s.id !== id)!.id);
   };
 
@@ -213,10 +290,12 @@ function EditorInner() {
     const idx = sections.findIndex(s => s.id === id);
     if (dir === "up" && idx === 0) return;
     if (dir === "down" && idx === sections.length - 1) return;
-    const newSections = [...sections];
-    const swap = dir === "up" ? idx - 1 : idx + 1;
-    [newSections[idx], newSections[swap]] = [newSections[swap], newSections[idx]];
-    setSections(newSections);
+    commitSections(prev => {
+      const next = [...prev];
+      const swap = dir === "up" ? idx - 1 : idx + 1;
+      [next[idx], next[swap]] = [next[swap], next[idx]];
+      return next;
+    });
   };
 
   const handleExport = async () => {
@@ -377,6 +456,7 @@ function EditorInner() {
         await storeFrames(`scrollcraft_mframes_${savedId}`, mobileFrames).catch(() => {});
       }
 
+      setDirty(false);
       if (!opts?.silent) toast.success("Site saved!");
       return savedId;
     } catch {
@@ -403,7 +483,8 @@ function EditorInner() {
       });
       const data = await res.json();
       if (data.updates?.length) {
-        setSections(prev => prev.map(s => {
+        // Route through commitSections so AI edits are a single undoable step.
+        commitSections(prev => prev.map(s => {
           const updates = data.updates.filter((u: { id: string }) => u.id === s.id);
           if (!updates.length) return s;
           return updates.reduce((acc: Section, u: { field: string; value: string | number }) => ({ ...acc, [u.field]: u.value }), s);
@@ -417,6 +498,39 @@ function EditorInner() {
     }
   };
 
+  // Keyboard shortcuts: ⌘Z undo, ⌘⇧Z / ⌘Y redo, ⌘S save, ⌘E export
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+      const key = e.key.toLowerCase();
+      if (key === "z") {
+        e.preventDefault();
+        if (e.shiftKey) redo(); else undo();
+      } else if (key === "y") {
+        e.preventDefault(); redo();
+      } else if (key === "s") {
+        e.preventDefault(); if (!isSaving) handleSave();
+      } else if (key === "e") {
+        e.preventDefault(); if (!isExporting) handleExport();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [undo, redo, isSaving, isExporting]);
+
+  // Warn before leaving with unsaved changes
+  useEffect(() => {
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!dirty) return;
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [dirty]);
+
   return (
     <div className="h-screen flex flex-col bg-background text-foreground overflow-hidden">
       {/* Top bar */}
@@ -428,13 +542,33 @@ function EditorInner() {
           <div className="w-px h-4 bg-white/10" />
           <Input
             value={siteName}
-            onChange={(e) => setSiteName(e.target.value)}
+            onChange={(e) => { setSiteName(e.target.value); setDirty(true); }}
             className="h-7 bg-transparent border-transparent hover:border-white/10 focus:border-primary/50 text-sm font-medium w-48"
           />
+          {dirty && <span title="Unsaved changes" className="w-1.5 h-1.5 rounded-full bg-amber-400 flex-shrink-0" />}
           {isDemo && <Badge variant="outline" className="border-amber-500/40 text-amber-400 text-xs">Demo mode</Badge>}
         </div>
 
         <div className="flex items-center gap-2">
+          {/* Undo / redo */}
+          <div className="flex items-center bg-white/5 rounded-md p-0.5 gap-0.5">
+            <button
+              onClick={undo}
+              disabled={!canUndo}
+              title="Undo (⌘Z)"
+              className="p-1 rounded transition-colors text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <Undo2 className="w-3.5 h-3.5" />
+            </button>
+            <button
+              onClick={redo}
+              disabled={!canRedo}
+              title="Redo (⌘⇧Z)"
+              className="p-1 rounded transition-colors text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <Redo2 className="w-3.5 h-3.5" />
+            </button>
+          </div>
           {/* Audio mute toggle — only show when audio is loaded */}
           {audioSrc && (
             <button
@@ -522,11 +656,14 @@ function EditorInner() {
                 <div className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${s.visible ? "bg-primary" : "bg-white/20"}`} />
                 <span className="text-xs flex-1 truncate">{s.heading || `Section ${i + 1}`}</span>
                 <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "up"); }} className="p-0.5 hover:text-primary">
+                  <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "up"); }} className="p-0.5 hover:text-primary" title="Move up">
                     <ChevronUp className="w-3 h-3" />
                   </button>
-                  <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "down"); }} className="p-0.5 hover:text-primary">
+                  <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "down"); }} className="p-0.5 hover:text-primary" title="Move down">
                     <ChevronDown className="w-3 h-3" />
+                  </button>
+                  <button onClick={(e) => { e.stopPropagation(); duplicateSection(s.id); }} className="p-0.5 hover:text-primary" title="Duplicate section">
+                    <Copy className="w-3 h-3" />
                   </button>
                   <button
                     onClick={(e) => { e.stopPropagation(); removeSection(s.id); }}
@@ -890,7 +1027,7 @@ function EditorInner() {
                   <p className="text-xs text-muted-foreground/70">Inject analytics, fonts, or meta tags into &lt;head&gt;</p>
                   <Textarea
                     value={customHead}
-                    onChange={(e) => setCustomHead(e.target.value)}
+                    onChange={(e) => { setCustomHead(e.target.value); setDirty(true); }}
                     placeholder={'<!-- e.g. Google Analytics, custom meta -->\n<script async src="..."></script>'}
                     className="min-h-[100px] font-mono text-xs bg-black/30 border-white/10 resize-none"
                   />
@@ -900,7 +1037,7 @@ function EditorInner() {
                   <p className="text-xs text-muted-foreground/70">Extra styles injected after the default stylesheet</p>
                   <Textarea
                     value={customCss}
-                    onChange={(e) => setCustomCss(e.target.value)}
+                    onChange={(e) => { setCustomCss(e.target.value); setDirty(true); }}
                     placeholder={".scroll-section { ... }\n.section-content { ... }"}
                     className="min-h-[100px] font-mono text-xs bg-black/30 border-white/10 resize-none"
                   />

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -498,27 +498,35 @@ function EditorInner() {
     }
   };
 
+  // handleSave/handleExport are re-created every render and read sections, frames
+  // and siteName from their closure. The keydown listener below is registered once,
+  // so it must reach them through a ref or it would act on a stale snapshot.
+  const shortcutsRef = useRef({ undo, redo, handleSave, handleExport, isSaving, isExporting });
+  useEffect(() => {
+    shortcutsRef.current = { undo, redo, handleSave, handleExport, isSaving, isExporting };
+  });
+
   // Keyboard shortcuts: ⌘Z undo, ⌘⇧Z / ⌘Y redo, ⌘S save, ⌘E export
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
+      const s = shortcutsRef.current;
       const key = e.key.toLowerCase();
       if (key === "z") {
         e.preventDefault();
-        if (e.shiftKey) redo(); else undo();
+        if (e.shiftKey) s.redo(); else s.undo();
       } else if (key === "y") {
-        e.preventDefault(); redo();
+        e.preventDefault(); s.redo();
       } else if (key === "s") {
-        e.preventDefault(); if (!isSaving) handleSave();
+        e.preventDefault(); if (!s.isSaving) s.handleSave();
       } else if (key === "e") {
-        e.preventDefault(); if (!isExporting) handleExport();
+        e.preventDefault(); if (!s.isExporting) s.handleExport();
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [undo, redo, isSaving, isExporting]);
+  }, []);
 
   // Warn before leaving with unsaved changes
   useEffect(() => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,6 @@
 import Link from "next/link";
 import { useState, useRef, useEffect } from "react";
 import { useSession } from "next-auth/react";
-import dynamic from "next/dynamic";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ArrowRight, Sparkles, Zap, Download, Play, Check } from "lucide-react";
@@ -10,7 +9,6 @@ import Navbar from "@/components/Navbar";
 
 const DEMO_COUNT = 60;
 const demoFrames = Array.from({ length: DEMO_COUNT }, (_, i) => `/api/demo-frame?i=${i}&total=${DEMO_COUNT}`);
-const ScrollEngine = dynamic(() => import("@/components/ScrollEngine"), { ssr: false });
 
 const PIPELINE = [
   { step: "01", title: "Pick a preset", desc: "Choose from 12+ production-ready templates across SaaS, agency, e-commerce, and more." },
@@ -56,12 +54,31 @@ const FAQ = [
 export default function Home() {
   const [openFaq, setOpenFaq] = useState<number | null>(null);
   const { data: session } = useSession();
-  const demoScrollRef = useRef<HTMLDivElement>(null);
   // Detect mobile on mount to skip 60 concurrent frame requests (#156)
   const [isMobileHero, setIsMobileHero] = useState(true);
+  // Autoplay: track current frame index for the hero canvas loop
+  const [heroFrameIdx, setHeroFrameIdx] = useState(0);
   useEffect(() => {
     setIsMobileHero(window.innerWidth < 768);
   }, []);
+  // Cycle through demo frames automatically at ~10fps (no user scroll required)
+  useEffect(() => {
+    if (isMobileHero) return;
+    let frame = 0;
+    let last = 0;
+    let rafId: number;
+    const INTERVAL = 100; // ms per frame → ~10fps
+    const tick = (ts: number) => {
+      if (ts - last >= INTERVAL) {
+        frame = (frame + 1) % DEMO_COUNT;
+        setHeroFrameIdx(frame);
+        last = ts;
+      }
+      rafId = requestAnimationFrame(tick);
+    };
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
+  }, [isMobileHero]);
 
   return (
     <main className="min-h-screen bg-background text-foreground overflow-x-hidden">
@@ -129,43 +146,18 @@ export default function Home() {
 
         {/* Hero visual — live scroll demo (desktop only; mobile skips 60 concurrent requests) */}
         <div className="relative mt-16 w-full max-w-5xl mx-auto rounded-2xl overflow-hidden border border-white/10 shadow-2xl shadow-black/60">
-          {isMobileHero ? (
-            /* Mobile: lightweight CSS gradient stand-in */
-            <div className="aspect-video bg-gradient-to-br from-violet-900 via-purple-950 to-indigo-950 flex items-center justify-center">
-              <div className="text-center px-6">
-                <div className="w-10 h-10 rounded-xl bg-primary/20 flex items-center justify-center mx-auto mb-3">
-                  <Sparkles className="w-5 h-5 text-primary" />
-                </div>
-                <p className="text-sm text-white/50">Open on desktop to see the live scroll demo</p>
-              </div>
-            </div>
-          ) : (
-            <>
-              {/* Scrollable container drives the demo ScrollEngine */}
-              <div
-                ref={demoScrollRef}
-                className="aspect-video overflow-y-scroll"
-                style={{ scrollbarWidth: "none" }}
-              >
-                {/* 3000px tall — scroll room for the full animation */}
-                <div style={{ height: 3000 }} />
-              </div>
-              {/* Canvas fills the rounded box and is driven by demoScrollRef */}
-              <ScrollEngine
-                frames={demoFrames}
-                totalScrollHeight={3000}
-                scrollContainer={demoScrollRef}
-                position="absolute"
-                className="absolute inset-0 pointer-events-none"
-              />
-            </>
-          )}
+          {/* Autoplay animation — cycles through demo frames at ~10fps */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={demoFrames[heroFrameIdx]}
+            alt="ScrollCraft scroll animation preview"
+            className="w-full aspect-video object-cover"
+          />
           {/* Fade-out at bottom */}
           <div className="absolute inset-0 bg-gradient-to-t from-background via-transparent to-transparent pointer-events-none" style={{ zIndex: 2 }} />
-          {/* Scroll hint overlay */}
-          <div className="absolute bottom-6 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2 text-muted-foreground text-xs uppercase tracking-widest pointer-events-none" style={{ zIndex: 3 }}>
-            <span>Scroll inside to preview</span>
-            <div className="w-px h-8 bg-gradient-to-b from-transparent to-white/30" />
+          {/* Label */}
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-xs text-white/30 uppercase tracking-widest pointer-events-none" style={{ zIndex: 3 }}>
+            Live preview
           </div>
         </div>
       </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import Link from "next/link";
-import { useState, useRef, useEffect } from "react";
-import { useSession } from "next-auth/react";
+import { useState, useEffect, useSyncExternalStore } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ArrowRight, Sparkles, Zap, Download, Play, Check } from "lucide-react";
@@ -9,6 +8,17 @@ import Navbar from "@/components/Navbar";
 
 const DEMO_COUNT = 60;
 const demoFrames = Array.from({ length: DEMO_COUNT }, (_, i) => `/api/demo-frame?i=${i}&total=${DEMO_COUNT}`);
+
+// Mobile skips the hero autoplay so it never fires 60 concurrent frame requests (#156).
+// Server-rendered as mobile so the initial HTML never references the frame URLs.
+const MOBILE_HERO_QUERY = "(max-width: 767px)";
+const subscribeMobileHero = (onChange: () => void) => {
+  const mq = window.matchMedia(MOBILE_HERO_QUERY);
+  mq.addEventListener("change", onChange);
+  return () => mq.removeEventListener("change", onChange);
+};
+const getMobileHeroSnapshot = () => window.matchMedia(MOBILE_HERO_QUERY).matches;
+const getMobileHeroServerSnapshot = () => true;
 
 const PIPELINE = [
   { step: "01", title: "Pick a preset", desc: "Choose from 12+ production-ready templates across SaaS, agency, e-commerce, and more." },
@@ -53,14 +63,13 @@ const FAQ = [
 
 export default function Home() {
   const [openFaq, setOpenFaq] = useState<number | null>(null);
-  const { data: session } = useSession();
-  // Detect mobile on mount to skip 60 concurrent frame requests (#156)
-  const [isMobileHero, setIsMobileHero] = useState(true);
+  const isMobileHero = useSyncExternalStore(
+    subscribeMobileHero,
+    getMobileHeroSnapshot,
+    getMobileHeroServerSnapshot
+  );
   // Autoplay: track current frame index for the hero canvas loop
   const [heroFrameIdx, setHeroFrameIdx] = useState(0);
-  useEffect(() => {
-    setIsMobileHero(window.innerWidth < 768);
-  }, []);
   // Cycle through demo frames automatically at ~10fps (no user scroll required)
   useEffect(() => {
     if (isMobileHero) return;

--- a/src/app/presets/page.tsx
+++ b/src/app/presets/page.tsx
@@ -611,7 +611,7 @@ export default function PresetsPage() {
             <button
               key={cat}
               onClick={() => setActiveCategory(cat)}
-              className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-all ${
+              className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-all cursor-pointer ${
                 activeCategory === cat
                   ? "bg-primary text-white border-primary"
                   : "border-white/10 text-muted-foreground hover:border-white/20 hover:text-foreground"
@@ -640,7 +640,7 @@ export default function PresetsPage() {
             {filtered.map((preset) => (
               <div
                 key={preset.name}
-                className="group relative rounded-2xl border border-white/8 overflow-hidden hover:border-white/20 transition-all hover:-translate-y-1"
+                className="group relative rounded-2xl border border-white/8 overflow-hidden hover:border-white/20 transition-all hover:-translate-y-1 cursor-pointer"
               >
                 {/* Visual preview */}
                 <div className={`aspect-video bg-gradient-to-br ${preset.gradient} relative flex items-end p-4`}>
@@ -670,8 +670,8 @@ export default function PresetsPage() {
                     <p className="font-bold text-base text-white leading-tight">{preset.name}</p>
                     <p className="text-xs text-white/60">{preset.category}</p>
                   </div>
-                  {/* Hover overlay */}
-                  <div className="absolute inset-0 flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity bg-black/60 backdrop-blur-sm">
+                  {/* Hover overlay — z-20 keeps it above the tags row (z-10) */}
+                  <div className="absolute inset-0 z-20 flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity bg-black/60 backdrop-blur-sm">
                     <Link href={`/create?template=${encodeURIComponent(preset.name)}&prompt=${encodeURIComponent(preset.prompt)}`}>
                       <Button size="sm" className="bg-primary text-white shadow-lg shadow-primary/30 text-xs h-8 px-3">
                         Use preset <ArrowRight className="ml-1 w-3 h-3" />

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import Navbar from "@/components/Navbar";
 
 export const metadata = { title: "Terms of Service — ScrollCraft" };

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,20 +1,34 @@
 // Lightweight auth config — no Prisma, no Node.js-only modules.
 // Used by middleware (Edge Runtime) and merged into the full auth.ts config.
 import type { NextAuthConfig } from "next-auth";
+import type { Provider } from "next-auth/providers";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
 
-export default {
-  providers: [
+// Only register a provider if its credentials are present, so the sign-in page
+// (via getProviders) shows exactly the providers that are actually configured.
+const providers: Provider[] = [];
+
+if (process.env.AUTH_GITHUB_ID && process.env.AUTH_GITHUB_SECRET) {
+  providers.push(
     GitHub({
       clientId: process.env.AUTH_GITHUB_ID,
       clientSecret: process.env.AUTH_GITHUB_SECRET,
-    }),
+    })
+  );
+}
+
+if (process.env.AUTH_GOOGLE_ID && process.env.AUTH_GOOGLE_SECRET) {
+  providers.push(
     Google({
       clientId: process.env.AUTH_GOOGLE_ID,
       clientSecret: process.env.AUTH_GOOGLE_SECRET,
-    }),
-  ],
+    })
+  );
+}
+
+export default {
+  providers,
   pages: {
     signIn: "/auth/signin",
   },

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -78,7 +78,7 @@ export default function Navbar({ position = "sticky" }: { position?: "fixed" | "
 
         {/* Mobile hamburger */}
         <button
-          className="md:hidden p-2 rounded-md text-muted-foreground hover:text-foreground"
+          className="md:hidden p-2 rounded-md text-muted-foreground hover:text-foreground cursor-pointer"
           onClick={() => setOpen((v) => !v)}
           aria-label="Toggle menu"
         >

--- a/src/components/StylePreview.tsx
+++ b/src/components/StylePreview.tsx
@@ -25,29 +25,47 @@ export default function StylePreview({
   className = "",
 }: StylePreviewProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const sizeRef = useRef({ w: 1, h: 1 });
 
+  // The running loop reads its draw options from a ref, so recoloring mid-loop
+  // repaints on the next tick instead of tearing the loop down and snapping to p=0.
+  const optsRef = useRef({ style, color1: colors[0], color2: colors[1], color3: colors[2], frameCount: 1 });
+  useEffect(() => {
+    optsRef.current = { style, color1: colors[0], color2: colors[1], color3: colors[2], frameCount: 1 };
+  });
+
+  // Keep the backing store matched to the element's rendered size, capped DPR for perf.
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
 
-    // Size the backing store to the element's rendered size, capped DPR for perf.
-    const dpr = Math.min(window.devicePixelRatio || 1, 2);
-    const rect = canvas.getBoundingClientRect();
-    const w = Math.max(rect.width, 1);
-    const h = Math.max(rect.height, 1);
-    canvas.width = Math.round(w * dpr);
-    canvas.height = Math.round(h * dpr);
-    ctx.scale(dpr, dpr);
-
-    const opts = {
-      style,
-      color1: colors[0],
-      color2: colors[1],
-      color3: colors[2],
-      frameCount: 1, // unused by drawFrame2D
+    const resize = () => {
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const rect = canvas.getBoundingClientRect();
+      const w = Math.max(rect.width, 1);
+      const h = Math.max(rect.height, 1);
+      canvas.width = Math.round(w * dpr);
+      canvas.height = Math.round(h * dpr);
+      // Assigning width/height resets the transform, so re-apply the DPR scale.
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      sizeRef.current = { w, h };
+      // Repaint immediately so a resize never leaves the canvas blank; a running
+      // loop overwrites this on its next tick.
+      drawFrame2D(ctx, w, h, 0, optsRef.current);
     };
+
+    resize();
+    const observer = new ResizeObserver(resize);
+    observer.observe(canvas);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (paused) return;
+    const ctx = canvasRef.current?.getContext("2d");
+    if (!ctx) return;
 
     let rafId = 0;
     let start = 0;
@@ -56,19 +74,23 @@ export default function StylePreview({
       if (!start) start = ts;
       const elapsed = (ts - start) / 1000;
       const p = (elapsed % durationSec) / durationSec; // 0..1 loop
-      drawFrame2D(ctx, w, h, p, opts);
+      const { w, h } = sizeRef.current;
+      drawFrame2D(ctx, w, h, p, optsRef.current);
       rafId = requestAnimationFrame(tick);
     };
 
-    if (paused) {
-      // Draw a single static frame so the card isn't blank while paused.
-      drawFrame2D(ctx, w, h, 0, opts);
-    } else {
-      rafId = requestAnimationFrame(tick);
-    }
-
+    rafId = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafId);
-  }, [style, colors, durationSec, paused]);
+  }, [paused, durationSec]);
+
+  // While paused the loop is not running, so redraw the static frame on restyle.
+  useEffect(() => {
+    if (!paused) return;
+    const ctx = canvasRef.current?.getContext("2d");
+    if (!ctx) return;
+    const { w, h } = sizeRef.current;
+    drawFrame2D(ctx, w, h, 0, { style, color1: colors[0], color2: colors[1], color3: colors[2], frameCount: 1 });
+  }, [paused, style, colors]);
 
   return <canvas ref={canvasRef} className={className} aria-hidden="true" />;
 }

--- a/src/components/StylePreview.tsx
+++ b/src/components/StylePreview.tsx
@@ -1,0 +1,74 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { drawFrame2D, type Style2D } from "@/lib/generate2DFrames";
+
+interface StylePreviewProps {
+  style: Style2D;
+  colors: [string, string, string];
+  /** Animation loop length in seconds (default 6s) */
+  durationSec?: number;
+  /** Pause the rAF loop to save CPU (e.g. when off-screen / not selected) */
+  paused?: boolean;
+  className?: string;
+}
+
+/**
+ * Renders a live, looping animation of a 2D style directly to a canvas via
+ * requestAnimationFrame — no JPEG encoding, no IndexedDB. Cheap enough to mount
+ * several at once for the create-flow style gallery.
+ */
+export default function StylePreview({
+  style,
+  colors,
+  durationSec = 6,
+  paused = false,
+  className = "",
+}: StylePreviewProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    // Size the backing store to the element's rendered size, capped DPR for perf.
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const rect = canvas.getBoundingClientRect();
+    const w = Math.max(rect.width, 1);
+    const h = Math.max(rect.height, 1);
+    canvas.width = Math.round(w * dpr);
+    canvas.height = Math.round(h * dpr);
+    ctx.scale(dpr, dpr);
+
+    const opts = {
+      style,
+      color1: colors[0],
+      color2: colors[1],
+      color3: colors[2],
+      frameCount: 1, // unused by drawFrame2D
+    };
+
+    let rafId = 0;
+    let start = 0;
+
+    const tick = (ts: number) => {
+      if (!start) start = ts;
+      const elapsed = (ts - start) / 1000;
+      const p = (elapsed % durationSec) / durationSec; // 0..1 loop
+      drawFrame2D(ctx, w, h, p, opts);
+      rafId = requestAnimationFrame(tick);
+    };
+
+    if (paused) {
+      // Draw a single static frame so the card isn't blank while paused.
+      drawFrame2D(ctx, w, h, 0, opts);
+    } else {
+      rafId = requestAnimationFrame(tick);
+    }
+
+    return () => cancelAnimationFrame(rafId);
+  }, [style, colors, durationSec, paused]);
+
+  return <canvas ref={canvasRef} className={className} aria-hidden="true" />;
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button cursor-pointer inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/src/lib/generate2DFrames.ts
+++ b/src/lib/generate2DFrames.ts
@@ -181,6 +181,28 @@ function drawWave(ctx: CanvasRenderingContext2D, w: number, h: number, p: number
   ctx.fillRect(0, 0, w, h);
 }
 
+/**
+ * Draw a single frame of any 2D style directly to a canvas context.
+ * Used by live preview components (rAF loop) so they can animate a style
+ * without pre-generating and JPEG-encoding a full frame sequence.
+ * @param p progress 0..1 through the animation loop
+ */
+export function drawFrame2D(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  p: number,
+  opts: FrameOptions
+) {
+  ctx.clearRect(0, 0, w, h);
+  switch (opts.style) {
+    case "gradient":   drawGradient(ctx, w, h, p, opts);   break;
+    case "geometric":  drawGeometric(ctx, w, h, p, opts);  break;
+    case "particles":  drawParticles(ctx, w, h, p, opts);  break;
+    case "wave":       drawWave(ctx, w, h, p, opts);        break;
+  }
+}
+
 export async function generate2DFrames(opts: FrameOptions, onProgress?: (pct: number) => void): Promise<string[]> {
   const w = opts.width ?? 1280;
   const h = opts.height ?? 720;
@@ -193,13 +215,7 @@ export async function generate2DFrames(opts: FrameOptions, onProgress?: (pct: nu
   for (let i = 0; i < opts.frameCount; i++) {
     const p = i / (opts.frameCount - 1);
 
-    ctx.clearRect(0, 0, w, h);
-    switch (opts.style) {
-      case "gradient":   drawGradient(ctx, w, h, p, opts);   break;
-      case "geometric":  drawGeometric(ctx, w, h, p, opts);  break;
-      case "particles":  drawParticles(ctx, w, h, p, opts);  break;
-      case "wave":       drawWave(ctx, w, h, p, opts);       break;
-    }
+    drawFrame2D(ctx, w, h, p, opts);
 
     frames.push(canvas.toDataURL("image/jpeg", 0.85));
 

--- a/src/lib/generate2DFrames.ts
+++ b/src/lib/generate2DFrames.ts
@@ -212,8 +212,11 @@ export async function generate2DFrames(opts: FrameOptions, onProgress?: (pct: nu
   const ctx = canvas.getContext("2d")!;
   const frames: string[] = [];
 
+  // A single-frame sequence has no span to interpolate across; clamp so p stays 0 rather than NaN.
+  const lastIndex = Math.max(opts.frameCount - 1, 1);
+
   for (let i = 0; i < opts.frameCount; i++) {
-    const p = i / (opts.frameCount - 1);
+    const p = i / lastIndex;
 
     drawFrame2D(ctx, w, h, p, opts);
 


### PR DESCRIPTION
Carries the four commits that were left stranded on `fix/mobile-perf-navbar` after PR #160 was squash-merged, plus a bug-audit pass on top.

## Previously unmerged work
- `fix(#161)`: resolve all 8 bugs reported in the issue, plus the follow-up audit pass (cursor, auth error handling, CSP, env docs)
- `feat(auth)`: render only configured OAuth providers dynamically
- `feat(editor+create)`: live style previews, undo/redo, shortcuts, drag-drop

## New fixes in this PR

**Editor keyboard shortcuts saved and exported stale data.** The `keydown` listener was registered once with `react-hooks/exhaustive-deps` suppressed, so it closed over the mount-time `handleSave`/`handleExport`. Those read `sections`, `frames`, and `siteName` from their closure, meaning ⌘S persisted the original sections no matter what had been edited. The Save button was unaffected, which is why it went unnoticed. Handlers now resolve through a ref refreshed each render, and the suppression is gone.

**`setState` inside an effect on the home page** (the one `react-hooks/set-state-in-effect` lint error). `isMobileHero` was initialized `true` and corrected by an effect — a cascading render, and with no resize listener the hero never re-evaluated on rotate or resize. Replaced with `useSyncExternalStore` over `matchMedia`. The server snapshot stays mobile, so SSR still emits no frame URLs and the #156 request-storm fix holds.

**`StylePreview` froze near the first frame while recoloring.** `colors` sat in the effect dependency list, so each change tore down the `requestAnimationFrame` loop and reset progress to 0 — dragging a color picker restarted it continuously. Draw options now come from a ref, and canvas sizing moved to a `ResizeObserver` (it had been riding along on that same teardown).

**Divide-by-zero in `generate2DFrames`.** `i / (frameCount - 1)` is `NaN` when `frameCount === 1`, producing a blank frame. Denominator clamped.

**Dead code.** Removed 11 unused imports and a `menuOpen` state left behind by the shared Navbar refactor.

## Verification
`npm run lint` (0 problems, down from 1 error + 13 warnings) · `npx tsc --noEmit` clean · `npm test` 8/8 · `npm run build` succeeds, 34 static pages generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)