### PR TITLE
fix: grant credits on upgrade, show the price actually charged

### DIFF
--- a/src/__tests__/promoConsumption.test.ts
+++ b/src/__tests__/promoConsumption.test.ts
@@ -270,7 +270,7 @@ describe("verify — the promo use is consumed exactly once, at capture", () => 
     expect(dbMock.$executeRaw).toHaveBeenCalledTimes(1);
     expect(dbMock.user.update).toHaveBeenCalledWith({
       where: { id: "user_1" },
-      data: { plan: "PRO" },
+      data: { plan: "PRO", credits: 6000 },
     });
   });
 

--- a/src/__tests__/razorpayWebhook.test.ts
+++ b/src/__tests__/razorpayWebhook.test.ts
@@ -130,7 +130,7 @@ describe("Razorpay webhook — payment.captured", () => {
     });
     expect(dbMock.user.update).toHaveBeenCalledWith({
       where: { id: "user_1" },
-      data: { plan: "PRO" },
+      data: { plan: "PRO", credits: 6000 },
     });
     expect(dbMock.$executeRaw).toHaveBeenCalledTimes(1);
   });
@@ -175,7 +175,7 @@ describe("Razorpay webhook — payment.captured", () => {
 
     expect(dbMock.user.update).toHaveBeenCalledWith({
       where: { id: "user_1" },
-      data: { plan: "BASIC" },
+      data: { plan: "BASIC", credits: 1500 },
     });
   });
 
@@ -240,7 +240,7 @@ describe("Razorpay webhook — payment.captured with no local order row", () => 
     });
     expect(dbMock.user.update).toHaveBeenCalledWith({
       where: { id: "user_1" },
-      data: { plan: "PRO" },
+      data: { plan: "PRO", credits: 6000 },
     });
   });
 
@@ -263,7 +263,7 @@ describe("Razorpay webhook — payment.captured with no local order row", () => 
     });
     expect(dbMock.user.update).toHaveBeenCalledWith({
       where: { id: "user_1" },
-      data: { plan: "PRO" },
+      data: { plan: "PRO", credits: 6000 },
     });
   });
 
@@ -343,7 +343,7 @@ describe("Razorpay webhook — refunds", () => {
     });
     expect(dbMock.user.update).toHaveBeenCalledWith({
       where: { id: "user_1" },
-      data: { plan: "FREE" },
+      data: { plan: "FREE", credits: 100 },
     });
   });
 
@@ -361,7 +361,7 @@ describe("Razorpay webhook — refunds", () => {
     );
     expect(dbMock.user.update).toHaveBeenCalledWith({
       where: { id: "user_1" },
-      data: { plan: "BASIC_PLUS" },
+      data: { plan: "BASIC_PLUS", credits: 2500 },
     });
   });
 
@@ -407,7 +407,7 @@ describe("Razorpay webhook — refunds", () => {
 
     expect(dbMock.user.update).toHaveBeenCalledWith({
       where: { id: "user_1" },
-      data: { plan: "FREE" },
+      data: { plan: "FREE", credits: 100 },
     });
   });
 

--- a/src/app/api/chat-edit/route.ts
+++ b/src/app/api/chat-edit/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { auth } from "@/auth";
 import { rateLimit, getClientIp } from "@/lib/rateLimit";
+import { logger } from "@/lib/logger";
 
 const MAX_BODY_BYTES = 1_000_000;
 const MAX_MODEL_UPDATES = 50;
@@ -132,7 +133,9 @@ Only include updates that actually change something. Keep edits focused and rele
       },
       body: JSON.stringify({
         model: "claude-sonnet-4-6",
-        max_tokens: 1024,
+        // A response truncated by max_tokens is invalid JSON, which lands in the catch
+        // below and silently degrades to the rule-based path — give it room.
+        max_tokens: 4096,
         system: systemPrompt,
         messages: [{ role: "user", content: message }],
       }),
@@ -161,15 +164,19 @@ Only include updates that actually change something. Keep edits focused and rele
       message: (modelResponse.data.message ?? "").slice(0, 1000) || "Done!",
       updates,
     });
-  } catch {
-    return demoEdit(message, sections, selectedSectionId);
+  } catch (err) {
+    // Falling back to the keyword rules is good resilience, but doing it silently is
+    // not: the user asked the AI for an edit, got a rule-based one, and had no way to
+    // tell. Log it, and mark the response so the client can say the AI was unavailable.
+    logger.error("chat-edit: AI request failed, using rule-based fallback", { error: String(err) });
+    return demoEdit(message, sections, selectedSectionId, true);
   }
 }
 
