### PR TITLE
feat(skill): ship ScrollCraft as a Claude Code plugin alongside the hosted app

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "scrollcraft",
+  "description": "Cinematic scroll-driven websites, as a Claude Code skill and as a hosted builder.",
+  "owner": {
+    "name": "Harsh Singh",
+    "url": "https://github.com/singhharsh1708"
+  },
+  "plugins": [
+    {
+      "name": "scrollcraft",
+      "description": "Build scroll-scrubbed canvas websites from a video or image sequence, and export a self-contained static site.",
+      "source": "./plugins/scrollcraft",
+      "category": "web-design"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,61 @@ ScrollCraft removes all of that. You:
 - 💳 **Payments** — Razorpay subscriptions (INR) + Lemon Squeezy one‑time export purchases (global).
 - 🔒 **Production‑grade** — rate limiting, structured logging, security headers, Sentry, Zod‑validated APIs.
 
+## Two ways to use ScrollCraft
+
+**Hosted app** — describe a vibe, get generated frames, edit visually, export a ZIP. Best when
+you have no footage. See [Getting started](#getting-started) to run it.
+
+**Claude Code skill** — build the same kind of site on your machine, from your own video, with
+the whole thing in version control. No account, no server, no payment. Best when you already
+have footage.
+
+Both emit the identical bundle layout (`index.html` + `frames/frame_0000.jpg` upward), so a
+site built by the skill opens in the hosted editor and an exported ZIP can be rebuilt by the
+skill.
+
+### Installing the skill
+
+This repository is also a Claude Code plugin marketplace. From inside Claude Code:
+
+```
+/plugin marketplace add singhharsh1708/scrollcraft
+/plugin install scrollcraft@scrollcraft
+```
+
+Then just describe what you want — "build me a scroll site from hero.mp4" — and the skill
+activates. To confirm it registered, run `/plugin` and look for `scrollcraft`.
+
+Updating later:
+
+```
+/plugin marketplace update scrollcraft
+```
+
+### What the skill does
+
+`ffmpeg` is the only external requirement (`brew install ffmpeg`, or `apt install ffmpeg`).
+
+```bash
+# 1. video -> frame sequence, desktop + mobile
+node scripts/frames-from-video.mjs --input hero.mp4 --out frames \
+  --fps 24 --width 1920 --mobile-width 828 --mobile-out frames-mobile
+
+# 2. write scrollcraft.json describing your sections, then build
+node scripts/build-site.mjs --spec scrollcraft.json --out dist
+
+# 3. check it before shipping, then look at it
+node scripts/doctor.mjs --spec scrollcraft.json
+node scripts/serve.mjs --dir dist --port 4321
+```
+
+`dist/` is a static directory with no runtime dependencies and no external requests. Deploy it
+anywhere.
+
+Skill source lives in [plugins/scrollcraft/](plugins/scrollcraft/); the bundle invariants both
+halves rely on are written down in
+[references/export-contract.md](plugins/scrollcraft/skills/scrollcraft/references/export-contract.md).
+
 ## Tech stack
 
 | Layer | Technology |

--- a/plugins/scrollcraft/.claude-plugin/plugin.json
+++ b/plugins/scrollcraft/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "scrollcraft",
+  "description": "Build cinematic scroll-driven websites. Turns a video or image sequence into a scroll-scrubbed canvas site and emits a self-contained static bundle, using the same output contract as the ScrollCraft hosted builder.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Harsh Singh",
+    "url": "https://github.com/singhharsh1708"
+  },
+  "homepage": "https://github.com/singhharsh1708/scrollcraft",
+  "license": "MIT"
+}

--- a/plugins/scrollcraft/skills/scrollcraft/SKILL.md
+++ b/plugins/scrollcraft/skills/scrollcraft/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: scrollcraft
+description: >
+  Build a cinematic scroll-driven website where scrolling scrubs a canvas frame sequence,
+  Apple-product-page style, and emit a self-contained static bundle that deploys to any
+  host with zero runtime dependencies. Turns a video or an existing image sequence into
+  frames, pins copy over them in sticky sections, and verifies the result before shipping.
+  Use for: "scroll animation site", "scroll-scrubbed video", "Apple-style scroll page",
+  "scrollytelling landing page", "frame sequence website", "cinematic landing page".
+---
+
+# ScrollCraft
+
+Scroll position drives a frame sequence painted on a fixed full-viewport canvas. Copy sits
+in sticky sections above it, so text stays pinned while the background scrubs. Output is
+`index.html` plus a `frames/` directory: no framework, no bundler, no runtime dependency.
+
+This skill builds sites locally. The hosted builder at
+https://github.com/singhharsh1708/scrollcraft additionally generates frame sequences from a
+text prompt, offers a visual editor with AI chat editing, and hosts the result. Both emit
+the same bundle layout, so a site built here can be opened in the hosted editor and vice
+versa. Reach for the hosted product when the user has no footage; use this skill when they
+have footage, or want the whole thing on disk and in version control.
+
+## Workflow
+
+Work in a dedicated directory. Every script lives in `${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/`.
+
+### 1. Establish the source material
+
+Three cases:
+
+- **User has a video.** Best case. Short, slow, continuous camera motion works; hard cuts do not, because the scrub reads as a glitch. 4 to 12 seconds is the useful range.
+- **User has a numbered image sequence.** Rename to `frame_0000.jpg` upward, gap-free, and skip to step 3.
+- **User has nothing.** Do not fabricate footage. Say plainly that a frame sequence is required and point at the hosted builder, which generates one from a prompt.
+
+Never invent a video file. If the path does not exist, stop and ask.
+
+### 2. Extract frames
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/frames-from-video.mjs" \
+  --input hero.mp4 --out frames --fps 24 --width 1920 \
+  --mobile-width 828 --mobile-out frames-mobile
+```
+
+Always build the mobile set. Without it phones download full-width desktop frames, which
+is the single most common way one of these sites becomes unusable on cellular.
+
+Budget: frame count is `fps × seconds`. At 24fps a 10-second clip is 240 frames; at roughly
+150KB each that is ~36MB for the desktop set alone. Keep the pair under ~60MB total. Cut
+`--fps` before cutting `--width`, the eye forgives a lower frame rate more readily than a
+soft image.
+
+### 3. Author the spec
+
+Write `scrollcraft.json`. See `references/site-spec.md` for every field. Minimum:
+
+```json
+{
+  "name": "Orrery",
+  "description": "A precision instrument for people who measure things.",
+  "sections": [
+    { "eyebrow": "Introducing", "heading": "Orrery", "body": "Machined from one billet.", "scrollHeight": 1400 },
+    { "heading": "Nothing wasted", "body": "Eleven parts. Each one load bearing.", "scrollHeight": 1200 },
+    { "heading": "Yours", "ctaLabel": "Pre-order", "ctaHref": "https://example.com/buy", "scrollHeight": 900 }
+  ]
+}
+```
+
+Section count and `scrollHeight` set the pace. The whole scroll track is
+`Σ scrollHeight + 1000`, and the frame sequence is mapped across it linearly, so a section
+with double the height gets double the frames. Give the moments that matter more room.
+Below ~400px of track a section flashes past unread.
+
+### 4. Build
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/build-site.mjs" \
+  --spec scrollcraft.json --out dist
+```
+
+Emits `dist/index.html`, `dist/frames/`, and `dist/frames-mobile/` plus `dist/audio.<ext>`
+when the spec names audio. All CSS and JS is inlined into the one HTML file.
+
+### 5. Verify before claiming it works
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/doctor.mjs" --spec scrollcraft.json
+node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/serve.mjs" --dir dist --port 4321
+```
+
+`doctor` exits non-zero on a real problem: gapped frame sequence, empty spec, missing audio,
+non-positive `scrollHeight`. Fix those before reporting success. It also warns on heavy
+frame payloads and missing mobile sets, which are judgement calls, not failures.
+
+Then actually look at the page. Load `http://127.0.0.1:4321`, scroll it, and confirm the
+background advances and the copy pins. A frame sequence that 404s renders as a black canvas
+with no error, so "the build succeeded" is not evidence the site works.
+
+### 6. Deploy
+
+`dist/` is a static directory. Any host serves it as-is. Do not add a build step.
+
+## Craft notes
+
+These are what separate a convincing scroll site from an obviously generated one.
+
+- **One idea per section.** A heading and at most two lines. The reader is scrolling, not studying.
+- **Let the footage breathe.** Sections that fire every 600px feel frantic. Long quiet stretches with no copy are correct and confident.
+- **Match copy to motion.** If the camera pushes in on section three, that is where the product name belongs.
+- **Accent colour, once.** `accentColor` on the eyebrow and the CTA, nowhere else.
+- **Contrast against the frames, not against black.** Light text over a bright frame is unreadable no matter what the palette says. Check the actual frames the copy sits over.
+- **Respect reduced motion.** The engine already disables the reveal transitions under `prefers-reduced-motion`. Do not add motion the setting cannot turn off.
+
+## Constraints
+
+- Frames must be `frame_NNNN.jpg`, zero-padded to 4, starting at `0000`, gap-free. The build refuses a gapped sequence rather than shipping a stutter.
+- Audio extensions are limited to mp3, m4a, wav, ogg, webm, aac, flac. Anything else is rejected, because static hosts serve unknown types as `application/octet-stream` and the browser silently declines to decode them.
+- Audio starts muted and only plays after a real user gesture. Autoplay with sound is blocked by every current browser, so do not present it as a feature that works unprompted.
+- `customCss` in the spec is filtered for `<script`, `<style`, `javascript:`/`data:` URLs and `expression(`. Treat it as a styling hook, not an extension point.

--- a/plugins/scrollcraft/skills/scrollcraft/engine/scrollcraft.css
+++ b/plugins/scrollcraft/skills/scrollcraft/engine/scrollcraft.css
@@ -1,0 +1,28 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: auto; }
+body { background: #000; color: #fff; font-family: system-ui, sans-serif; overflow-x: hidden; }
+#scroll-canvas { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
+#scroll-container { position: relative; z-index: 1; pointer-events: none; }
+.scroll-section { pointer-events: none; }
+.section-sticky { pointer-events: none; }
+.section-content { pointer-events: auto; }
+.section-content.visible { opacity: 1 !important; transform: translateY(0) !important; }
+#scroll-hint {
+  position: fixed; bottom: 2rem; left: 50%; transform: translateX(-50%);
+  display: flex; flex-direction: column; align-items: center; gap: 0.5rem;
+  color: rgba(255,255,255,0.4); font-size: 0.75rem; letter-spacing: 0.1em;
+  text-transform: uppercase; z-index: 20; transition: opacity 0.5s;
+}
+#scroll-hint .arrow { width: 1px; height: 40px; background: linear-gradient(to bottom, transparent, rgba(255,255,255,0.4)); }
+#audio-mute {
+  position: fixed; top: 1rem; right: 1rem; z-index: 30;
+  background: rgba(0,0,0,0.5); border: 1px solid rgba(255,255,255,0.15);
+  color: #fff; border-radius: 50%; width: 2rem; height: 2rem;
+  cursor: pointer; font-size: 1rem; display: flex; align-items: center; justify-content: center;
+  transition: background 0.2s;
+}
+#audio-mute:hover { background: rgba(255,255,255,0.1); }
+@media (prefers-reduced-motion: reduce) {
+  .section-content { transition: none !important; }
+  #scroll-hint { display: none; }
+}

