### PR TITLE
fix: stop rendering API failures as success on the client

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -29,6 +29,7 @@ export default function DashboardPage() {
   const router = useRouter();
   const [sites, setSites] = useState<Site[]>([]);
   const [sitesLoading, setSitesLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [exportCount, setExportCount] = useState(0);
   const userPlanKey = (session?.user?.plan ?? "FREE") as string;
@@ -44,14 +45,25 @@ export default function DashboardPage() {
 
   useEffect(() => {
     if (status !== "authenticated") return;
+    // A failed load used to parse fine (the body is valid JSON, just `{error}`), so
+    // `sites` stayed empty, the catch never ran, and a user with sites was shown the
+    // "no sites yet" empty state. Reject on a non-ok status so failure is visible.
     Promise.all([
-      fetch("/api/sites").then(r => r.json()),
-      fetch("/api/user/stats").then(r => r.json()).catch(() => ({})),
+      fetch("/api/sites").then(async r => {
+        if (!r.ok) throw new Error("sites");
+        return r.json();
+      }),
+      fetch("/api/user/stats")
+        .then(r => (r.ok ? r.json() : {}))
+        .catch(() => ({})) as Promise<{ exportCount?: number }>,
     ]).then(([sitesData, statsData]) => {
-      if (sitesData.sites) setSites(sitesData.sites);
+      setSites(Array.isArray(sitesData.sites) ? sitesData.sites : []);
       if (typeof statsData.exportCount === "number") setExportCount(statsData.exportCount);
-    }).catch(() => toast.error("Failed to load dashboard"))
-      .finally(() => setSitesLoading(false));
+      setLoadFailed(false);
+    }).catch(() => {
+      setLoadFailed(true);
+      toast.error("Couldn't load your sites. Refresh to try again.");
+    }).finally(() => setSitesLoading(false));
   }, [status]);
 
   const deleteSite = async (id: string) => {
@@ -59,7 +71,13 @@ export default function DashboardPage() {
     setDeletingId(id);
     try {
       const res = await fetch(`/api/sites/${id}`, { method: "DELETE" });
-      if (!res.ok) throw new Error();
+      if (!res.ok) {
+        // Throwing away the body made the 409 "this site has a purchased export"
+        // unreachable — the user saw "Failed to delete" and retried forever.
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.error || "Failed to delete site");
+        return;
+      }
       setSites(prev => prev.filter(s => s.id !== id));
       toast.success("Site deleted");
     } catch {
@@ -155,6 +173,16 @@ export default function DashboardPage() {
           {sitesLoading ? (
             <div className="flex items-center justify-center py-12">
               <Loader2 className="w-6 h-6 text-primary animate-spin" />
+            </div>
+          ) : loadFailed ? (
+            // Distinct from the empty state: telling someone with 12 sites to "create
+            // their first" is worse than telling them the load failed.
+            <div className="text-center py-20 rounded-2xl border border-dashed border-amber-500/30">
+              <p className="font-medium mb-1">Couldn&apos;t load your sites</p>
+              <p className="text-sm text-muted-foreground mb-4">Your sites are safe — this is a loading problem.</p>
+              <Button className="bg-primary text-white" onClick={() => window.location.reload()}>
+                Try again
+              </Button>
             </div>
           ) : sites.length === 0 ? (
             <div className="text-center py-20 rounded-2xl border border-dashed border-white/10">

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -514,7 +514,17 @@ function EditorInner() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: text, sections, selectedSectionId: selectedSection }),
       });
-      const data = await res.json();
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        // The route returns {error} with no message/updates for 401, 429, 400 and 413.
+        // Reading straight through rendered every one of those as a cheerful "Done!"
+        // while nothing changed — reachable from a long chat message or a big section.
+        setChatMessages(m => [...m, { role: "ai", text: data.error || "That didn't go through. Try again." }]);
+        return;
+      }
+      if (data.aiUnavailable) {
+        setChatMessages(m => [...m, { role: "ai", text: "The AI is unavailable right now — I applied a basic edit instead." }]);
+      }
       if (data.updates?.length) {
         // Route through commitSections so AI edits are a single undoable step.
         commitSections(prev => prev.map(s => {

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -268,29 +268,48 @@ export default function PricingPage() {
         name: "ScrollCraft",
         description: `${planName} plan — ${annual ? "Annual" : "Monthly"}`,
         theme: { color: "#7c3aed" },
+        // The user has already been charged by the time this runs, so nothing in here
+        // may throw unhandled — an unhandled rejection left them with no toast, no
+        // redirect and no way to know whether the payment landed.
         handler: async (response: { razorpay_order_id: string; razorpay_payment_id: string; razorpay_signature: string }) => {
-          const verifyRes = await fetch("/api/payments/verify", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              orderId: response.razorpay_order_id,
-              paymentId: response.razorpay_payment_id,
-              signature: response.razorpay_signature,
-            }),
-          });
-          const verifyData = await verifyRes.json();
-          if (verifyData.success) {
-            toast.success(`${planName} activated! Welcome aboard.`);
-            window.location.href = `/create?plan=${encodeURIComponent(planName)}`;
-          } else {
-            toast.error("Payment verification failed. Contact support.");
+          try {
+            const verifyRes = await fetch("/api/payments/verify", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                orderId: response.razorpay_order_id,
+                paymentId: response.razorpay_payment_id,
+                signature: response.razorpay_signature,
+              }),
+            });
+            const verifyData = await verifyRes.json().catch(() => ({}));
+            if (verifyRes.ok && verifyData.success) {
+              toast.success(`${planName} activated! Welcome aboard.`);
+              window.location.href = `/create?plan=${encodeURIComponent(planName)}`;
+              return;
+            }
+            // Surface the reason the server gave instead of one generic string.
+            toast.error(
+              verifyData.error
+                ? `${verifyData.error} Your payment went through — contact support if this persists.`
+                : "We couldn't confirm your payment. Contact support with your payment ID."
+            );
+          } catch {
+            toast.error("Your payment went through but we couldn't confirm it. Contact support before paying again.");
+          } finally {
+            setCheckingOut(null);
           }
+        },
+        modal: {
+          // Without this the button left its "Processing…" state as soon as the modal
+          // opened, so dismissing and clicking again created more orders — five cycles
+          // hit the 5/hour create-order limit and locked the user out of buying at all.
+          ondismiss: () => setCheckingOut(null),
         },
       });
       rzp.open();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Checkout failed");
