### PR TITLE
fix: confirm site deletion, and stop advertising an OG image that 404s

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -31,6 +31,10 @@ export default function DashboardPage() {
   const [sitesLoading, setSitesLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  // Two-click confirm, matching the editor's existing pattern. The trash button sits
+  // directly beside Edit in the hover row, and one misclick permanently destroyed the
+  // site and its stored frames with no undo.
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [exportCount, setExportCount] = useState(0);
   const userPlanKey = (session?.user?.plan ?? "FREE") as string;
   const plan = planByKey(userPlanKey);
@@ -68,6 +72,14 @@ export default function DashboardPage() {
 
   const deleteSite = async (id: string) => {
     if (deletingId) return;
+    if (pendingDeleteId !== id) {
+      setPendingDeleteId(id);
+      // Reset if they do not confirm, so the armed state cannot linger and catch a
+      // later stray click.
+      window.setTimeout(() => setPendingDeleteId(cur => (cur === id ? null : cur)), 4000);
+      return;
+    }
+    setPendingDeleteId(null);
     setDeletingId(id);
     try {
       const res = await fetch(`/api/sites/${id}`, { method: "DELETE" });
@@ -217,11 +229,13 @@ export default function DashboardPage() {
                       variant="outline"
                       onClick={() => deleteSite(site.id)}
                       disabled={deletingId === site.id}
-                      className="border-white/10 h-7 w-7 p-0 hover:border-destructive hover:text-destructive"
+                      className={`border-white/10 h-7 p-0 hover:border-destructive hover:text-destructive ${pendingDeleteId === site.id ? "w-12 border-destructive text-destructive" : "w-7"}`}
                     >
                       {deletingId === site.id
                         ? <Loader2 className="w-3 h-3 animate-spin" />
-                        : <Trash2 className="w-3 h-3" />}
+                        : pendingDeleteId === site.id
+                          ? <span className="text-[10px] font-semibold px-1">Sure?</span>
+                          : <Trash2 className="w-3 h-3" />}
                     </Button>
                   </div>
                 </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,13 +25,14 @@ export const metadata: Metadata = {
     siteName: "ScrollCraft",
     title: "ScrollCraft — AI Scroll Sites",
     description: "Build immersive 2D scroll websites with animated canvas backgrounds. No code needed.",
-    images: [{ url: "/og-image.png", width: 1200, height: 630, alt: "ScrollCraft" }],
+    // No images key: src/app/opengraph-image.tsx generates the real 1200x630 card and
+    // Next wires it up automatically. The hardcoded /og-image.png overrode that with a
+    // file that does not exist, so every share rendered with no preview.
   },
   twitter: {
     card: "summary_large_image",
     title: "ScrollCraft — AI Scroll Sites",
     description: "Build immersive 2D scroll websites with animated canvas backgrounds. No code needed.",
-    images: ["/og-image.png"],
   },
   robots: { index: true, follow: true },
 };


### PR DESCRIPTION
**Deleting a site fired on a single click.** The trash button sits directly beside Edit in the hover row, and there is no undo — one misclick permanently removed the site, its sections, and its stored frames. The editor already guards its own delete with a two-click confirm; the dashboard now uses the same pattern, and disarms after a few seconds so the armed state can't catch a later stray click.

**The metadata advertised `/og-image.png`, which doesn't exist** — `public/` contains only the five default SVGs. Every share of any ScrollCraft URL on Slack, X, or LinkedIn resolved that to a 404 and rendered with no preview image.

The fix is a deletion, not a new asset: `src/app/opengraph-image.tsx` **already generates a real 1200×630 card**, and Next wires it up automatically through the file convention. The hardcoded `images` key was overriding it with a path that was never there.

Verified against a running server — `og:image` now resolves to `/opengraph-image`, which returns `200 image/png`:

```
<meta property="og:image" content="http://localhost:3000/opengraph-image?290b346c82d14d31"/>
<meta property="og:image:type" content="image/png"/>
<meta property="og:image:width" content="1200"/>
```

## Verification

`npm run lint` clean · `npx tsc --noEmit` clean · `npm test` 116/116 · `npm run build` succeeds.