--- a/plugins/scrollcraft/skills/scrollcraft/engine/scrollcraft.runtime.js
+++ b/plugins/scrollcraft/skills/scrollcraft/engine/scrollcraft.runtime.js
@@ -1,0 +1,188 @@
+(function () {
+  var canvas = document.getElementById('scroll-canvas');
+  if (!canvas) return;
+  var ctx = canvas.getContext('2d');
+
+  var desktopCount = __DESKTOP_COUNT__;
+  var mobileCount = __MOBILE_COUNT__;
+  var hasMobile = __HAS_MOBILE__;
+  var totalScrollHeight = __TOTAL_SCROLL__;
+  var framesDir = '__FRAMES_DIR__';
+  var framesMobileDir = '__FRAMES_MOBILE_DIR__';
+
+  var mq = window.matchMedia('(max-width: 767px)');
+  var isMobile = hasMobile && mq.matches;
+  var frameCount = isMobile ? mobileCount : desktopCount;
+  var desktopImages = new Array(desktopCount);
+  var mobileImages = hasMobile ? new Array(mobileCount) : null;
+  var currentFrame = 0;
+  var dpr = 1;
+
+  function getImages() {
+    return (isMobile && mobileImages) ? mobileImages : desktopImages;
+  }
+
+  function resize() {
+    dpr = Math.min(window.devicePixelRatio || 1, 2);
+    var cssW = window.innerWidth;
+    var cssH = window.innerHeight;
+    canvas.width = Math.max(1, Math.round(cssW * dpr));
+    canvas.height = Math.max(1, Math.round(cssH * dpr));
+    canvas.style.width = cssW + 'px';
+    canvas.style.height = cssH + 'px';
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    drawFrame(currentFrame);
+  }
+
+  function drawFrame(index) {
+    var images = getImages();
+    var img = images[index];
+    if (!img || !img.complete) return;
+    if (!img.naturalWidth || !img.naturalHeight) return;
+    var cssW = window.innerWidth;
+    var cssH = window.innerHeight;
+    var scale = Math.max(cssW / img.naturalWidth, cssH / img.naturalHeight);
+    var w = img.naturalWidth * scale;
+    var h = img.naturalHeight * scale;
+    ctx.clearRect(0, 0, cssW, cssH);
+    ctx.drawImage(img, (cssW - w) / 2, (cssH - h) / 2, w, h);
+  }
+
+  function framePath(dir, idx) {
+    var s = String(idx);
+    while (s.length < 4) s = '0' + s;
+    return dir + '/frame_' + s + '.jpg';
+  }
+
+  function preloadSet(count, dir, target, isPrimary) {
+    if (!count) return;
+    var STEP = 5;
+    var keyframes = [];
+    for (var i = 0; i < count; i += STEP) keyframes.push(i);
+    var settled = 0;
+
+    function loadOne(idx) {
+      var img = new Image();
+      img.src = framePath(dir, idx);
+      img.onload = function () {
+        target[idx] = img;
+        if (idx === currentFrame) drawFrame(idx);
+      };
+    }
+
+    keyframes.forEach(function (i) {
+      var img = new Image();
+      img.src = framePath(dir, i);
+      function advance() {
+        settled++;
+        if (settled === keyframes.length) {
+          for (var j = 0; j < count; j++) {
+            if (j % STEP !== 0) loadOne(j);
+          }
+        }
+      }
+      img.onload = function () {
+        target[i] = img;
+        if (i === 0 && isPrimary) drawFrame(0);
+        if (i === currentFrame) drawFrame(i);
+        advance();
+      };
+      img.onerror = advance;
+    });
+  }
+
+  var mobileLoaded = false;
+  var desktopLoaded = false;
+
+  function preload() {
+    if (hasMobile && isMobile) {
+      preloadSet(mobileCount, framesMobileDir, mobileImages, true);
+      mobileLoaded = true;
+    } else {
+      preloadSet(desktopCount, framesDir, desktopImages, true);
+      desktopLoaded = true;
+    }
+  }
+
+  var rafId = 0;
+
+  function onScroll() {
+    if (rafId) return;
+    rafId = window.requestAnimationFrame(function () {
+      rafId = 0;
+      var track = totalScrollHeight - window.innerHeight;
+      var progress = track > 0 ? window.scrollY / track : 0;
+      if (progress < 0) progress = 0;
+      if (progress > 1) progress = 1;
+      var last = frameCount - 1;
+      var index = last > 0 ? Math.round(progress * last) : 0;
+      if (index !== currentFrame) {
+        currentFrame = index;
+        drawFrame(index);
+      }
+      var hint = document.getElementById('scroll-hint');
+      if (hint) hint.style.opacity = window.scrollY > 80 ? '0' : '1';
+    });
+  }
+
+  if (hasMobile) {
+    mq.addEventListener('change', function (e) {
+      isMobile = e.matches;
+      frameCount = isMobile ? mobileCount : desktopCount;
+      if (isMobile && !mobileLoaded) {
+        preloadSet(mobileCount, framesMobileDir, mobileImages, true);
+        mobileLoaded = true;
+      }
+      if (!isMobile && !desktopLoaded) {
+        preloadSet(desktopCount, framesDir, desktopImages, true);
+        desktopLoaded = true;
+      }
+      currentFrame = -1;
+      onScroll();
+    });
+  }
+
+  var reveal = document.querySelectorAll('.section-content');
+  if ('IntersectionObserver' in window) {
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) entry.target.classList.add('visible');
+      });
+    }, { threshold: 0.25 });
+    Array.prototype.forEach.call(reveal, function (el) { io.observe(el); });
+  } else {
+    Array.prototype.forEach.call(reveal, function (el) { el.classList.add('visible'); });
+  }
+
+  if (__HAS_AUDIO__) {
+    var audio = new Audio('__AUDIO_SRC__');
+    audio.loop = true;
+    audio.volume = 0.5;
+    var muted = true;
+    audio.muted = true;
+    var btn = document.getElementById('audio-mute');
+    function start() {
+      var p = audio.play();
+      if (p && typeof p.catch === 'function') p.catch(function () {});
+      window.removeEventListener('scroll', start);
+      window.removeEventListener('pointerdown', start);
+    }
+    window.addEventListener('scroll', start, { once: true, passive: true });
+    window.addEventListener('pointerdown', start, { once: true });
+    if (btn) {
+      btn.addEventListener('click', function () {
+        muted = !muted;
+        audio.muted = muted;
+        btn.textContent = muted ? '🔇' : '🔊';
+        btn.setAttribute('aria-label', muted ? 'Unmute background audio' : 'Mute background audio');
+        if (!muted) start();
+      });
+    }
+  }
+
+  window.addEventListener('resize', resize, { passive: true });
+  window.addEventListener('scroll', onScroll, { passive: true });
+  resize();
+  preload();
+  onScroll();
+})();

