### PR TITLE
feat(skill): generate backgrounds, scaffold in one command, and support section images

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,27 @@ Updating later:
 ### What the skill does
 
 `ffmpeg` is the only external requirement (`brew install ffmpeg`, or `apt install ffmpeg`).
+Everything else is plain Node with no dependencies.
+
+Ask Claude for a scroll site, or drive it yourself:
 
 ```bash
-# 1. video -> frame sequence, desktop + mobile
+# Fastest path — no footage needed. Scaffolds the spec, generates a
+# background, and builds a working site in one command.
+node scripts/init.mjs --name "Orrery" --style aurora
+```
+
+Or step by step:
+
+```bash
+# 1a. your own video -> frame sequence, desktop + mobile
 node scripts/frames-from-video.mjs --input hero.mp4 --out frames \
   --fps 24 --width 1920 --mobile-width 828 --mobile-out frames-mobile
+
+# 1b. or generate one: six cinematic styles, ~1MB instead of ~36MB
+node scripts/frames-from-style.mjs --list
+node scripts/frames-from-style.mjs --style nebula --count 180 \
+  --width 1920 --mobile-width 828 --mobile-out frames-mobile
 
 # 2. write scrollcraft.json describing your sections, then build
 node scripts/build-site.mjs --spec scrollcraft.json --out dist
@@ -84,6 +100,9 @@ node scripts/build-site.mjs --spec scrollcraft.json --out dist
 node scripts/doctor.mjs --spec scrollcraft.json
 node scripts/serve.mjs --dir dist --port 4321
 ```
+
+Two slash commands come with the plugin: `/scrollcraft-new` to start a site and
+`/scrollcraft-build` to rebuild, check and preview one.
 
 `dist/` is a static directory with no runtime dependencies and no external requests. Deploy it
 anywhere.

--- a/plugins/scrollcraft/commands/scrollcraft-build.md
+++ b/plugins/scrollcraft/commands/scrollcraft-build.md
@@ -1,0 +1,15 @@
+---
+description: Rebuild the ScrollCraft site in this directory, check it, and preview it
+---
+
+Rebuild and verify the scroll site in the current directory.
+
+1. `node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/build-site.mjs" --spec scrollcraft.json --out dist`
+2. `node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/doctor.mjs" --spec scrollcraft.json`
+3. If the doctor exits non-zero, fix what it reports before saying anything succeeded.
+4. `node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/serve.mjs" --dir dist` and give the user the URL.
+
+A build that succeeds is not evidence the page works — a missing frame renders as a black canvas
+with no error. Say what you actually verified.
+
+$ARGUMENTS

--- a/plugins/scrollcraft/commands/scrollcraft-new.md
+++ b/plugins/scrollcraft/commands/scrollcraft-new.md
@@ -1,0 +1,20 @@
+---
+description: Start a new ScrollCraft scroll site — scaffolds the spec, generates a background, and builds it
+---
+
+Start a new cinematic scroll site in the current directory.
+
+Arguments (all optional): $ARGUMENTS — may contain a site name, and/or a style name from
+`aurora`, `nebula`, `tide`, `ember`, `dusk`, `monolith`.
+
+Steps:
+
+1. Read `${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/SKILL.md` and follow it.
+2. If the user gave no style, run `node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/frames-from-style.mjs" --list`
+   and pick the one that fits what they described. Say which you picked and why.
+3. Scaffold with `node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/init.mjs" --name "<name>" --style <style>`.
+4. Rewrite the placeholder sections in `scrollcraft.json` as real copy for their subject. One idea
+   per section. Do not leave the starter text in place.
+5. Rebuild, run the doctor, then serve it and tell them the URL.
+
+If they have their own footage, use `frames-from-video.mjs` instead of the procedural style.

--- a/plugins/scrollcraft/skills/scrollcraft/SKILL.md
+++ b/plugins/scrollcraft/skills/scrollcraft/SKILL.md
@@ -3,8 +3,9 @@ name: scrollcraft
 description: >
   Build a cinematic scroll-driven website where scrolling scrubs a canvas frame sequence,
   Apple-product-page style, and emit a self-contained static bundle that deploys to any
-  host with zero runtime dependencies. Turns a video or an existing image sequence into
-  frames, pins copy over them in sticky sections, and verifies the result before shipping.
+  host with zero runtime dependencies. Works from a video, an existing image sequence, or
+  no assets at all via generated cinematic backgrounds. Pins copy over the frames in sticky
+  sections and verifies the result before shipping.
   Use for: "scroll animation site", "scroll-scrubbed video", "Apple-style scroll page",
   "scrollytelling landing page", "frame sequence website", "cinematic landing page".
 ---
@@ -19,8 +20,21 @@ This skill builds sites locally. The hosted builder at
 https://github.com/singhharsh1708/scrollcraft additionally generates frame sequences from a
 text prompt, offers a visual editor with AI chat editing, and hosts the result. Both emit
 the same bundle layout, so a site built here can be opened in the hosted editor and vice
-versa. Reach for the hosted product when the user has no footage; use this skill when they
-have footage, or want the whole thing on disk and in version control.
+versa. Reach for the hosted product for a visual editor, AI chat editing and hosting; use
+this skill to work on disk and in version control, with or without footage of your own.
+
+## Fast path
+
+If the user has no footage and just wants a site, one command produces a working one:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/init.mjs" --name "Orrery" --style aurora
+```
+
+That writes `scrollcraft.json`, generates a procedural background plus its mobile set, and
+builds `dist/`. Then replace the placeholder sections with real copy and rebuild. **Never
+leave the starter copy in place** — it says "Replace this copy" and shipping it is worse
+than shipping nothing.
 
 ## Workflow
 
@@ -30,13 +44,11 @@ Work in a dedicated directory. Every script lives in `${CLAUDE_PLUGIN_ROOT}/skil
 
 Three cases:
 