-function demoEdit(message: string, sections: Section[], selectedSectionId: string) {
+function demoEdit(message: string, sections: Section[], selectedSectionId: string, aiUnavailable = false) {
   const lower = message.toLowerCase();
   const section = sections.find((s: Section) => s.id === selectedSectionId) || sections[0];
-  if (!section) return NextResponse.json({ message: "No section selected", updates: [] });
+  if (!section) return NextResponse.json({ message: "No section selected", updates: [], aiUnavailable });
 
   const updates: { id: string; field: string; value: string | number }[] = [];
   let reply = "";
@@ -216,5 +223,5 @@ function demoEdit(message: string, sections: Section[], selectedSectionId: strin
     reply = "I can help you change colors, text alignment, scroll height, headings, and button labels. Try: 'Make it purple', 'Center the text', 'Make the section taller'.";
   }
 
-  return NextResponse.json({ message: reply, updates });
+  return NextResponse.json({ message: reply, updates, aiUnavailable });
 }

--- a/src/app/api/payments/verify/route.ts
+++ b/src/app/api/payments/verify/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { consumePromoCode } from "@/lib/promo";
 import { rateLimit, getClientIp } from "@/lib/rateLimit";
+import { PLANS } from "@/lib/plans";
 
 // Conditional UPDATE so concurrent captures can never push uses past maxUses.
 export async function POST(req: NextRequest) {
@@ -68,7 +69,16 @@ export async function POST(req: NextRequest) {
       data: { razorpayPaymentId: paymentId, status: "CAPTURED" },
     });
     if (claimed.count > 0) {
-      if (newPlan) await db.user.update({ where: { id: user.id }, data: { plan: newPlan } });
+      if (newPlan) {
+        // Grant the plan's credit allowance. Nothing wrote `credits` anywhere, so it sat
+        // at the schema default of 100 forever — the dashboard computes used = max
+        // remaining, and a customer who had just paid for Pro was shown "5,900 / 6,000
+        // used" with 100 left.
+        await db.user.update({
+          where: { id: user.id },
+          data: { plan: newPlan, credits: PLANS[newPlan].credits },
+        });
+      }
       await consumePromoCode(payment.promoCode);
     }
 

--- a/src/app/api/webhooks/razorpay/route.ts
+++ b/src/app/api/webhooks/razorpay/route.ts
@@ -3,6 +3,7 @@ import crypto from "crypto";
 import Razorpay from "razorpay";
 import { db } from "@/lib/db";
 import { consumePromoCode } from "@/lib/promo";
+import { PLANS } from "@/lib/plans";
 
 const PLAN_MAP: Record<string, "BASIC" | "BASIC_PLUS" | "PRO" | "PREMIUM"> = {
   Basic: "BASIC", "Basic Plus": "BASIC_PLUS", Pro: "PRO", Premium: "PREMIUM",
@@ -40,14 +41,25 @@ async function repriceUserPlan(userId: string) {
     select: { plan: true },
   });
   const nextPlan = (latest ? PLAN_MAP[latest.plan] : undefined) ?? "FREE";
-  await db.user.update({ where: { id: userId }, data: { plan: nextPlan } });
+  // Reprice the credit allowance with the plan — otherwise a user refunded from
+  // Premium down to Basic Plus keeps Premium's 25,000 credits.
+  await db.user.update({
+    where: { id: userId },
+    data: { plan: nextPlan, credits: PLANS[nextPlan].credits },
+  });
 }
 
 // Conditional UPDATE so concurrent captures can never push uses past maxUses.
 async function applyPlan(userId: string, planName: string | null | undefined) {
   const newPlan = planName ? PLAN_MAP[planName] : undefined;
   if (newPlan) {
-    await db.user.update({ where: { id: userId }, data: { plan: newPlan } });
+    // Grant credits alongside the plan — the webhook is the path that runs when the
+    // browser never returns from checkout, so omitting them here leaves exactly the
+    // same "paid but shows 100 credits left" state as the verify route did.
+    await db.user.update({
+      where: { id: userId },
+      data: { plan: newPlan, credits: PLANS[newPlan].credits },
+    });
   }
 }
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import {
   Zap, Globe, Download, Loader2
 } from "lucide-react";
 import Navbar from "@/components/Navbar";