--- a/plugins/scrollcraft/skills/scrollcraft/references/export-contract.md
+++ b/plugins/scrollcraft/skills/scrollcraft/references/export-contract.md
@@ -1,0 +1,49 @@
+# Bundle contract
+
+Both this skill and the hosted ScrollCraft exporter (`src/app/api/export-site/route.ts`)
+emit the same layout. Keeping them identical is what lets a site move between the two.
+
+```
+dist/
+├── index.html          all CSS and JS inlined, no external requests
+├── frames/
+│   ├── frame_0000.jpg
+│   └── frame_0001.jpg  …
+├── frames-mobile/      optional, served to (max-width: 767px)
+└── audio.mp3           optional, extension varies
+```
+
+## Invariants
+
+Anything consuming or producing this bundle must hold to these:
+
+1. **Frame naming.** `frame_%04d.jpg`, starting at `0000`, gap-free. The runtime computes a
+   path from an index rather than listing a directory, so a missing file is an unrecoverable
+   silent hole.
+2. **Canvas id.** `#scroll-canvas`, `position: fixed`, full viewport, `z-index: 0`.
+3. **Scroll container.** `#scroll-container` carries the full `totalScrollHeight` and holds a
+   leading `100vh` spacer, then one `.scroll-section` per visible section.
+4. **Section structure.** `.scroll-section` > `.section-sticky` (`position: sticky; top: 0`) >
+   `.section-content`. The `.visible` class on `.section-content` is what reveals it.
+5. **Track maths.** `totalScrollHeight = Σ scrollHeight + 1000`.
+6. **Frame mapping.** `round(progress × (frameCount - 1))`, `progress` clamped to `[0, 1]`,
+   denominator `totalScrollHeight - innerHeight` guarded against `<= 0`.
+
+## Runtime behaviour worth knowing
+
+- **Keyframe preload.** Every 5th frame loads first; once all of those have settled, success
+  or failure, the gaps fill in. So the scrub is usable early instead of waiting on the whole
+  sequence. Failure is counted, not ignored, which is why one dead frame cannot hang the
+  chain.
+- **Draw guards.** `drawFrame` returns early unless the image is `complete` and reports
+  non-zero `naturalWidth`/`naturalHeight`. A half-decoded image would otherwise throw or
+  paint a 0×0 region.
+- **DPR.** Capped at 2 and recomputed inside `resize`, so dragging the window to a non-Retina
+  display rebuilds the backing store at the right ratio instead of a stale one.
+- **Cover scaling.** `max(cssW / naturalWidth, cssH / naturalHeight)`, centred. Frames fill
+  the viewport without distorting aspect ratio.
+- **Breakpoint switching.** Only the set actually being drawn is fetched. Crossing the
+  breakpoint loads the other set on demand and recomputes from the current scroll position,
+  so rotating a phone does not snap the background back to frame 0.
+- **One rAF in flight.** Scroll handlers coalesce into a single `requestAnimationFrame`;
+  a scroll burst cannot queue a backlog of draws.