-    } finally {
       setCheckingOut(null);
     }
   };


### PR DESCRIPTION
Three client fetches read their response body without checking the status. Both outcomes are valid JSON — a failure body is just `{error}` — so the parse succeeded, the `catch` never ran, and every failure surfaced as success.

**The dashboard showed "No sites yet" to users who have sites.** A failed `/api/sites` load left `sites` as `[]` and the catch never fired, so someone with a dozen sites got the empty state and a "Create your first site" button. Failure is now distinct from empty, with a retry.

**Deleting a site discarded the response body**, which made the 409 `HAS_PURCHASE` message added in #167 unreachable — the user was told it *failed* rather than that it *cannot succeed*, so they retried forever.

**The editor's chat rendered every API error as "Done!"** `/api/chat-edit` returns `{error}` with no `message` and no `updates` for 401, 429, 400 and 413 — the client read `data.message || "Done!"` and cheerfully reported success while nothing changed. All reachable from normal use: a chat message over 2000 chars, a section body over 5000, or the 20/min rate limit. It now shows the server's reason, and surfaces the rule-based fallback instead of passing it off as an AI edit.

**The Razorpay handler runs after the customer has been charged, and nothing in it was guarded.** A network blip on the verify call — or a 500 with a non-JSON body — rejected unhandled: no toast, no redirect, no way to tell whether the payment landed. It's now wrapped, reports the server's actual reason instead of one generic string, and always tells the user their payment went through.

**The checkout button re-enabled while the modal was still open.** `setCheckingOut(null)` ran in `finally`, immediately after `rzp.open()`. Dismissing and clicking again created additional orders; five cycles hit the 5/hour `create-order` limit and locked the user out of buying anything at all. It now clears on the modal's `ondismiss` and after verification.

## Verification

`npm run lint` clean · `npx tsc --noEmit` clean · `npm test` 116/116 · `npm run build` succeeds.