### PR TITLE
fix: use list form for the GitHub Sponsors funding entry

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: singhharsh1708
+github: [singhharsh1708]


### PR DESCRIPTION
# Description

The Sponsor card still did not render after #176 merged and the repo's Sponsorships feature was enabled. GitHub's `fundingLinks` for this repo reported an empty list and the repo home page had no "Sponsor this project" card, while kitbash (same owner, same sponsors listing) rendered both.

The one remaining difference was the YAML shape: kitbash uses the list form, this repo used a bare scalar. Switching to the list form to match the working config.

## Type of change

- [x] 🔧 Chore / tooling

## Checklist

- [x] I updated docs / `.env.example` if config or env vars changed

Single config line, no application code touched.