--- a/plugins/scrollcraft/skills/scrollcraft/references/site-spec.md
+++ b/plugins/scrollcraft/skills/scrollcraft/references/site-spec.md
@@ -1,0 +1,60 @@
+# `scrollcraft.json` reference
+
+The spec is the single source of truth for a build. Paths inside it resolve relative to the
+spec file, not the working directory.
+
+## Top level
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `name` | string | `"ScrollCraft Site"` | Page `<title>` and `og:title`. |
+| `description` | string | none | Emits `<meta name="description">` and `og:description`. Omitted entirely when absent rather than left empty. |
+| `lang` | string | `"en"` | `<html lang>`. |
+| `canvasAlt` | string | falls back to `name` | `aria-label` on the canvas. The canvas is the whole visual, so screen readers get nothing without this. |
+| `frames` | string | `"frames"` | Desktop frame directory. |
+| `framesMobile` | string | none | Mobile frame directory. Omit and phones load desktop frames. |
+| `audio` | string | none | Path to an audio file. Copied to `dist/audio.<ext>`. |
+| `customCss` | string | none | Injected as a second `<style>` block, after the engine CSS, so it wins on ties. Filtered. |
+| `sections` | array | required | At least one entry with `visible !== false`. |
+
+## Section fields
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `heading` | string | none | Renders as `<h2>`, `clamp(2rem, 5vw, 4rem)`. |
+| `body` | string | none | One paragraph, capped at 600px measure. |
+| `eyebrow` | string | none | Small uppercase label above the heading. |
+| `ctaLabel` | string | none | Renders a button-styled link. Needs `ctaHref` to go anywhere. |
+| `ctaHref` | string | `"#"` | Only `http://`, `https://` and in-page `#anchors` survive; anything else becomes `#`. |
+| `scrollHeight` | number | `1000` | Scroll track in px this section occupies. Drives pacing. |
+| `align` | string | `"center"` | Flex `align-items` on the sticky wrapper. |
+| `justify` | string | `"center"` | Flex `justify-content`. |
+| `textAlign` | string | `"center"` | Text alignment inside the content block. |
+| `accentColor` | string | `#a78bfa` eyebrow / `#7c3aed` CTA | Used for both. |
+| `headingColor` | string | `#ffffff` | |
+| `bodyColor` | string | `rgba(255,255,255,0.7)` | |
+| `visible` | boolean | `true` | `false` excludes the section from both the output and the scroll-track total. |
+
+## How pacing works
+
+```
+totalScrollHeight = Σ scrollHeight (visible sections only) + 1000
+```
+
+The trailing `1000` plus a leading `100vh` spacer give the first frame a beat to land before
+any copy appears. Frame index is `round(progress × (frameCount - 1))` where `progress` is
+scroll position over `totalScrollHeight - innerHeight`, clamped to `[0, 1]`. So frames spread
+evenly across the whole track, and a section's share of the track is its share of the
+sequence.
+
+Hiding a section changes the pacing of every section after it, because the total shrinks.
+That is intended: drafts should not inflate the track.
+
+## Escaping
+
+All text fields are HTML-escaped. Colour and alignment fields are stripped of
+`< > " ' \ ; { }` because they are interpolated into inline `style` attributes, where a value
+like `#fff;background-image:url(https://tracker/x.png)` would otherwise append a declaration
+and make every visitor call out to that host. Parentheses are preserved so `rgba(...)` works.
+
+`ctaHref` is protocol-checked, not escaped, so `javascript:` cannot survive as a link target.

