### PR TITLE
chore: add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: singhharsh1708

--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ prisma/
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow,
 coding standards, and how to pick up an issue.
 
+## Sponsor
+
+ScrollCraft is free and open source, and the hosted version costs real money to run
+(model calls, frame rendering, storage). If it saved you a studio invoice, you can
+[sponsor the project on GitHub](https://github.com/sponsors/singhharsh1708), one-off or
+monthly. Sponsoring is separate from the paid plans: it funds the open source work, not an
+account upgrade.
+
+Not in a position to pay? Starring the repo, filing a good bug report, or shipping a PR
+helps just as much.
+
 ## License
 
 [MIT](LICENSE) © ScrollCraft


### PR DESCRIPTION
# Description

Adds `.github/FUNDING.yml` so the repo shows a **Sponsor** button, pointing at the GitHub Sponsors listing (`github.com/sponsors/singhharsh1708`, live and public). Also adds a short `## Sponsor` section to the README between Contributing and License.

The README wording keeps sponsorship distinct from the Razorpay / Lemon Squeezy plans, so nobody reads a sponsorship as an account upgrade.

GitHub Sponsors only. No Ko-fi / Patreon / custom links.

## Type of change

- [x] 🔧 Chore / tooling
- [x] 📝 Documentation

## Checklist

- [x] I updated docs / `.env.example` if config or env vars changed

Docs and config only, no application code touched, so lint / tsc / test / build are unaffected.