-- **User has a video.** Best case. Short, slow, continuous camera motion works; hard cuts do not, because the scrub reads as a glitch. 4 to 12 seconds is the useful range.
+- **User has a video.** Short, slow, continuous camera motion works; hard cuts do not, because the scrub reads as a glitch. 4 to 12 seconds is the useful range.
 - **User has a numbered image sequence.** Rename to `frame_0000.jpg` upward, gap-free, and skip to step 3.
-- **User has nothing.** Do not fabricate footage. Say plainly that a frame sequence is required and point at the hosted builder, which generates one from a prompt.
+- **User has nothing.** Generate a procedural background — see step 2b. Do not fabricate footage and never invent a video path; if a path they gave does not exist, stop and ask.
 
-Never invent a video file. If the path does not exist, stop and ask.
-
-### 2. Extract frames
+### 2a. Extract frames from their video
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/frames-from-video.mjs" \
@@ -51,6 +63,23 @@ Budget: frame count is `fps × seconds`. At 24fps a 10-second clip is 240 frames
 150KB each that is ~36MB for the desktop set alone. Keep the pair under ~60MB total. Cut
 `--fps` before cutting `--width`, the eye forgives a lower frame rate more readily than a
 soft image.
+
+### 2b. Or generate one, no footage required
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/frames-from-style.mjs" --list
+node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/frames-from-style.mjs" \
+  --style nebula --count 180 --width 1920 --mobile-width 828 --mobile-out frames-mobile
+```
+
+Six styles, all measured dark enough to carry white text: `aurora`, `nebula`, `tide`,
+`ember`, `dusk`, `monolith`. See `references/styles.md`. These are roughly 15KB a frame
+rather than 150KB, so a 180-frame pair costs about 1MB total instead of 36MB — a
+procedural background is the cheaper choice on payload as well as effort.
+
+Pick the style from what the user is building, not at random, and say which you picked.
+`--colors` overrides the palette; if your override is too bright the script warns, because
+white copy over a light frame is unreadable no matter how good the palette looks alone.
 
 ### 3. Author the spec
 
@@ -110,6 +139,7 @@ These are what separate a convincing scroll site from an obviously generated one
 - **Let the footage breathe.** Sections that fire every 600px feel frantic. Long quiet stretches with no copy are correct and confident.
 - **Match copy to motion.** If the camera pushes in on section three, that is where the product name belongs.
 - **Accent colour, once.** `accentColor` on the eyebrow and the CTA, nowhere else.
+- **An image earns its place.** A section can carry one (`image`, `imageAlt`, `imageWidth`) — use it for a logo, product shot or diagram, not for decoration competing with the background.
 - **Contrast against the frames, not against black.** Light text over a bright frame is unreadable no matter what the palette says. Check the actual frames the copy sits over.
 - **Respect reduced motion.** The engine already disables the reveal transitions under `prefers-reduced-motion`. Do not add motion the setting cannot turn off.
 
@@ -119,3 +149,5 @@ These are what separate a convincing scroll site from an obviously generated one
 - Audio extensions are limited to mp3, m4a, wav, ogg, webm, aac, flac. Anything else is rejected, because static hosts serve unknown types as `application/octet-stream` and the browser silently declines to decode them.
 - Audio starts muted and only plays after a real user gesture. Autoplay with sound is blocked by every current browser, so do not present it as a feature that works unprompted.
 - `customCss` in the spec is filtered for `<script`, `<style`, `javascript:`/`data:` URLs and `expression(`. Treat it as a styling hook, not an extension point.
+- Section images must be `png`, `jpg`, `jpeg`, `webp`, `avif`, `gif` or `svg`. `imageWidth` is capped at 1600px. A missing image fails the build rather than shipping a broken tag.
+- `ffmpeg` is required for both frame paths and nothing else is. The build, doctor and preview server are plain Node with no dependencies.

--- a/plugins/scrollcraft/skills/scrollcraft/references/site-spec.md
+++ b/plugins/scrollcraft/skills/scrollcraft/references/site-spec.md
@@ -34,6 +34,9 @@ spec file, not the working directory.
 | `headingColor` | string | `#ffffff` | |
 | `bodyColor` | string | `rgba(255,255,255,0.7)` | |
 | `visible` | boolean | `true` | `false` excludes the section from both the output and the scroll-track total. |
+| `image` | string | none | Path to an image, resolved relative to the spec. Copied to `dist/assets/img_NN.<ext>`. Allowed: png, jpg, jpeg, webp, avif, gif, svg. A missing file fails the build. |
+| `imageAlt` | string | `""` | Alt text. Omitting it emits a build warning, because the image then carries nothing for a screen reader. |
+| `imageWidth` | number | `480` | Max rendered width in px, capped at 1600. The image never exceeds its container. |
 
 ## How pacing works
 

--- a/plugins/scrollcraft/skills/scrollcraft/references/styles.md
+++ b/plugins/scrollcraft/skills/scrollcraft/references/styles.md
@@ -1,0 +1,46 @@
+# Generated backgrounds
+
+`frames-from-style.mjs` renders a frame sequence with ffmpeg's `gradients` source, so a site
+needs no footage. Nothing is downloaded and no dependency is added: ffmpeg is already
+required for the video path.
+
+## The six styles
+
+Peak average luma is measured across the first frames of each render. It matters because the
+frames sit behind white copy: past roughly 90 the text stops being readable, and the script
+warns when a `--colors` override crosses that line.
+
+| Style | Look | Gradient type | Peak luma |
+| --- | --- | --- | --- |
+| `aurora` | cold blue-teal spiral, slow drift | spiral | 42 |
+| `nebula` | deep violet and blue, soft-focus | circular | 30 |
+| `tide` | dark teal linear sweep | linear | 27 |
+| `ember` | warm rust glow on near-black | radial | 22 |
+| `dusk` | plum and clay, square falloff | square | 36 |
+| `monolith` | graphite and steel, near-monochrome | square | 25 |
+
+All six sit far below the limit, so any of them carries white text safely.
+
+## Cost
+
+A generated frame is roughly 15KB at 1920px against roughly 150KB for a frame of real
+video, because a smooth gradient compresses far better than photographic detail. A
+180-frame desktop plus mobile pair lands near 1MB, where the same thing from video is
+closer to 36MB. On payload alone, generated backgrounds are the better default.
+
+## Overriding the palette
+
+```bash
+frames-from-style.mjs --style tide --colors "#01090d,#0a2f3a,#1d8b96,#02121a" --seed 42
+```
+
+Two to eight colours, the limit of the underlying filter. Keep the first and last dark: they
+dominate the frame edges, and the vignette that follows only darkens the corners. `--seed`
+changes where the gradient starts, `--speed` how far it travels per frame — lower is calmer
+and almost always better for a scroll background.
+
+## When to shoot instead
+
+Generated backgrounds are abstract. They cannot show a product, a place or a face. If the
+site is about a physical thing, use `frames-from-video.mjs` with real footage and accept the
+payload; an abstract gradient behind a product launch reads as a placeholder.

--- a/plugins/scrollcraft/skills/scrollcraft/scripts/build-site.mjs
+++ b/plugins/scrollcraft/skills/scrollcraft/scripts/build-site.mjs
@@ -15,6 +15,8 @@ const AUDIO_EXT = {
 
 const EXT_OK = new Set(Object.values(AUDIO_EXT));
 
+const IMAGE_EXT = new Set(["png", "jpg", "jpeg", "webp", "avif", "gif", "svg"]);
+
 function fail(msg) {
   process.stderr.write("build-site: " + msg + "\n");
   process.exit(1);
@@ -80,10 +82,16 @@ function copyFrames(srcDir, outDir) {
   }
 }
 
-function renderSections(sections) {
-  return sections.map((s) => {
+function renderSections(sections, images) {
+  return sections.map((s, idx) => {
     const height = Number(s.scrollHeight) || 1000;
     const parts = [];
+    const img = images.get(idx);
+    if (img) {
+      const w = Number(s.imageWidth);
+      const cap = Number.isFinite(w) && w > 0 ? Math.min(w, 1600) : 480;
+      parts.push(`<img src="${esc(img)}" alt="${esc(s.imageAlt || "")}" style="display:block; max-width:min(100%, ${cap}px); height:auto; margin:0 auto 1.5rem;" />`);
+    }
     if (s.eyebrow) {
       parts.push(`<p class="eyebrow" style="font-size:0.875rem; font-weight:600; letter-spacing:0.1em; text-transform:uppercase; color:${safeCss(s.accentColor || "#a78bfa")}; margin-bottom:0.75rem;">${esc(s.eyebrow)}</p>`);
     }
@@ -154,6 +162,24 @@ function main() {
     fs.copyFileSync(audioPath, path.join(outDir, audioOut));
   }
 
+  const images = new Map();
+  sections.forEach((s, idx) => {
+    if (!s.image) return;
+    const src = path.resolve(specDir, s.image);
+    if (!fs.existsSync(src)) fail(`section ${idx} image not found: ${src}`);
+    const ext = path.extname(src).slice(1).toLowerCase();
+    if (!IMAGE_EXT.has(ext)) {
+      fail(`section ${idx} image has unsupported extension ".${ext}" (allowed: ${[...IMAGE_EXT].join(", ")})`);
+    }
+    if (!s.imageAlt) {
+      process.stdout.write(`warning: section ${idx} has an image but no imageAlt, so screen readers get nothing\n`);
+    }
+    const name = `img_${String(idx).padStart(2, "0")}.${ext}`;
+    fs.mkdirSync(path.join(outDir, "assets"), { recursive: true });
+    fs.copyFileSync(src, path.join(outDir, "assets", name));
+    images.set(idx, `assets/${name}`);
+  });
+
   const css = fs.readFileSync(path.join(ENGINE, "scrollcraft.css"), "utf8");
   const runtime = fs
     .readFileSync(path.join(ENGINE, "scrollcraft.runtime.js"), "utf8")
@@ -165,6 +191,11 @@ function main() {
     .replace(/__FRAMES_MOBILE_DIR__/g, "frames-mobile")
     .replace(/__HAS_AUDIO__/g, audioOut ? "true" : "false")
     .replace(/__AUDIO_SRC__/g, audioOut);
+
+  const leftover = runtime.match(/__[A-Z][A-Z0-9_]*__/g);
+  if (leftover) {
+    fail(`engine placeholder(s) never substituted: ${[...new Set(leftover)].join(", ")}`);
+  }
 
   const title = esc(spec.name || "ScrollCraft Site");
   const description = esc(spec.description || "");
@@ -186,7 +217,7 @@ ${customCss ? `  <style>\n${customCss}\n  </style>\n` : ""}</head>
   <canvas id="scroll-canvas" role="img" aria-label="${esc(spec.canvasAlt || title)}"></canvas>
   <div id="scroll-container" style="height:${totalScrollHeight}px;">
     <div style="height:100vh;"></div>
-${renderSections(sections)}
+${renderSections(sections, images)}
   </div>
   <div id="scroll-hint" aria-hidden="true">
     <span>Scroll</span>

--- a/plugins/scrollcraft/skills/scrollcraft/scripts/frames-from-style.mjs
+++ b/plugins/scrollcraft/skills/scrollcraft/scripts/frames-from-style.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const RATE = 25;
+const LUMA_WARN = 90;
+
+const STYLES = {
+  aurora: {
+    blurb: "cold blue-teal spiral, slow drift",
+    colors: ["0x0b1026", "0x1b3a6b", "0x2f7d8c", "0x0b1026"],
+    type: "spiral", speed: 0.06, seed: 7, post: "vignette=PI/5",
+  },
+  nebula: {
+    blurb: "deep violet and blue, soft-focus",
+    colors: ["0x07030f", "0x2b1055", "0x6b2d8f", "0x1b6ba8", "0x07030f"],
+    type: "circular", speed: 0.04, seed: 11, post: "vignette=PI/4,gblur=sigma=1.2",
+  },
+  tide: {
+    blurb: "dark teal linear sweep",
+    colors: ["0x01090d", "0x073038", "0x14707d", "0x02121a"],
+    type: "linear", speed: 0.03, seed: 5, post: "vignette=PI/4",
+  },
+  ember: {
+    blurb: "warm rust glow on near-black",
+    colors: ["0x0d0503", "0x3d1206", "0x8c3a0d", "0x2a0d05", "0x0d0503"],
+    type: "radial", speed: 0.05, seed: 3, post: "vignette=PI/4,gblur=sigma=1.6",
+  },
+  dusk: {
+    blurb: "plum and clay, square falloff",
+    colors: ["0x120b1a", "0x3a1d3d", "0x8a4a55", "0x1d1024", "0x120b1a"],
+    type: "square", speed: 0.045, seed: 19, post: "vignette=PI/4",
+  },
+  monolith: {
+    blurb: "graphite and steel, near-monochrome",
+    colors: ["0x0a0c0f", "0x1e262e", "0x46545f", "0x0c0f13"],
+    type: "square", speed: 0.035, seed: 23, post: "vignette=PI/5",
+  },
+};
+
+function fail(msg) {
+  process.stderr.write("frames-from-style: " + msg + "\n");
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) out[key] = true;
+    else { out[key] = next; i++; }
+  }
+  return out;
+}
+
+function intArg(v, fallback, min, max, label) {
+  if (v === undefined) return fallback;
+  const n = Number(v);
+  if (!Number.isInteger(n)) fail(`${label} must be an integer`);
+  if (n < min || n > max) fail(`${label} must be between ${min} and ${max}`);
+  return n;
+}
+
+function haveFfmpeg() {
+  const p = spawnSync("ffmpeg", ["-version"], { stdio: "ignore" });
+  return !p.error && p.status === 0;
+}
+
+function normalizeColor(c, i) {
+  const s = String(c).trim().replace(/^#/, "").replace(/^0x/i, "");
+  if (!/^[0-9a-f]{6}$/i.test(s)) fail(`--colors entry ${i + 1} ("${c}") must be a 6-digit hex colour`);
+  return "0x" + s.toLowerCase();
+}
+
+function source(style, width, height, colors, speed, seed) {
+  const parts = [
+    `s=${width}x${height}`, `r=${RATE}`, `n=${colors.length}`,
+    ...colors.map((c, i) => `c${i}=${c}`),
+    `type=${style.type}`, `speed=${speed}`, `seed=${seed}`,
+  ];
+  return "gradients=" + parts.join(":");
+}
+
+function peakLuma(src, post, frames) {
+  const r = spawnSync("ffmpeg", [
+    "-hide_banner", "-f", "lavfi", "-i", src,
+    "-vf", `${post},signalstats,metadata=print`,
+    "-frames:v", String(Math.min(frames, 6)), "-f", "null", "-",
+  ], { encoding: "utf8" });
+  const vals = [...String(r.stderr || "").matchAll(/YAVG=([0-9.]+)/g)].map((m) => Number(m[1]));
+  return vals.length ? Math.max(...vals) : null;
+}
+
+function render(src, post, outDir, count, quality) {
+  fs.mkdirSync(outDir, { recursive: true });
+  for (const name of fs.readdirSync(outDir)) {
+    if (/^frame_\d{4}\.jpg$/.test(name)) fs.rmSync(path.join(outDir, name));
+  }
+  const r = spawnSync("ffmpeg", [
+    "-hide_banner", "-loglevel", "error",
+    "-f", "lavfi", "-i", src,
+    "-vf", post,
+    "-frames:v", String(count),
+    "-q:v", String(quality),
+    "-start_number", "0",
+    path.join(outDir, "frame_%04d.jpg"),
+  ], { stdio: ["ignore", "inherit", "inherit"] });
+  if (r.error) fail(`failed to run ffmpeg: ${r.error.message}`);
+  if (r.status !== 0) fail(`ffmpeg exited with status ${r.status}`);
+  const made = fs.readdirSync(outDir).filter((n) => /^frame_\d{4}\.jpg$/.test(n));
+  if (made.length !== count) fail(`expected ${count} frames, ffmpeg produced ${made.length}`);
+  let bytes = 0;
+  for (const n of made) bytes += fs.statSync(path.join(outDir, n)).size;
+  return { count: made.length, bytes };
+}
+
+function mib(b) { return (b / 1024 / 1024).toFixed(1) + " MiB"; }
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.list || args.help) {
+    process.stdout.write(
+      "Usage: frames-from-style.mjs --style <name> [--out frames] [--count 180] [--width 1920]\n" +
+      "                            [--mobile-width 828] [--mobile-out frames-mobile]\n" +
+      "                            [--colors '#0b1026,#1b3a6b,...'] [--speed 0.05] [--seed 7] [--quality 4]\n\nStyles:\n"
+    );
+    for (const [k, v] of Object.entries(STYLES)) {
+      process.stdout.write(`  ${k.padEnd(9)} ${v.blurb}\n`);
+    }
+    return;
+  }
+
+  const name = typeof args.style === "string" ? args.style : null;
+  if (!name) fail("--style <name> is required. Run with --list to see the styles.");
+  const style = STYLES[name];
+  if (!style) fail(`unknown style "${name}". Run with --list to see the styles.`);
+
+  if (!haveFfmpeg()) {
+    fail("ffmpeg not found on PATH. Install it (macOS: brew install ffmpeg, Debian: apt install ffmpeg) and retry.");
+  }
+
+  const outDir = typeof args.out === "string" ? args.out : "frames";
+  const count = intArg(args.count, 180, 2, 9999, "--count");
+  const width = intArg(args.width, 1920, 320, 3840, "--width");
+  const quality = intArg(args.quality, 4, 1, 31, "--quality");
+  const seed = intArg(args.seed, style.seed, 0, 4294967295, "--seed");
+
+  let speed = style.speed;
+  if (args.speed !== undefined) {
+    speed = Number(args.speed);
+    if (!Number.isFinite(speed) || speed <= 0 || speed > 1) fail("--speed must be between 0 and 1");
+  }
+
+  let colors = style.colors;
+  if (typeof args.colors === "string") {
+    const list = args.colors.split(",").map((s) => s.trim()).filter(Boolean);
+    if (list.length < 2 || list.length > 8) fail("--colors needs between 2 and 8 comma-separated hex colours");
+    colors = list.map(normalizeColor);
+  }
+
+  const height = Math.round(width * 9 / 16 / 2) * 2;
+  const src = source(style, width, height, colors, speed, seed);
+  const peak = peakLuma(src, style.post, count);
+  if (peak !== null && peak > LUMA_WARN) {
+    process.stdout.write(
+      `warning: peak average luma ${peak.toFixed(1)} is bright for a background carrying white text. ` +
+      `Darken the first and last --colors entries.\n`
+    );
+  }
+
+  const desktop = render(src, style.post, outDir, count, quality);
+  process.stdout.write(`${outDir}: ${desktop.count} frames, ${mib(desktop.bytes)}` +
+    (peak !== null ? `, peak luma ${peak.toFixed(1)}` : "") + "\n");
+
+  let mobile = null;
+  if (args["mobile-width"] !== undefined || args["mobile-out"] !== undefined) {
+    const mw = intArg(args["mobile-width"], 828, 320, 1600, "--mobile-width");
+    const mOut = typeof args["mobile-out"] === "string" ? args["mobile-out"] : "frames-mobile";
+    const mh = Math.round(mw * 9 / 16 / 2) * 2;
+    mobile = render(source(style, mw, mh, colors, speed, seed), style.post, mOut, count, quality);
+    process.stdout.write(`${mOut}: ${mobile.count} frames, ${mib(mobile.bytes)}\n`);
+  } else {
+    process.stdout.write("note: no mobile set built. Pass --mobile-width 828 so phones do not download desktop frames.\n");
+  }
+}
+
+main();

--- a/plugins/scrollcraft/skills/scrollcraft/scripts/init.mjs
+++ b/plugins/scrollcraft/skills/scrollcraft/scripts/init.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+function fail(msg) {
+  process.stderr.write("init: " + msg + "\n");
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) out[key] = true;
+    else { out[key] = next; i++; }
+  }
+  return out;
+}
+
+function run(script, args) {
+  const r = spawnSync(process.execPath, [path.join(HERE, script), ...args], {
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  if (r.error) fail(`could not run ${script}: ${r.error.message}`);
+  if (r.status !== 0) fail(`${script} failed with status ${r.status}`);
+}
+
+function starterSpec(name, style) {
+  return {
+    name,
+    description: `${name} — a scroll-driven story.`,
+    canvasAlt: `Abstract ${style} background that shifts as the page scrolls`,
+    framesMobile: "frames-mobile",
+    sections: [
+      {
+        eyebrow: "Introducing",
+        heading: name,
+        body: "Replace this copy. One idea per section, a heading and at most two lines — the reader is scrolling, not studying.",
+        scrollHeight: 1400,
+      },
+      {
+        heading: "Give the good part room",
+        body: "This section owns more of the scroll track than the others, so the background moves further while it is on screen.",
+        scrollHeight: 2000,
+      },
+      {
+        heading: "Then ask for something",
+        ctaLabel: "Get started",
+        ctaHref: "https://example.com",
+        scrollHeight: 1000,
+      },
+    ],
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(
+      "Usage: init.mjs [--name \"My Site\"] [--style aurora] [--dir .] [--count 180]\n" +
+      "                [--width 1920] [--force] [--no-build]\n\n" +
+      "Scaffolds scrollcraft.json, generates a frame set, and builds dist/ so there is\n" +
+      "something real on screen before you write any copy.\n"
+    );
+    return;
+  }
+
+  const dir = path.resolve(typeof args.dir === "string" ? args.dir : ".");
+  const name = typeof args.name === "string" ? args.name : "Untitled";
+  const style = typeof args.style === "string" ? args.style : "aurora";
+  const count = typeof args.count === "string" ? args.count : "180";
+  const width = typeof args.width === "string" ? args.width : "1920";
+
+  fs.mkdirSync(dir, { recursive: true });
+  const specPath = path.join(dir, "scrollcraft.json");
+
+  if (fs.existsSync(specPath) && !args.force) {
+    fail(`${specPath} already exists. Pass --force to overwrite it, or --dir to scaffold elsewhere.`);
+  }
+
+  fs.writeFileSync(specPath, JSON.stringify(starterSpec(name, style), null, 2) + "\n");
+  process.stdout.write(`wrote ${path.relative(process.cwd(), specPath) || "scrollcraft.json"}\n`);
+
+  run("frames-from-style.mjs", [
+    "--style", style, "--count", count, "--width", width,
+    "--out", path.join(dir, "frames"),
+    "--mobile-out", path.join(dir, "frames-mobile"),
+    "--mobile-width", "828",
+  ]);
+
+  if (!args["no-build"]) {
+    run("build-site.mjs", ["--spec", specPath, "--out", path.join(dir, "dist")]);
+  }
+
+  const rel = path.relative(process.cwd(), dir) || ".";
+  const shortest = (p) => {
+    const r = path.relative(process.cwd(), p);
+    return !r || r.startsWith("..") ? p : r;
+  };
+  process.stdout.write(
+    "\nNext:\n" +
+    `  1. open ${path.join(rel, "scrollcraft.json")} and write your own sections\n` +
+    `  2. node ${shortest(path.join(HERE, "build-site.mjs"))} --spec ${path.join(rel, "scrollcraft.json")} --out ${path.join(rel, "dist")}\n` +
+    `  3. node ${shortest(path.join(HERE, "serve.mjs"))} --dir ${path.join(rel, "dist")}\n` +
+    `\nTo try another look: ${shortest(path.join(HERE, "frames-from-style.mjs"))} --list\n`
+  );
+}
+
+main();

--- a/src/__tests__/skillScaffold.test.ts
+++ b/src/__tests__/skillScaffold.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SCRIPTS = path.resolve(__dirname, "../../plugins/scrollcraft/skills/scrollcraft/scripts");
+const INIT = path.join(SCRIPTS, "init.mjs");
+const STYLE = path.join(SCRIPTS, "frames-from-style.mjs");
+const BUILD = path.join(SCRIPTS, "build-site.mjs");
+
+const hasFfmpeg = spawnSync("ffmpeg", ["-version"], { stdio: "ignore" }).status === 0;
+const ffmpegIt = hasFfmpeg ? it : it.skip;
+
+const ONE_PX_JPEG = Buffer.from(
+  "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRof" +
+    "Hh0aHBwcJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPDU0NP/bAEMBCQkJDAsMGA0NGDIhHCEy" +
+    "MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAB" +
+    "AAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAA" +
+    "AAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMB" +
+    "AAIRAxEAPwCdABmX/9k=",
+  "base64"
+);
+
+let tmp: string;
+const node = (script: string, args: string[]) =>
+  spawnSync(process.execPath, [script, ...args], { encoding: "utf8", cwd: tmp });
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "scrollcraft-scaffold-"));
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("skill frames-from-style", () => {
+  it("lists every style with a description", () => {
+    const run = node(STYLE, ["--list"]);
+    expect(run.status).toBe(0);
+    for (const s of ["aurora", "nebula", "tide", "ember", "dusk", "monolith"]) {
+      expect(run.stdout).toContain(s);
+    }
+  });
+
+  it("rejects an unknown style rather than guessing one", () => {
+    const run = node(STYLE, ["--style", "banana"]);
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain('unknown style "banana"');
+  });
+
+  it("requires a style", () => {
+    const run = node(STYLE, []);
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("--style");
+  });
+
+  it("rejects a malformed colour", () => {
+    const run = node(STYLE, ["--style", "aurora", "--colors", "#0b1026,nope"]);
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("6-digit hex");
+  });
+
+  it("rejects a colour list outside the filter's 2-8 range", () => {
+    const run = node(STYLE, ["--style", "aurora", "--colors", "#0b1026"]);
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("between 2 and 8");
+  });
+
+  it("rejects an out-of-range frame count", () => {
+    const run = node(STYLE, ["--style", "aurora", "--count", "99999"]);
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("--count");
+  });
+
+  ffmpegIt("renders a gap-free sequence the build accepts", () => {
+    const run = node(STYLE, ["--style", "monolith", "--count", "6", "--width", "320", "--out", "frames"]);
+    expect(run.status).toBe(0);
+    const names = fs.readdirSync(path.join(tmp, "frames")).sort();
+    expect(names).toEqual([
+      "frame_0000.jpg", "frame_0001.jpg", "frame_0002.jpg",
+      "frame_0003.jpg", "frame_0004.jpg", "frame_0005.jpg",
+    ]);
+  });
+
+  ffmpegIt("produces frames that actually differ, or the scrub would be static", () => {
+    expect(node(STYLE, ["--style", "aurora", "--count", "6", "--width", "320", "--out", "frames"]).status).toBe(0);
+    const read = (n: string) => fs.readFileSync(path.join(tmp, "frames", n)).toString("base64");
+    expect(read("frame_0000.jpg")).not.toEqual(read("frame_0005.jpg"));
+  });
+
+  ffmpegIt("keeps the built-in styles dark enough for white text", () => {
+    const run = node(STYLE, ["--style", "nebula", "--count", "4", "--width", "320", "--out", "frames"]);
+    expect(run.status).toBe(0);
+    const peak = Number(/peak luma ([0-9.]+)/.exec(run.stdout)?.[1]);
+    expect(peak).toBeLessThan(90);
+  });
+
+  ffmpegIt("warns when custom colours are too bright to carry white text", () => {
+    const run = node(STYLE, [
+      "--style", "tide", "--count", "4", "--width", "320", "--out", "frames",
+      "--colors", "#ffffff,#fafafa,#ffffff",
+    ]);
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("bright for a background carrying white text");
+  });
+});
+
+describe("skill init", () => {
+  ffmpegIt("scaffolds a spec, frames and a built site in one command", () => {
+    const run = node(INIT, ["--name", "Orrery", "--style", "tide", "--count", "4", "--width", "320"]);
+    expect(run.status).toBe(0);
+
+    const spec = JSON.parse(fs.readFileSync(path.join(tmp, "scrollcraft.json"), "utf8"));
+    expect(spec.name).toBe("Orrery");
+    expect(spec.sections.length).toBeGreaterThan(1);
+    expect(spec.canvasAlt).toBeTruthy();
+
+    const html = fs.readFileSync(path.join(tmp, "dist", "index.html"), "utf8");
+    expect(html).toContain("<title>Orrery</title>");
+    expect(html).toContain("var hasMobile = true;");
+    expect(fs.readdirSync(path.join(tmp, "dist", "frames"))).toHaveLength(4);
+    expect(fs.readdirSync(path.join(tmp, "dist", "frames-mobile"))).toHaveLength(4);
+  });
+
+  ffmpegIt("refuses to overwrite an existing spec without --force", () => {
+    fs.writeFileSync(path.join(tmp, "scrollcraft.json"), '{"mine":true}');
+    const run = node(INIT, ["--name", "X", "--count", "4", "--width", "320"]);
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("--force");
+    expect(JSON.parse(fs.readFileSync(path.join(tmp, "scrollcraft.json"), "utf8")).mine).toBe(true);
+  });
+
+  it("fails on an unknown style before writing anything", () => {
+    const run = node(INIT, ["--name", "X", "--style", "banana"]);
+    expect(run.status).toBe(1);
+    expect(fs.existsSync(path.join(tmp, "frames"))).toBe(false);
+  });
+});
+
+describe("skill build-site section images", () => {
+  const frames = () => {
+    fs.mkdirSync(path.join(tmp, "frames"), { recursive: true });
+    fs.writeFileSync(path.join(tmp, "frames", "frame_0000.jpg"), ONE_PX_JPEG);
+  };
+  const spec = (o: unknown) => fs.writeFileSync(path.join(tmp, "scrollcraft.json"), JSON.stringify(o));
+  const build = () => node(BUILD, ["--spec", "scrollcraft.json", "--out", "dist"]);
+  const html = () => fs.readFileSync(path.join(tmp, "dist", "index.html"), "utf8");
+
+  it("copies a section image into assets and renders it with its alt text", () => {
+    frames();
+    fs.writeFileSync(path.join(tmp, "logo.png"), ONE_PX_JPEG);
+    spec({ sections: [{ heading: "A", image: "logo.png", imageAlt: "Orrery logo" }] });
+
+    expect(build().status).toBe(0);
+    expect(fs.existsSync(path.join(tmp, "dist", "assets", "img_00.png"))).toBe(true);
+    expect(html()).toContain('src="assets/img_00.png"');
+    expect(html()).toContain('alt="Orrery logo"');
+  });
+
+  it("warns when a section image has no alt text", () => {
+    frames();
+    fs.writeFileSync(path.join(tmp, "logo.png"), ONE_PX_JPEG);
+    spec({ sections: [{ heading: "A", image: "logo.png" }] });
+
+    const run = build();
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("imageAlt");
+  });
+
+  it("fails on a missing image rather than emitting a broken tag", () => {
+    frames();
+    spec({ sections: [{ heading: "A", image: "nope.png" }] });
+
+    const run = build();
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("image not found");
+  });
+
+  it("rejects an image type browsers will not render", () => {
+    frames();
+    fs.writeFileSync(path.join(tmp, "art.psd"), "nope");
+    spec({ sections: [{ heading: "A", image: "art.psd" }] });
+
+    const run = build();
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("unsupported extension");
+  });
+
+  it("caps an oversized imageWidth instead of trusting it", () => {
+    frames();
+    fs.writeFileSync(path.join(tmp, "logo.png"), ONE_PX_JPEG);
+    spec({ sections: [{ heading: "A", image: "logo.png", imageAlt: "x", imageWidth: 99999 }] });
+
+    expect(build().status).toBe(0);
+    expect(html()).toContain("max-width:min(100%, 1600px)");
+  });
+
+  it("escapes hostile alt text", () => {
+    frames();
+    fs.writeFileSync(path.join(tmp, "logo.png"), ONE_PX_JPEG);
+    spec({ sections: [{ heading: "A", image: "logo.png", imageAlt: '"><script>alert(1)</script>' }] });
+
+    expect(build().status).toBe(0);
+    expect(html()).not.toContain("<script>alert(1)</script>");
+  });
+});


### PR DESCRIPTION
# Description

Follow-up to #179. That shipped the skill; this makes it something a stranger can actually use.

Two things made the first five minutes bad, and both are gone:

- **It required footage.** Anyone without a video was stuck. Now backgrounds can be generated.
- **It required hand-authoring `scrollcraft.json`.** Now one command produces a served, working site.

## Generated backgrounds, no assets needed

`frames-from-style.mjs` renders a frame sequence from ffmpeg's `gradients` source. ffmpeg was already required for the video path, so this adds no dependency and downloads nothing.

Six styles ship. They were chosen by **measurement, not taste**: the frames sit behind white copy, so each was checked for peak average luma via `signalstats`. Two candidates were cut for failing that — an early `tide` at **YAVG 118.9** and a mandelbrot style whose palette came out bright and garish. Both looked acceptable in isolation and would have made the copy unreadable.

| Style | Look | Peak luma |
| --- | --- | --- |
| `aurora` | cold blue-teal spiral | 42 |
| `nebula` | deep violet and blue, soft-focus | 30 |
| `tide` | dark teal linear sweep | 27 |
| `ember` | warm rust glow on near-black | 22 |
| `dusk` | plum and clay, square falloff | 36 |
| `monolith` | graphite and steel, near-monochrome | 25 |

A `--colors` override that crosses the threshold warns rather than failing, since it may be deliberate.

**It is also the cheaper option.** A generated frame is roughly 15KB at 1920px against roughly 150KB for a frame of real video, because a smooth gradient compresses far better than photographic detail. A 180-frame desktop plus mobile pair lands near 1MB where the same thing from video is closer to 36MB.

The honest limit is documented too: generated backgrounds are abstract and cannot show a product, place or face. `references/styles.md` says so and points at real footage when the site is about a physical thing.

## One-command scaffold

```bash
node init.mjs --name "Orrery" --style aurora
```

Writes the spec, generates desktop and mobile frame sets, builds `dist/`. It refuses to overwrite an existing `scrollcraft.json` without `--force`, and fails on an unknown style before writing anything.

## Section images

Sections were text-only, so a site could not show its own logo or product. This is the gap filed as #245 for the hosted app, closed on the skill side: `image`, `imageAlt`, `imageWidth`. The file is copied to `dist/assets/img_NN.<ext>`, width is capped at 1600px, a missing file fails the build rather than emitting a broken tag, and a missing `imageAlt` warns.

## Unsubstituted-placeholder guard

The engine runtime is token-substituted at build time. If a placeholder were added and not substituted, the build previously succeeded and shipped a runtime that threw on load. The build now refuses. This is self-defence against a future edit to this code, not a bug being fixed today.

## Slash commands

`/scrollcraft-new` and `/scrollcraft-build`, so the plugin is discoverable without reading `SKILL.md`.

## Behaviour change worth calling out

The `SKILL.md` frontmatter `description` changed. That string decides when the skill activates, and it previously said the skill "turns a video or an existing image sequence into frames" — which would have kept it from triggering for someone with no assets, exactly the case this PR adds support for. It is the one change with effects beyond the files in the diff.

## Testing

`src/__tests__/skillScaffold.test.ts`, 19 cases driving the real scripts as subprocesses: style listing, unknown-style refusal, malformed and out-of-range `--colors`, out-of-range `--count`, gap-free output, frames actually differing (a static scrub is the failure mode that looks fine), the luma floor holding for built-in styles, the brightness warning firing, the full init scaffold, clobber refusal, and the six section-image cases including escaped hostile alt text and the width cap.

ffmpeg-dependent cases skip cleanly via `it.skip` where ffmpeg is absent instead of failing.

Measured on this branch:

- `npx tsc --noEmit` clean
- `npx eslint` clean, confirmed reaching the new `.mjs` files
- `npx vitest run` **151 passed / 10 files**, up from 132 / 9 on `main`
- `npx next build` succeeds, route table unchanged
- new test file adds ~1.33s, because it renders real frames through ffmpeg

The suite is not vacuous. Five mutations, each caught: removing the `imageWidth` cap, unescaping `imageAlt`, raising the luma threshold so the warning never fires, letting an unknown style fall through, and leaving an engine placeholder unsubstituted (that one fails 16 tests).

End to end, run for real: `init.mjs` scaffolded a project, generated 60 desktop and 60 mobile frames at 0.9 and 0.5 MiB with peak luma 36.2, built a 5400px track, and `serve.mjs` returned 200 for `index.html` and for `frames/frame_0059.jpg` with zero unresolved placeholders in the output.

## Type of change

- [x] ✨ New feature
- [x] 📝 Documentation

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes
- [x] `npm run build` passes
- [x] I updated docs / `.env.example` if config or env vars changed
- [x] I added tests for new logic where practical

## Risks and trade-offs

- **The luma threshold is a heuristic.** Mean luma does not capture a bright patch behind a specific line of copy. It catches the common failure and does not replace looking at the page.
- **`gradients` output depends on the local ffmpeg build.** Frame bytes may differ slightly across versions. The tests assert structure, counts and that frames differ, never exact bytes.
- **Six styles is a small palette** and they will start to look recognisable if the skill gets used widely. `--colors`, `--seed` and `--speed` are the escape hatch; more styles are cheap to add.