--- a/plugins/scrollcraft/skills/scrollcraft/scripts/build-site.mjs
+++ b/plugins/scrollcraft/skills/scrollcraft/scripts/build-site.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ENGINE = path.resolve(HERE, "..", "engine");
+
+const AUDIO_EXT = {
+  "audio/mpeg": "mp3", "audio/mp3": "mp3",
+  "audio/x-m4a": "m4a", "audio/m4a": "m4a", "audio/mp4": "m4a",
+  "audio/wav": "wav", "audio/x-wav": "wav", "audio/wave": "wav",
+  "audio/ogg": "ogg", "audio/webm": "webm", "audio/aac": "aac", "audio/flac": "flac",
+};
+
+const EXT_OK = new Set(Object.values(AUDIO_EXT));
+
+function fail(msg) {
+  process.stderr.write("build-site: " + msg + "\n");
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+function esc(s) {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").replace(/'/g, "&#x27;");
+}
+
+function safeCss(s) {
+  return String(s ?? "").replace(/[<>"'\\;{}]/g, "");
+}
+
+function safeHref(s) {
+  const href = String(s ?? "");
+  return /^https?:\/\//i.test(href) || href.startsWith("#") ? href : "#";
+}
+
+function safeCssBlock(s) {
+  return String(s ?? "")
+    .replace(/<\/?(script|style)/gi, "")
+    .replace(/url\(\s*['"]?\s*(javascript|data):/gi, "url(")
+    .replace(/expression\s*\(/gi, "");
+}
+
+function countFrames(dir) {
+  if (!fs.existsSync(dir)) return 0;
+  const names = fs.readdirSync(dir).filter((n) => /^frame_\d{4}\.jpg$/.test(n));
+  if (names.length === 0) return 0;
+  const nums = names.map((n) => Number(n.slice(6, 10))).sort((a, b) => a - b);
+  for (let i = 0; i < nums.length; i++) {
+    if (nums[i] !== i) {
+      fail(`frames in ${dir} are not a gap-free sequence starting at frame_0000.jpg (missing ${String(i).padStart(4, "0")})`);
+    }
+  }
+  return nums.length;
+}
+
+function copyFrames(srcDir, outDir) {
+  fs.mkdirSync(outDir, { recursive: true });
+  for (const name of fs.readdirSync(srcDir)) {
+    if (!/^frame_\d{4}\.jpg$/.test(name)) continue;
+    fs.copyFileSync(path.join(srcDir, name), path.join(outDir, name));
+  }
+}
+
+function renderSections(sections) {
+  return sections.map((s) => {
+    const height = Number(s.scrollHeight) || 1000;
+    const parts = [];
+    if (s.eyebrow) {
+      parts.push(`<p class="eyebrow" style="font-size:0.875rem; font-weight:600; letter-spacing:0.1em; text-transform:uppercase; color:${safeCss(s.accentColor || "#a78bfa")}; margin-bottom:0.75rem;">${esc(s.eyebrow)}</p>`);
+    }
+    if (s.heading) {
+      parts.push(`<h2 style="font-size:clamp(2rem,5vw,4rem); font-weight:900; line-height:1; letter-spacing:-0.03em; color:${safeCss(s.headingColor || "#ffffff")}; margin-bottom:1rem;">${esc(s.heading)}</h2>`);
+    }
+    if (s.body) {
+      parts.push(`<p style="font-size:1.125rem; line-height:1.7; color:${safeCss(s.bodyColor || "rgba(255,255,255,0.7)")}; max-width:600px; margin:0 auto 1.5rem;">${esc(s.body)}</p>`);
+    }
+    if (s.ctaLabel) {
+      parts.push(`<a href="${esc(safeHref(s.ctaHref || "#"))}" style="display:inline-block; background:${safeCss(s.accentColor || "#7c3aed")}; color:#fff; padding:0.875rem 2rem; border-radius:0.5rem; font-weight:600; text-decoration:none; font-size:1rem;">${esc(s.ctaLabel)}</a>`);
+    }
+    return `    <section class="scroll-section" style="height:${height}px; position:relative; z-index:10;">
+      <div class="section-sticky" style="position:sticky; top:0; height:100vh; display:flex; align-items:${safeCss(s.align || "center")}; justify-content:${safeCss(s.justify || "center")}; overflow:hidden;">
+        <div class="section-content" style="text-align:${safeCss(s.textAlign || "center")}; padding:2rem; max-width:800px; opacity:0; transform:translateY(32px); transition:opacity 0.6s cubic-bezier(0.25,0.46,0.45,0.94),transform 0.6s cubic-bezier(0.25,0.46,0.45,0.94);">
+${parts.map((p) => "          " + p).join("\n")}
+        </div>
+      </div>
+    </section>`;
+  }).join("\n");
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(
+      "Usage: build-site.mjs --spec <scrollcraft.json> --out <dir> [--frames <dir>] [--frames-mobile <dir>] [--audio <file>]\n"
+    );
+    return;
+  }
+
+  const specPath = typeof args.spec === "string" ? args.spec : "scrollcraft.json";
+  if (!fs.existsSync(specPath)) fail(`spec not found: ${specPath}`);
+
+  let spec;
+  try {
+    spec = JSON.parse(fs.readFileSync(specPath, "utf8"));
+  } catch (e) {
+    fail(`spec is not valid JSON: ${e.message}`);
+  }
+
+  const outDir = typeof args.out === "string" ? args.out : "dist";
+  const specDir = path.dirname(path.resolve(specPath));
+  const framesDir = path.resolve(specDir, typeof args.frames === "string" ? args.frames : spec.frames || "frames");
+  const framesMobileArg = typeof args["frames-mobile"] === "string" ? args["frames-mobile"] : spec.framesMobile;
+  const framesMobileDir = framesMobileArg ? path.resolve(specDir, framesMobileArg) : null;
+  const audioArg = typeof args.audio === "string" ? args.audio : spec.audio;
+
+  const sections = Array.isArray(spec.sections) ? spec.sections.filter((s) => s && s.visible !== false) : [];
+  if (sections.length === 0) fail("spec needs at least one section with visible !== false");
+
+  const desktopCount = countFrames(framesDir);
+  if (desktopCount === 0) fail(`no frames found in ${framesDir} (expected frame_0000.jpg upward)`);
+  const mobileCount = framesMobileDir ? countFrames(framesMobileDir) : 0;
+  if (framesMobileDir && mobileCount === 0) fail(`--frames-mobile given but no frames found in ${framesMobileDir}`);
+
+  const totalScrollHeight =
+    sections.reduce((acc, s) => acc + (Number(s.scrollHeight) || 1000), 0) + 1000;
+
+  let audioOut = "";
+  if (audioArg) {
+    const audioPath = path.resolve(specDir, audioArg);
+    if (!fs.existsSync(audioPath)) fail(`audio file not found: ${audioPath}`);
+    const ext = path.extname(audioPath).slice(1).toLowerCase();
+    if (!EXT_OK.has(ext)) fail(`unsupported audio extension ".${ext}" (allowed: ${[...EXT_OK].join(", ")})`);
+    audioOut = "audio." + ext;
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.copyFileSync(audioPath, path.join(outDir, audioOut));
+  }
+
+  const css = fs.readFileSync(path.join(ENGINE, "scrollcraft.css"), "utf8");
+  const runtime = fs
+    .readFileSync(path.join(ENGINE, "scrollcraft.runtime.js"), "utf8")
+    .replace(/__DESKTOP_COUNT__/g, String(desktopCount))
+    .replace(/__MOBILE_COUNT__/g, String(mobileCount))
+    .replace(/__HAS_MOBILE__/g, mobileCount > 0 ? "true" : "false")
+    .replace(/__TOTAL_SCROLL__/g, String(totalScrollHeight))
+    .replace(/__FRAMES_DIR__/g, "frames")
+    .replace(/__FRAMES_MOBILE_DIR__/g, "frames-mobile")
+    .replace(/__HAS_AUDIO__/g, audioOut ? "true" : "false")
+    .replace(/__AUDIO_SRC__/g, audioOut);
+
+  const title = esc(spec.name || "ScrollCraft Site");
+  const description = esc(spec.description || "");
+  const customCss = safeCssBlock(spec.customCss || "");
+
+  const html = `<!DOCTYPE html>
+<html lang="${esc(spec.lang || "en")}">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${title}</title>
+${description ? `  <meta name="description" content="${description}" />\n` : ""}  <meta property="og:title" content="${title}" />
+${description ? `  <meta property="og:description" content="${description}" />\n` : ""}  <meta property="og:type" content="website" />
+  <style>
+${css}
+  </style>
+${customCss ? `  <style>\n${customCss}\n  </style>\n` : ""}</head>
+<body>
+  <canvas id="scroll-canvas" role="img" aria-label="${esc(spec.canvasAlt || title)}"></canvas>
+  <div id="scroll-container" style="height:${totalScrollHeight}px;">
+    <div style="height:100vh;"></div>
+${renderSections(sections)}
+  </div>
+  <div id="scroll-hint" aria-hidden="true">
+    <span>Scroll</span>
+    <div class="arrow"></div>
+  </div>
+${audioOut ? `  <button id="audio-mute" type="button" aria-label="Unmute background audio">🔇</button>\n` : ""}  <noscript>
+    <div style="position:relative; z-index:40; padding:2rem; text-align:center;">
+      This site animates a frame sequence as you scroll and needs JavaScript enabled.
+    </div>
+  </noscript>
+  <script>
+${runtime}
+  </script>
+</body>
+</html>
+`;
+
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, "index.html"), html);
+  copyFrames(framesDir, path.join(outDir, "frames"));
+  if (framesMobileDir) copyFrames(framesMobileDir, path.join(outDir, "frames-mobile"));
+
+  process.stdout.write(
+    `built ${path.join(outDir, "index.html")}\n` +
+    `  sections: ${sections.length}\n` +
+    `  desktop frames: ${desktopCount}\n` +
+    `  mobile frames: ${mobileCount}\n` +
+    `  scroll track: ${totalScrollHeight}px\n` +
+    `  audio: ${audioOut || "none"}\n`
+  );
+}
+
+main();

--- a/plugins/scrollcraft/skills/scrollcraft/scripts/doctor.mjs
+++ b/plugins/scrollcraft/skills/scrollcraft/scripts/doctor.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+const problems = [];
+const warnings = [];
+const notes = [];
+
+function checkFfmpeg() {
+  const probe = spawnSync("ffmpeg", ["-version"], { encoding: "utf8" });
+  if (probe.error || probe.status !== 0) {
+    warnings.push("ffmpeg not on PATH — video extraction unavailable (brew install ffmpeg / apt install ffmpeg)");
+    return;
+  }
+  const first = String(probe.stdout || "").split("\n")[0];
+  notes.push(first.trim());
+}
+
+function checkFrames(dir, label) {
+  if (!fs.existsSync(dir)) {
+    notes.push(`${label}: absent`);
+    return 0;
+  }
+  const names = fs.readdirSync(dir).filter((n) => /^frame_\d{4}\.jpg$/.test(n));
+  const stray = fs.readdirSync(dir).filter((n) => !/^frame_\d{4}\.jpg$/.test(n) && !n.startsWith("."));
+  if (names.length === 0) {
+    problems.push(`${label}: directory exists but holds no frame_NNNN.jpg files`);
+    return 0;
+  }
+  const nums = names.map((n) => Number(n.slice(6, 10))).sort((a, b) => a - b);
+  for (let i = 0; i < nums.length; i++) {
+    if (nums[i] !== i) {
+      problems.push(`${label}: sequence has a gap — expected frame_${String(i).padStart(4, "0")}.jpg`);
+      break;
+    }
+  }
+  let bytes = 0;
+  for (const n of names) bytes += fs.statSync(path.join(dir, n)).size;
+  const mib = bytes / 1024 / 1024;
+  notes.push(`${label}: ${names.length} frames, ${mib.toFixed(1)} MiB, avg ${(bytes / names.length / 1024).toFixed(0)} KiB`);
+  if (stray.length) warnings.push(`${label}: ${stray.length} non-frame file(s) will be ignored by the build`);
+  if (mib > 40) warnings.push(`${label}: ${mib.toFixed(1)} MiB is a heavy first load — consider lower fps or width`);
+  return names.length;
+}
+
+function checkSpec(specPath) {
+  if (!fs.existsSync(specPath)) {
+    problems.push(`spec not found: ${specPath}`);
+    return null;
+  }
+  let spec;
+  try {
+    spec = JSON.parse(fs.readFileSync(specPath, "utf8"));
+  } catch (e) {
+    problems.push(`spec is not valid JSON: ${e.message}`);
+    return null;
+  }
+  if (!Array.isArray(spec.sections)) {
+    problems.push("spec.sections must be an array");
+    return spec;
+  }
+  const visible = spec.sections.filter((s) => s && s.visible !== false);
+  if (visible.length === 0) problems.push("spec has no section with visible !== false");
+  visible.forEach((s, i) => {
+    if (!s.heading && !s.body && !s.eyebrow && !s.ctaLabel) {
+      warnings.push(`section ${i} renders no text at all`);
+    }
+    const h = Number(s.scrollHeight);
+    if (s.scrollHeight !== undefined && (!Number.isFinite(h) || h <= 0)) {
+      problems.push(`section ${i} has a non-positive scrollHeight`);
+    }
+    if (Number.isFinite(h) && h > 0 && h < 400) {
+      warnings.push(`section ${i} scrollHeight ${h}px is short — the copy will flash past`);
+    }
+    if (s.ctaLabel && !s.ctaHref) warnings.push(`section ${i} has a CTA label but no ctaHref`);
+  });
+  if (!spec.name) warnings.push("spec has no name — the page title will fall back to a generic one");
+  if (!spec.description) warnings.push("spec has no description — no meta description or og:description will be emitted");
+  return spec;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write("Usage: doctor.mjs [--spec scrollcraft.json] [--frames frames] [--frames-mobile frames-mobile]\n");
+    return;
+  }
+
+  const specPath = typeof args.spec === "string" ? args.spec : "scrollcraft.json";
+  const spec = checkSpec(specPath);
+  const specDir = path.dirname(path.resolve(specPath));
+
+  const framesDir = path.resolve(specDir, typeof args.frames === "string" ? args.frames : (spec && spec.frames) || "frames");
+  const desktop = checkFrames(framesDir, "frames");
+
+  const mobileArg = typeof args["frames-mobile"] === "string" ? args["frames-mobile"] : (spec && spec.framesMobile) || "frames-mobile";
+  const mobileDir = path.resolve(specDir, mobileArg);
+  const mobile = checkFrames(mobileDir, "frames-mobile");
+
+  if (desktop && !mobile) {
+    warnings.push("no mobile frame set — phones will download the desktop frames");
+  }
+
+  if (spec && spec.audio) {
+    const audioPath = path.resolve(specDir, spec.audio);
+    if (!fs.existsSync(audioPath)) problems.push(`spec.audio not found: ${audioPath}`);
+  }
+
+  checkFfmpeg();
+
+  for (const n of notes) process.stdout.write("  " + n + "\n");
+  for (const w of warnings) process.stdout.write("warn: " + w + "\n");
+  for (const p of problems) process.stdout.write("FAIL: " + p + "\n");
+
+  process.stdout.write(`\n${problems.length} problem(s), ${warnings.length} warning(s)\n`);
+  process.exit(problems.length ? 1 : 0);
+}
+
+main();

--- a/plugins/scrollcraft/skills/scrollcraft/scripts/frames-from-video.mjs
+++ b/plugins/scrollcraft/skills/scrollcraft/scripts/frames-from-video.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function fail(msg) {
+  process.stderr.write("frames-from-video: " + msg + "\n");
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+function intArg(value, fallback, min, max, label) {
+  if (value === undefined) return fallback;
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) fail(`${label} must be an integer`);
+  if (n < min || n > max) fail(`${label} must be between ${min} and ${max}`);
+  return n;
+}
+
+function haveFfmpeg() {
+  const probe = spawnSync("ffmpeg", ["-version"], { stdio: "ignore" });
+  return !probe.error && probe.status === 0;
+}
+
+function extract(input, outDir, fps, width, quality) {
+  fs.mkdirSync(outDir, { recursive: true });
+  for (const name of fs.readdirSync(outDir)) {
+    if (/^frame_\d{4}\.jpg$/.test(name)) fs.rmSync(path.join(outDir, name));
+  }
+  const args = [
+    "-hide_banner",
+    "-loglevel", "error",
+    "-i", input,
+    "-vf", `fps=${fps},scale=${width}:-2:flags=lanczos`,
+    "-q:v", String(quality),
+    "-start_number", "0",
+    path.join(outDir, "frame_%04d.jpg"),
+  ];
+  const run = spawnSync("ffmpeg", args, { stdio: ["ignore", "inherit", "inherit"] });
+  if (run.error) fail(`failed to run ffmpeg: ${run.error.message}`);
+  if (run.status !== 0) fail(`ffmpeg exited with status ${run.status}`);
+  const produced = fs.readdirSync(outDir).filter((n) => /^frame_\d{4}\.jpg$/.test(n));
+  if (produced.length === 0) fail(`ffmpeg produced no frames from ${input}`);
+  if (produced.length > 9999) fail(`${produced.length} frames exceeds the frame_%04d naming space`);
+  let bytes = 0;
+  for (const name of produced) bytes += fs.statSync(path.join(outDir, name)).size;
+  return { count: produced.length, bytes };
+}
+
+function mib(bytes) {
+  return (bytes / 1024 / 1024).toFixed(1) + " MiB";
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(
+      "Usage: frames-from-video.mjs --input <video> [--out frames] [--fps 24] [--width 1920]\n" +
+      "                            [--quality 4] [--mobile-width 828] [--mobile-out frames-mobile]\n"
+    );
+    return;
+  }
+
+  const input = typeof args.input === "string" ? args.input : null;
+  if (!input) fail("--input <video> is required");
+  if (!fs.existsSync(input)) fail(`input not found: ${input}`);
+  if (!fs.statSync(input).isFile()) fail(`input is not a file: ${input}`);
+
+  if (!haveFfmpeg()) {
+    fail("ffmpeg not found on PATH. Install it (macOS: brew install ffmpeg, Debian: apt install ffmpeg) and retry.");
+  }
+
+  const outDir = typeof args.out === "string" ? args.out : "frames";
+  const fps = intArg(args.fps, 24, 1, 60, "--fps");
+  const width = intArg(args.width, 1920, 320, 3840, "--width");
+  const quality = intArg(args.quality, 4, 1, 31, "--quality");
+
+  const desktop = extract(input, outDir, fps, width, quality);
+  process.stdout.write(`${outDir}: ${desktop.count} frames, ${mib(desktop.bytes)}\n`);
+
+  let mobile = null;
+  if (args["mobile-width"] !== undefined || args["mobile-out"] !== undefined) {
+    const mobileWidth = intArg(args["mobile-width"], 828, 320, 1600, "--mobile-width");
+    const mobileOut = typeof args["mobile-out"] === "string" ? args["mobile-out"] : "frames-mobile";
+    mobile = extract(input, mobileOut, fps, mobileWidth, quality);
+    process.stdout.write(`${mobileOut}: ${mobile.count} frames, ${mib(mobile.bytes)}\n`);
+  }
+
+  const total = desktop.bytes + (mobile ? mobile.bytes : 0);
+  if (total > 60 * 1024 * 1024) {
+    process.stdout.write(
+      `warning: ${mib(total)} of frames is a heavy first load. Lower --fps or --width, or raise --quality.\n`
+    );
+  }
+  if (!mobile) {
+    process.stdout.write(
+      "note: no mobile set built. Pass --mobile-width 828 so phones do not download desktop frames.\n"
+    );
+  }
+}
+
+main();

--- a/plugins/scrollcraft/skills/scrollcraft/scripts/serve.mjs
+++ b/plugins/scrollcraft/skills/scrollcraft/scripts/serve.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".webm": "audio/webm",
+  ".aac": "audio/aac",
+  ".flac": "audio/flac",
+  ".json": "application/json; charset=utf-8",
+};
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help) {
+  process.stdout.write("Usage: serve.mjs [--dir dist] [--port 4321]\n");
+  process.exit(0);
+}
+
+const root = path.resolve(typeof args.dir === "string" ? args.dir : "dist");
+const port = Number(args.port) || 4321;
+
+if (!fs.existsSync(root)) {
+  process.stderr.write(`serve: directory not found: ${root}\n`);
+  process.exit(1);
+}
+
+const server = http.createServer((req, res) => {
+  let pathname;
+  try {
+    pathname = decodeURIComponent(new URL(req.url, "http://localhost").pathname);
+  } catch {
+    res.writeHead(400).end("Bad request");
+    return;
+  }
+
+  const rel = pathname === "/" ? "index.html" : pathname.replace(/^\/+/, "");
+  const target = path.resolve(root, rel);
+
+  if (target !== root && !target.startsWith(root + path.sep)) {
+    res.writeHead(403).end("Forbidden");
+    return;
+  }
+
+  fs.stat(target, (err, stat) => {
+    if (err || !stat.isFile()) {
+      res.writeHead(404).end("Not found");
+      return;
+    }
+    res.writeHead(200, {
+      "Content-Type": MIME[path.extname(target).toLowerCase()] || "application/octet-stream",
+      "Content-Length": stat.size,
+      "Cache-Control": "no-store",
+    });
+    fs.createReadStream(target).pipe(res);
+  });
+});
+
+server.listen(port, "127.0.0.1", () => {
+  process.stdout.write(`serving ${root} at http://127.0.0.1:${port}\n`);
+});