+import { planByKey } from "@/lib/plans";
 
 interface Site {
   id: string;
@@ -22,13 +23,6 @@ interface Site {
   updatedAt: string;
 }
 
-const PLANS: Record<string, { label: string; maxCredits: number; color: string }> = {
-  FREE:       { label: "Free Trial", maxCredits: 100,   color: "text-muted-foreground" },
-  BASIC:      { label: "Basic",      maxCredits: 1500,  color: "text-blue-400" },
-  BASIC_PLUS: { label: "Basic Plus", maxCredits: 3000,  color: "text-cyan-400" },
-  PRO:        { label: "Pro",        maxCredits: 6000,  color: "text-primary" },
-  PREMIUM:    { label: "Premium",    maxCredits: 25000, color: "text-amber-400" },
-};
 
 export default function DashboardPage() {
   const { data: session, status } = useSession();
@@ -38,8 +32,8 @@ export default function DashboardPage() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [exportCount, setExportCount] = useState(0);
   const userPlanKey = (session?.user?.plan ?? "FREE") as string;
-  const plan = PLANS[userPlanKey] ?? PLANS.FREE;
-  const totalCredits = plan.maxCredits;
+  const plan = planByKey(userPlanKey);
+  const totalCredits = plan.credits;
   // credits in the DB is the *remaining* balance; used = max - remaining
   const remainingCredits = session?.user?.credits ?? 0;
   const usedCredits = Math.max(0, totalCredits - remainingCredits);

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Check, Minus, Sparkles, Zap, Loader2, Tag, X } from "lucide-react";
 import { toast } from "sonner";
 import Navbar from "@/components/Navbar";
+import { planByName, formatINR } from "@/lib/plans";
 
 const PLANS = [
   {
@@ -191,6 +192,21 @@ function loadRazorpayScript(): Promise<void> {
     script.onerror = () => reject(new Error("Failed to load Razorpay"));
     document.head.appendChild(script);
   });
+}
+
+// Displayed prices must match what create-order actually charges. The page rendered
+// dollar amounts ("$200/mo") against a Razorpay order billed in INR (₹14,999) — the
+// wrong symbol and a different number at the moment of payment.
+function priceLabel(name: string, annual: boolean): string {
+  const p = planByName(name);
+  if (!p) return "—";
+  const paise = annual ? p.annualPaise : p.monthlyPaise;
+  return paise === 0 ? "Free" : formatINR(paise);
+}
+
+function annualTotalLabel(name: string): string {
+  const p = planByName(name);
+  return p ? formatINR(p.annualPaise * 12) : "—";
 }
 
 export default function PricingPage() {
@@ -382,13 +398,13 @@ export default function PricingPage() {
               <div>
                 <div className="flex items-end gap-1">
                   <span className="text-4xl font-black tracking-tighter">
-                    ${annual ? plan.annual : plan.monthly}
+                    {priceLabel(plan.name, annual)}
                   </span>
                   <span className="text-muted-foreground text-sm mb-1">/mo</span>
                 </div>
                 {plan.annual > 0 && annual && (
                   <p className="text-xs text-muted-foreground mt-0.5">
-                    Billed ${plan.annual * 12}/yr
+                    Billed {annualTotalLabel(plan.name)}/yr
                   </p>
                 )}
                 {plan.annual === 0 && (

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,0 +1,67 @@
+/**
+ * Single source of truth for plan pricing and credit allowances.
+ *
+ * These lived in three places that had already drifted apart: the pricing page
+ * rendered dollar amounts while the order endpoint charged rupees, and the
+ * dashboard's credit denominator for Basic Plus did not match the number the
+ * pricing page advertised. Anything that shows a price or a credit allowance
+ * reads it from here.
+ */
+
+export type PlanKey = "FREE" | "BASIC" | "BASIC_PLUS" | "PRO" | "PREMIUM";
+
+export interface Plan {
+  key: PlanKey;
+  /** Display name, and the value the checkout API expects as `plan`. */
+  name: string;
+  label: string;
+  /** Charged amounts in INR paise — what Razorpay actually bills. */
+  monthlyPaise: number;
+  /** Per-month rate when billed annually; the annual charge is 12x this. */
+  annualPaise: number;
+  /** Credits granted for the billing period. */
+  credits: number;
+  color: string;
+}
+
+export const PLANS: Record<PlanKey, Plan> = {
+  FREE: {
+    key: "FREE", name: "Free Trial", label: "Free Trial",
+    monthlyPaise: 0, annualPaise: 0, credits: 100,
+    color: "text-muted-foreground",
+  },
+  BASIC: {
+    key: "BASIC", name: "Basic", label: "Basic",
+    monthlyPaise: 199900, annualPaise: 159900, credits: 1500,
+    color: "text-blue-400",
+  },
+  BASIC_PLUS: {
+    key: "BASIC_PLUS", name: "Basic Plus", label: "Basic Plus",
+    monthlyPaise: 299900, annualPaise: 239900, credits: 2500,
+    color: "text-cyan-400",
+  },
+  PRO: {
+    key: "PRO", name: "Pro", label: "Pro",
+    monthlyPaise: 499900, annualPaise: 399900, credits: 6000,
+    color: "text-primary",
+  },
+  PREMIUM: {
+    key: "PREMIUM", name: "Premium", label: "Premium",
+    monthlyPaise: 1499900, annualPaise: 1199900, credits: 25000,
+    color: "text-amber-400",
+  },
+};
+
+/** Maps the display name used by the checkout API back to a plan. */
+export function planByName(name: string): Plan | undefined {
+  return Object.values(PLANS).find((p) => p.name.toLowerCase() === name.trim().toLowerCase());
+}
+
+export function planByKey(key: string | null | undefined): Plan {
+  return PLANS[(key ?? "FREE") as PlanKey] ?? PLANS.FREE;
+}
+
+/** Formats paise as the rupee amount a customer is actually charged. */
+export function formatINR(paise: number): string {
+  return `₹${Math.round(paise / 100).toLocaleString("en-IN")}`;
+}


### PR DESCRIPTION
> Stacked on `fix/loop-round1` (PR #167). Merge #166 → #167 → this.

Two audits — the export generator, and the chat/dashboard/pricing flows. This PR fixes the money-facing findings; the rest are listed at the bottom as follow-up.

## Customers who paid were shown almost no credits

**Nothing in the codebase ever wrote `User.credits`.** `grep -rn credits src/app/api/` returns nothing — it sat at the schema default of `100` for every user forever. The dashboard derives *used* as allowance minus remaining, so someone who had just paid ₹4,999 for Pro saw:

> **5,900 / 6,000 credits used** · 98%-full progress bar · "100 credits remaining this month"

with no UI path to recover. Both capture paths now grant the plan's allowance: the verify endpoint, and the webhook that runs when the browser never makes it back from checkout.

**Refunds repriced the plan but not the allowance** — a user refunded from Premium down to Basic Plus kept Premium's 25,000 credits. Repricing now moves both, including the drop to FREE.

## The pricing page showed the wrong currency *and* the wrong number

The page rendered `$` while `create-order` charges INR, and the amounts weren't conversions of each other:

| Plan | Page displayed | Razorpay actually charged |
|---|---|---|
| Basic | $25/mo | ₹1,999/mo |
| Premium | $200/mo | ₹14,999/mo |
| Basic (annual) | "Billed $240/yr" | ₹19,188/yr |

Prices now render in INR, derived from the same table the order endpoint bills from.

## One root cause behind all three

Three separate plan tables that had drifted. Basic Plus advertised **2,500** credits on the pricing page and **3,000** in the dashboard's denominator. `src/lib/plans.ts` is now the single source for plan names, charged amounts, and credit allowances; the pricing page, dashboard, verify route, and webhook all read from it.

## chat-edit failed silently into the demo editor

Every AI failure landed in a bare `catch {}` that returned the keyword-matching `demoEdit`. A bad API key, a 429, a 30-second timeout, or a `max_tokens`-truncated response all produced a cheerful **"Done!"** with a rule-based edit — nothing logged, no way for the user to know the AI never ran. Failures are now logged and flagged to the client, and `max_tokens` went 1024 → 4096 so a longer edit doesn't truncate into that path.

## The tests caught the change

Six assertions pinned the exact `db.user.update` payload and failed the moment credits were added. Updated to *require* the grant, so silently dropping it again breaks the build.

## Verification

`npm run lint` clean · `npx tsc --noEmit` clean · `npm test` 116/116 · `npm run build` succeeds.

## Not fixed here — follow-up

**Export generator** (severe, worth its own PR): hidden sections are exported (a section toggled off still ships its text and inflates the scroll track); the scroll→frame denominator ignores the 100vh spacer, so on viewports taller than 1000px the animation finishes early — and with one short section it never advances past frame 0; `preload()` downloads **both** desktop and mobile frame sets unconditionally (~70MB on cellular for a 240-frame export); exported audio can never start, because `play()` is only attempted from a scroll handler, which is not a user-activation gesture; Lenis is loaded from jsDelivr with no SRI on every customer's own domain.

**Client error handling:** the dashboard and editor read `data.updates` / `data.sites` without checking `res.ok`, so a 401/429/400 renders as success or as an empty state — the 409 `HAS_PURCHASE` message added in #167 is currently unreachable for the same reason.

**Unmetered AI:** chat-edit has no per-user quota despite being sold per-plan, and embeds the full sections array twice in the system prompt.

**`og-image.png` referenced in metadata does not exist** — every social share renders with no preview.