--- a/src/__tests__/skillBuildSite.test.ts
+++ b/src/__tests__/skillBuildSite.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SCRIPT = path.resolve(
+  __dirname,
+  "../../plugins/scrollcraft/skills/scrollcraft/scripts/build-site.mjs"
+);
+
+const ONE_PX_JPEG = Buffer.from(
+  "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRof" +
+    "Hh0aHBwcJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPDU0NP/bAEMBCQkJDAsMGA0NGDIhHCEy" +
+    "MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAB" +
+    "AAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAA" +
+    "AAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMB" +
+    "AAIRAxEAPwCdABmX/9k=",
+  "base64"
+);
+
+let tmp: string;
+
+function writeFrames(dir: string, indices: number[]) {
+  fs.mkdirSync(dir, { recursive: true });
+  for (const i of indices) {
+    fs.writeFileSync(path.join(dir, `frame_${String(i).padStart(4, "0")}.jpg`), ONE_PX_JPEG);
+  }
+}
+
+function writeSpec(spec: unknown) {
+  fs.writeFileSync(path.join(tmp, "scrollcraft.json"), JSON.stringify(spec));
+}
+
+function build(extra: string[] = []) {
+  return spawnSync(
+    process.execPath,
+    [SCRIPT, "--spec", path.join(tmp, "scrollcraft.json"), "--out", path.join(tmp, "dist"), ...extra],
+    { encoding: "utf8" }
+  );
+}
+
+function html() {
+  return fs.readFileSync(path.join(tmp, "dist", "index.html"), "utf8");
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "scrollcraft-skill-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("skill build-site", () => {
+  it("builds a bundle and copies the frame sequence", () => {
+    writeFrames(path.join(tmp, "frames"), [0, 1, 2]);
+    writeSpec({
+      name: "Orrery",
+      description: "A precision instrument.",
+      sections: [{ heading: "One", scrollHeight: 1200 }, { heading: "Two", scrollHeight: 800 }],
+    });
+
+    const run = build();
+    expect(run.status).toBe(0);
+
+    const out = html();
+    expect(out).toContain("<title>Orrery</title>");
+    expect(out).toContain('name="description" content="A precision instrument."');
+    expect(out).toContain("Two");
+    expect(fs.readdirSync(path.join(tmp, "dist", "frames"))).toHaveLength(3);
+  });
+
+  it("sets the scroll track to the sum of section heights plus 1000", () => {
+    writeFrames(path.join(tmp, "frames"), [0, 1]);
+    writeSpec({ sections: [{ heading: "A", scrollHeight: 1200 }, { heading: "B", scrollHeight: 900 }] });
+
+    expect(build().status).toBe(0);
+    const out = html();
+    expect(out).toContain("height:3100px");
+    expect(out).toContain("var totalScrollHeight = 3100;");
+  });
+
+  it("excludes sections marked visible:false from output and from the track total", () => {
+    writeFrames(path.join(tmp, "frames"), [0]);
+    writeSpec({
+      sections: [
+        { heading: "Shown", scrollHeight: 1000 },
+        { heading: "Draft copy", scrollHeight: 5000, visible: false },
+      ],
+    });
+
+    expect(build().status).toBe(0);
+    const out = html();
+    expect(out).toContain("Shown");
+    expect(out).not.toContain("Draft copy");
+    expect(out).toContain("var totalScrollHeight = 2000;");
+  });
+
+  it("injects the real frame counts into the runtime", () => {
+    writeFrames(path.join(tmp, "frames"), [0, 1, 2, 3]);
+    writeFrames(path.join(tmp, "frames-mobile"), [0, 1]);
+    writeSpec({ framesMobile: "frames-mobile", sections: [{ heading: "A" }] });
+
+    expect(build().status).toBe(0);
+    const out = html();
+    expect(out).toContain("var desktopCount = 4;");
+    expect(out).toContain("var mobileCount = 2;");
+    expect(out).toContain("var hasMobile = true;");
+  });
+
+  it("reports hasMobile false when no mobile set is supplied", () => {
+    writeFrames(path.join(tmp, "frames"), [0]);
+    writeSpec({ sections: [{ heading: "A" }] });
+
+    expect(build().status).toBe(0);
+    expect(html()).toContain("var hasMobile = false;");
+  });
+
+  it("refuses a gapped frame sequence instead of shipping a stutter", () => {
+    writeFrames(path.join(tmp, "frames"), [0, 1, 3]);
+    writeSpec({ sections: [{ heading: "A" }] });
+
+    const run = build();
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("gap-free");
+    expect(fs.existsSync(path.join(tmp, "dist", "index.html"))).toBe(false);
+  });
+
+  it("refuses a spec whose every section is hidden", () => {
+    writeFrames(path.join(tmp, "frames"), [0]);
+    writeSpec({ sections: [{ heading: "A", visible: false }] });
+
+    const run = build();
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("at least one section");
+  });
+
+  it("refuses a frames directory with no frames", () => {
+    fs.mkdirSync(path.join(tmp, "frames"));
+    writeSpec({ sections: [{ heading: "A" }] });
+
+    const run = build();
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("no frames found");
+  });
+
+  it("escapes HTML in section copy", () => {
+    writeFrames(path.join(tmp, "frames"), [0]);
+    writeSpec({
+      name: '</title><script>alert(1)</script>',
+      sections: [{ heading: '<img src=x onerror=alert(1)>', body: 'a & b' }],
+    });
+
+    expect(build().status).toBe(0);
+    const out = html();
+    expect(out).not.toContain("<script>alert(1)</script>");
+    expect(out).not.toContain("<img src=x");
+    expect(out).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(out).toContain("a &amp; b");
+  });
+
+  it("neutralises a javascript: CTA href", () => {
+    writeFrames(path.join(tmp, "frames"), [0]);
+    writeSpec({
+      sections: [{ heading: "A", ctaLabel: "Go", ctaHref: "javascript:alert(1)" }],
+    });
+
+    expect(build().status).toBe(0);
+    const out = html();
+    expect(out).not.toContain("javascript:alert");
+    expect(out).toContain('href="#"');
+  });
+
+  it("strips declaration-breaking characters from colour fields", () => {
+    writeFrames(path.join(tmp, "frames"), [0]);
+    writeSpec({
+      sections: [
+        { heading: "A", headingColor: "#fff;background-image:url(https://tracker/x.png)" },
+      ],
+    });
+
+    expect(build().status).toBe(0);
+    const out = html();
+    expect(out).not.toContain("#fff;background-image");
+    expect(out).toContain("#fffbackground-image");
+  });
+
+  it("rejects an audio file whose extension no static host serves correctly", () => {
+    writeFrames(path.join(tmp, "frames"), [0]);
+    fs.writeFileSync(path.join(tmp, "track.aiff"), "not audio");
+    writeSpec({ audio: "track.aiff", sections: [{ heading: "A" }] });
+
+    const run = build();
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("unsupported audio extension");
+  });
+
+  it("copies allowed audio and wires the mute control", () => {
+    writeFrames(path.join(tmp, "frames"), [0]);
+    fs.writeFileSync(path.join(tmp, "track.mp3"), "not really audio");
+    writeSpec({ audio: "track.mp3", sections: [{ heading: "A" }] });
+
+    expect(build().status).toBe(0);
+    const out = html();
+    expect(fs.existsSync(path.join(tmp, "dist", "audio.mp3"))).toBe(true);
+    expect(out).toContain('id="audio-mute"');
+    expect(out).toContain("var audio = new Audio('audio.mp3');");
+  });
+
+  it("omits the audio control entirely when no audio is specified", () => {
+    writeFrames(path.join(tmp, "frames"), [0]);
+    writeSpec({ sections: [{ heading: "A" }] });
+
+    expect(build().status).toBe(0);
+    const out = html();
+    expect(out).not.toContain('id="audio-mute"');
+    expect(out).toContain("if (false) {");
+  });
+
+  it("fails on a missing spec rather than emitting an empty site", () => {
+    const run = build();
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("spec not found");
+  });
+
+  it("leaves no external network references in the bundle", () => {
+    writeFrames(path.join(tmp, "frames"), [0]);
+    writeSpec({ sections: [{ heading: "A" }] });
+
+    expect(build().status).toBe(0);
+    const out = html();
+    expect(out).not.toMatch(/<script[^>]+src=/);
+    expect(out).not.toMatch(/<link[^>]+href="https?:/);
+  });
+});


### PR DESCRIPTION
# Description

ScrollCraft currently only exists as a hosted app. This makes the repository a Claude Code plugin marketplace as well, exposing one skill that builds scroll-scrubbed canvas sites locally.

The two halves are deliberately complementary rather than duplicated:

- **Hosted app** generates frames from a prompt, gives you a visual editor and AI chat editing, and hosts the result. It is the answer when you have no footage.
- **Skill** takes footage you already have, extracts frames with ffmpeg, and builds the static bundle on your machine, in version control, with no account and no server.

Both emit the **identical bundle layout**, so a site built by the skill opens in the hosted editor and an exported ZIP can be rebuilt offline. That interchange is the point: the invariants are written down in `references/export-contract.md` and both sides are held to them.

Nothing in `src/` changes except one new test file. No existing behaviour is touched.

## What is in here

```
.claude-plugin/marketplace.json                    marketplace manifest
plugins/scrollcraft/.claude-plugin/plugin.json     plugin manifest
plugins/scrollcraft/skills/scrollcraft/
├── SKILL.md                                       workflow, craft notes, constraints
├── engine/scrollcraft.css + scrollcraft.runtime.js scrub engine, token-substituted at build
├── references/site-spec.md                        every spec field
├── references/export-contract.md                  invariants shared with the exporter
└── scripts/  frames-from-video · build-site · doctor · serve
```

`ffmpeg` is the only external requirement. Everything else is Node builtins, no new dependency.

## Shared contract

The skill reproduces what `src/app/api/export-site/route.ts` already emits:

- frames named `frame_%04d.jpg`, zero-padded, gap-free from `0000`
- fixed full-viewport `#scroll-canvas` at `z-index: 0`
- `.scroll-section` > `.section-sticky` > `.section-content`, revealed via a `.visible` class
- scroll track `= Σ scrollHeight + 1000`, with a leading `100vh` spacer
- frame index `round(progress × (frameCount - 1))`, denominator guarded against `<= 0`
- step-5 keyframe preload that counts failures, so one dead frame cannot hang the chain
- device pixel ratio capped at 2 and recomputed on resize
- only the frame set actually being drawn is fetched, so phones do not pull desktop frames

Escaping matches the server too: text is HTML-escaped, colour and alignment fields are stripped of `< > " ' \ ; { }` so a value cannot break out of its inline declaration, and `ctaHref` is protocol-checked so `javascript:` cannot survive.

## Testing

`src/__tests__/skillBuildSite.test.ts`, 16 cases, driving the real script as a subprocess: track maths, `visible: false` exclusion from both output and track total, frame-count injection, mobile-set wiring, gapped-sequence refusal, empty-spec refusal, HTML escaping, `javascript:` href neutralisation, colour-field stripping, audio allowlist, and an assertion that the bundle contains no external network reference.

Measured on this branch:

- `npx tsc --noEmit` clean
- `npx eslint` clean, and it does reach the new `.mjs` files
- `npx vitest run` **132 passed / 9 files**, up from 116 / 8 on `main`
- `npx next build` succeeds, route table unchanged
- new test file adds ~512ms (it spawns node 16 times)

The suite is not vacuous: zeroing the `+ 1000` track constant fails 2 tests, making `esc()` the identity fails 1, disabling the gap check fails 1.

End to end, run for real rather than asserted: ffmpeg generated a 3s clip, `frames-from-video.mjs` produced 36 desktop + 36 mobile frames, `doctor.mjs` reported 0 problems / 0 warnings, `build-site.mjs` computed a 3400px track (1400 + 1000 + 1000), and `serve.mjs` served `index.html` as `text/html` and frames as `image/jpeg` while 404ing both `../` and `%2e%2e/` traversal.

## Type of change

- [x] ✨ New feature
- [x] 📝 Documentation

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes
- [x] `npm run build` passes
- [x] I updated docs / `.env.example` if config or env vars changed
- [x] I added tests for new logic where practical

## Risks and trade-offs

- **The skill cannot reach the hosted API.** Every route gates on a next-auth session cookie and Prisma has no token model, so a CLI has no way to authenticate. The skill therefore stands alone. Adding API tokens would unlock "build locally, publish to the cloud" and is worth doing separately.
- **Contract drift.** Two implementations of one bundle format can diverge. `references/export-contract.md` is the written spec and the new tests pin the skill side, but a change to the exporter still has to be mirrored by hand.
- **`plugins/` is new ground** in this repo, so there is no in-repo precedent to match. The layout follows the documented Claude Code plugin format.