### PR TITLE
feat(skill): verify what renders, and let sections change shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,17 @@ node scripts/frames-from-style.mjs --style nebula --count 180 \
 # 2. write scrollcraft.json describing your sections, then build
 node scripts/build-site.mjs --spec scrollcraft.json --out dist
 
-# 3. check it before shipping, then look at it
+# 3. check the files, then check what actually renders
 node scripts/doctor.mjs --spec scrollcraft.json
+node scripts/verify.mjs --dir dist --shots shots
 node scripts/serve.mjs --dir dist --port 4321
 ```
+
+`verify.mjs` drives headless Chrome over the DevTools Protocol with no npm dependencies,
+scrolls the built page, and measures the frames a reader actually sees: that the canvas
+paints, that it advances, and that every line of copy clears 4.5:1 contrast against the
+pixels behind it. It catches the failure that matters — a missing frame set renders a black
+canvas, throws nothing, and logs nothing.
 
 Two slash commands come with the plugin: `/scrollcraft-new` to start a site and
 `/scrollcraft-build` to rebuild, check and preview one.

--- a/plugins/scrollcraft/commands/scrollcraft-build.md
+++ b/plugins/scrollcraft/commands/scrollcraft-build.md
@@ -6,10 +6,12 @@ Rebuild and verify the scroll site in the current directory.
 
 1. `node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/build-site.mjs" --spec scrollcraft.json --out dist`
 2. `node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/doctor.mjs" --spec scrollcraft.json`
-3. If the doctor exits non-zero, fix what it reports before saying anything succeeded.
-4. `node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/serve.mjs" --dir dist` and give the user the URL.
+3. `node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/verify.mjs" --dir dist --shots shots`
+4. If either exits non-zero, fix what it reports before saying anything succeeded. Contrast
+   failures are real: they mean the copy cannot be read over the frame behind it.
+5. `node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/serve.mjs" --dir dist` and give the user the URL.
 
 A build that succeeds is not evidence the page works — a missing frame renders as a black canvas
-with no error. Say what you actually verified.
+with no error, which is exactly what `verify` catches. Report the contrast figure it measured.
 
 $ARGUMENTS

--- a/plugins/scrollcraft/commands/scrollcraft-new.md
+++ b/plugins/scrollcraft/commands/scrollcraft-new.md
@@ -15,6 +15,7 @@ Steps:
 3. Scaffold with `node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/init.mjs" --name "<name>" --style <style>`.
 4. Rewrite the placeholder sections in `scrollcraft.json` as real copy for their subject. One idea
    per section. Do not leave the starter text in place.
-5. Rebuild, run the doctor, then serve it and tell them the URL.
+5. Vary each section's `layout` so consecutive screens do not share a shape.
+6. Rebuild, run `doctor.mjs` and `verify.mjs`, then serve it and tell them the URL and the measured contrast.
 
 If they have their own footage, use `frames-from-video.mjs` instead of the procedural style.

--- a/plugins/scrollcraft/skills/scrollcraft/SKILL.md
+++ b/plugins/scrollcraft/skills/scrollcraft/SKILL.md
@@ -114,18 +114,31 @@ when the spec names audio. All CSS and JS is inlined into the one HTML file.
 
 ### 5. Verify before claiming it works
 
+Two checks. Run both. Neither is optional.
+
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/doctor.mjs" --spec scrollcraft.json
-node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/serve.mjs" --dir dist --port 4321
+node "${CLAUDE_PLUGIN_ROOT}/skills/scrollcraft/scripts/verify.mjs" --dir dist --shots shots
 ```
 
-`doctor` exits non-zero on a real problem: gapped frame sequence, empty spec, missing audio,
-non-positive `scrollHeight`. Fix those before reporting success. It also warns on heavy
-frame payloads and missing mobile sets, which are judgement calls, not failures.
+`doctor` reads the files: gapped frame sequence, empty spec, missing audio, non-positive
+`scrollHeight`. It cannot tell you the page renders.
 
-Then actually look at the page. Load `http://127.0.0.1:4321`, scroll it, and confirm the
-background advances and the copy pins. A frame sequence that 404s renders as a black canvas
-with no error, so "the build succeeded" is not evidence the site works.
+`verify` opens the built site in headless Chrome, scrolls it, and measures what the reader
+actually sees at each position:
+
+- the canvas is painting at all, instead of the black rectangle a 404 frame produces
+- the background genuinely advances, instead of holding one frame the whole way down
+- **every line of copy clears 4.5:1 contrast against the pixels behind it**, sampled from the
+  real composite at that scroll offset, with an element's own background used when it has one
+- nothing 404s, nothing throws, the page never scrolls sideways
+
+It exits non-zero on any of those. `--shots <dir>` also writes a PNG per sampled position if
+you want to look. It needs Chrome, Chromium or Edge on the machine and nothing installed.
+
+This is the check that matters, because the characteristic failure of this kind of page is
+silent: a missing frame set renders a black canvas, throws nothing, and logs nothing. A build
+that exits 0 is not evidence the site works. `verify` exiting 0 is.
 
 ### 6. Deploy
 
@@ -135,6 +148,9 @@ with no error, so "the build succeeded" is not evidence the site works.
 
 These are what separate a convincing scroll site from an obviously generated one.
 
+- **Vary the layout.** Every section takes `layout`: `center`, `left`, `right`, `lower-third`,
+  `upper-third`. Consecutive screens that share a shape are what makes a scroll site read as a
+  template. The build says so when all of them match.
 - **One idea per section.** A heading and at most two lines. The reader is scrolling, not studying.
 - **Let the footage breathe.** Sections that fire every 600px feel frantic. Long quiet stretches with no copy are correct and confident.
 - **Match copy to motion.** If the camera pushes in on section three, that is where the product name belongs.

--- a/plugins/scrollcraft/skills/scrollcraft/references/site-spec.md
+++ b/plugins/scrollcraft/skills/scrollcraft/references/site-spec.md
@@ -21,16 +21,17 @@ spec file, not the working directory.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
+| `layout` | string | `center` | One of `center`, `left`, `right`, `lower-third`, `upper-third`. Sets alignment, measure and padding together. An unknown value fails the build. |
 | `heading` | string | none | Renders as `<h2>`, `clamp(2rem, 5vw, 4rem)`. |
 | `body` | string | none | One paragraph, capped at 600px measure. |
 | `eyebrow` | string | none | Small uppercase label above the heading. |
 | `ctaLabel` | string | none | Renders a button-styled link. Needs `ctaHref` to go anywhere. |
 | `ctaHref` | string | `"#"` | Only `http://`, `https://` and in-page `#anchors` survive; anything else becomes `#`. |
 | `scrollHeight` | number | `1000` | Scroll track in px this section occupies. Drives pacing. |
-| `align` | string | `"center"` | Flex `align-items` on the sticky wrapper. |
-| `justify` | string | `"center"` | Flex `justify-content`. |
-| `textAlign` | string | `"center"` | Text alignment inside the content block. |
-| `accentColor` | string | `#a78bfa` eyebrow / `#7c3aed` CTA | Used for both. |
+| `align` | string | from `layout` | Flex `align-items` on the sticky wrapper. Overrides the layout. |
+| `justify` | string | from `layout` | Flex `justify-content`. Overrides the layout. |
+| `textAlign` | string | from `layout` | Text alignment inside the content block. Overrides the layout. |
+| `accentColor` | string | `#ddd6fe` eyebrow / `#7c3aed` CTA | Used for both. Note the two roles pull in opposite directions: a colour readable as text on a dark frame is usually too light behind white CTA text. Run `verify.mjs` after overriding it. |
 | `headingColor` | string | `#ffffff` | |
 | `bodyColor` | string | `rgba(255,255,255,0.7)` | |
 | `visible` | boolean | `true` | `false` excludes the section from both the output and the scroll-track total. |

--- a/plugins/scrollcraft/skills/scrollcraft/scripts/build-site.mjs
+++ b/plugins/scrollcraft/skills/scrollcraft/scripts/build-site.mjs
@@ -17,6 +17,14 @@ const EXT_OK = new Set(Object.values(AUDIO_EXT));
 
 const IMAGE_EXT = new Set(["png", "jpg", "jpeg", "webp", "avif", "gif", "svg"]);
 
+const LAYOUTS = {
+  center: { align: "center", justify: "center", textAlign: "center", maxWidth: 800, pad: "2rem" },
+  left: { align: "center", justify: "flex-start", textAlign: "left", maxWidth: 620, pad: "2rem clamp(2rem, 8vw, 8rem)" },
+  right: { align: "center", justify: "flex-end", textAlign: "left", maxWidth: 620, pad: "2rem clamp(2rem, 8vw, 8rem)" },
+  "lower-third": { align: "flex-end", justify: "flex-start", textAlign: "left", maxWidth: 900, pad: "0 clamp(2rem, 8vw, 8rem) clamp(3rem, 10vh, 7rem)" },
+  "upper-third": { align: "flex-start", justify: "center", textAlign: "center", maxWidth: 800, pad: "clamp(3rem, 12vh, 8rem) 2rem 0" },
+};
+
 function fail(msg) {
   process.stderr.write("build-site: " + msg + "\n");
   process.exit(1);
@@ -85,28 +93,31 @@ function copyFrames(srcDir, outDir) {
 function renderSections(sections, images) {
   return sections.map((s, idx) => {
     const height = Number(s.scrollHeight) || 1000;
+    const L = LAYOUTS[s.layout] || LAYOUTS.center;
     const parts = [];
     const img = images.get(idx);
     if (img) {
       const w = Number(s.imageWidth);
       const cap = Number.isFinite(w) && w > 0 ? Math.min(w, 1600) : 480;
-      parts.push(`<img src="${esc(img)}" alt="${esc(s.imageAlt || "")}" style="display:block; max-width:min(100%, ${cap}px); height:auto; margin:0 auto 1.5rem;" />`);
+      const m = L.textAlign === "center" ? "0 auto 1.5rem" : "0 0 1.5rem";
+      parts.push(`<img src="${esc(img)}" alt="${esc(s.imageAlt || "")}" style="display:block; max-width:min(100%, ${cap}px); height:auto; margin:${m};" />`);
     }
     if (s.eyebrow) {
-      parts.push(`<p class="eyebrow" style="font-size:0.875rem; font-weight:600; letter-spacing:0.1em; text-transform:uppercase; color:${safeCss(s.accentColor || "#a78bfa")}; margin-bottom:0.75rem;">${esc(s.eyebrow)}</p>`);
+      parts.push(`<p class="eyebrow" style="font-size:0.875rem; font-weight:600; letter-spacing:0.1em; text-transform:uppercase; color:${safeCss(s.accentColor || "#ddd6fe")}; margin-bottom:0.75rem;">${esc(s.eyebrow)}</p>`);
     }
     if (s.heading) {
       parts.push(`<h2 style="font-size:clamp(2rem,5vw,4rem); font-weight:900; line-height:1; letter-spacing:-0.03em; color:${safeCss(s.headingColor || "#ffffff")}; margin-bottom:1rem;">${esc(s.heading)}</h2>`);
     }
+    const bodyMargin = L.textAlign === "center" ? "0 auto 1.5rem" : "0 0 1.5rem";
     if (s.body) {
-      parts.push(`<p style="font-size:1.125rem; line-height:1.7; color:${safeCss(s.bodyColor || "rgba(255,255,255,0.7)")}; max-width:600px; margin:0 auto 1.5rem;">${esc(s.body)}</p>`);
+      parts.push(`<p style="font-size:1.125rem; line-height:1.7; color:${safeCss(s.bodyColor || "rgba(255,255,255,0.72)")}; max-width:600px; margin:${bodyMargin};">${esc(s.body)}</p>`);
     }
     if (s.ctaLabel) {
       parts.push(`<a href="${esc(safeHref(s.ctaHref || "#"))}" style="display:inline-block; background:${safeCss(s.accentColor || "#7c3aed")}; color:#fff; padding:0.875rem 2rem; border-radius:0.5rem; font-weight:600; text-decoration:none; font-size:1rem;">${esc(s.ctaLabel)}</a>`);
     }
     return `    <section class="scroll-section" style="height:${height}px; position:relative; z-index:10;">
-      <div class="section-sticky" style="position:sticky; top:0; height:100vh; display:flex; align-items:${safeCss(s.align || "center")}; justify-content:${safeCss(s.justify || "center")}; overflow:hidden;">
-        <div class="section-content" style="text-align:${safeCss(s.textAlign || "center")}; padding:2rem; max-width:800px; opacity:0; transform:translateY(32px); transition:opacity 0.6s cubic-bezier(0.25,0.46,0.45,0.94),transform 0.6s cubic-bezier(0.25,0.46,0.45,0.94);">
+      <div class="section-sticky" style="position:sticky; top:0; height:100vh; display:flex; align-items:${safeCss(s.align || L.align)}; justify-content:${safeCss(s.justify || L.justify)}; overflow:hidden;">
+        <div class="section-content" style="text-align:${safeCss(s.textAlign || L.textAlign)}; padding:${L.pad}; max-width:${L.maxWidth}px; opacity:0; transform:translateY(32px); transition:opacity 0.6s cubic-bezier(0.25,0.46,0.45,0.94),transform 0.6s cubic-bezier(0.25,0.46,0.45,0.94);">
 ${parts.map((p) => "          " + p).join("\n")}
         </div>
       </div>
@@ -142,6 +153,22 @@ function main() {
 
   const sections = Array.isArray(spec.sections) ? spec.sections.filter((s) => s && s.visible !== false) : [];
   if (sections.length === 0) fail("spec needs at least one section with visible !== false");
+
+  sections.forEach((s, i) => {
+    if (s.layout !== undefined && !LAYOUTS[s.layout]) {
+      fail(`section ${i} has unknown layout "${s.layout}" (allowed: ${Object.keys(LAYOUTS).join(", ")})`);
+    }
+  });
+
+  if (sections.length > 2) {
+    const used = new Set(sections.map((s) => s.layout || "center"));
+    if (used.size === 1) {
+      process.stdout.write(
+        `note: all ${sections.length} sections use the "${[...used][0]}" layout, so every screen has the same shape. ` +
+        `Vary "layout" (${Object.keys(LAYOUTS).join(", ")}) so the page does not read as a template.\n`
+      );
+    }
+  }
 
   const desktopCount = countFrames(framesDir);
   if (desktopCount === 0) fail(`no frames found in ${framesDir} (expected frame_0000.jpg upward)`);

--- a/plugins/scrollcraft/skills/scrollcraft/scripts/init.mjs
+++ b/plugins/scrollcraft/skills/scrollcraft/scripts/init.mjs
@@ -40,17 +40,26 @@ function starterSpec(name, style) {
     framesMobile: "frames-mobile",
     sections: [
       {
+        layout: "center",
         eyebrow: "Introducing",
         heading: name,
         body: "Replace this copy. One idea per section, a heading and at most two lines — the reader is scrolling, not studying.",
         scrollHeight: 1400,
       },
       {
+        layout: "left",
         heading: "Give the good part room",
         body: "This section owns more of the scroll track than the others, so the background moves further while it is on screen.",
         scrollHeight: 2000,
       },
       {
+        layout: "lower-third",
+        heading: "Change shape as you go",
+        body: "Each section sets its own layout, so consecutive screens do not share a skeleton.",
+        scrollHeight: 1200,
+      },
+      {
+        layout: "center",
         heading: "Then ask for something",
         ctaLabel: "Get started",
         ctaHref: "https://example.com",

--- a/plugins/scrollcraft/skills/scrollcraft/scripts/verify.mjs
+++ b/plugins/scrollcraft/skills/scrollcraft/scripts/verify.mjs
@@ -1,0 +1,395 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http from "node:http";
+import { spawn } from "node:child_process";
+
+const CHROME_CANDIDATES = [
+  process.env.CHROME_PATH,
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/Applications/Chromium.app/Contents/MacOS/Chromium",
+  "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+  "/usr/bin/google-chrome",
+  "/usr/bin/google-chrome-stable",
+  "/usr/bin/chromium",
+  "/usr/bin/chromium-browser",
+  "C:/Program Files/Google/Chrome/Application/chrome.exe",
+  "C:/Program Files (x86)/Google/Chrome/Application/chrome.exe",
+].filter(Boolean);
+
+function fail(msg) {
+  process.stderr.write("verify: " + msg + "\n");
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) out[key] = true;
+    else { out[key] = next; i++; }
+  }
+  return out;
+}
+
+function findChrome() {
+  for (const p of CHROME_CANDIDATES) {
+    try { if (fs.statSync(p).isFile()) return p; } catch { /* next */ }
+  }
+  return null;
+}
+
+const MIME = {
+  ".html": "text/html; charset=utf-8", ".js": "text/javascript", ".css": "text/css",
+  ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png", ".webp": "image/webp",
+  ".avif": "image/avif", ".gif": "image/gif", ".svg": "image/svg+xml",
+  ".mp3": "audio/mpeg", ".m4a": "audio/mp4", ".wav": "audio/wav", ".ogg": "audio/ogg",
+  ".webm": "audio/webm", ".aac": "audio/aac", ".flac": "audio/flac",
+};
+
+function serve(root) {
+  const missing = [];
+  const server = http.createServer((req, res) => {
+    let pathname;
+    try { pathname = decodeURIComponent(new URL(req.url, "http://x").pathname); }
+    catch { res.writeHead(400).end(); return; }
+    const rel = pathname === "/" ? "index.html" : pathname.replace(/^\/+/, "");
+    const target = path.resolve(root, rel);
+    if (target !== root && !target.startsWith(root + path.sep)) { res.writeHead(403).end(); return; }
+    fs.stat(target, (err, st) => {
+      if (err || !st.isFile()) {
+        if (rel !== "favicon.ico") missing.push(rel);
+        res.writeHead(404).end();
+        return;
+      }
+      res.writeHead(200, {
+        "Content-Type": MIME[path.extname(target).toLowerCase()] || "application/octet-stream",
+        "Content-Length": st.size,
+      });
+      fs.createReadStream(target).pipe(res);
+    });
+  });
+  return { server, missing };
+}
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+  });
+}
+
+function getJson(url) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      let b = "";
+      res.on("data", (d) => { b += d; });
+      res.on("end", () => { try { resolve(JSON.parse(b)); } catch (e) { reject(e); } });
+    });
+    req.on("error", reject);
+    req.setTimeout(4000, () => req.destroy(new Error("timeout")));
+  });
+}
+
+async function waitForPort(userDataDir, timeoutMs) {
+  const file = path.join(userDataDir, "DevToolsActivePort");
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const txt = fs.readFileSync(file, "utf8").split("\n");
+      const port = Number(txt[0]);
+      if (port > 0) return port;
+    } catch { /* not yet */ }
+    await new Promise((r) => setTimeout(r, 80));
+  }
+  throw new Error("Chrome did not report a debugging port");
+}
+
+class Cdp {
+  constructor(ws) { this.ws = ws; this.id = 0; this.pending = new Map(); this.handlers = new Map();
+    ws.addEventListener("message", (ev) => {
+      const msg = JSON.parse(ev.data);
+      if (msg.id && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.error) reject(new Error(msg.error.message));
+        else resolve(msg.result);
+      } else if (msg.method) {
+        (this.handlers.get(msg.method) || []).forEach((h) => h(msg.params));
+      }
+    });
+  }
+  on(method, fn) {
+    if (!this.handlers.has(method)) this.handlers.set(method, []);
+    this.handlers.get(method).push(fn);
+  }
+  send(method, params = {}) {
+    const id = ++this.id;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws.send(JSON.stringify({ id, method, params }));
+      setTimeout(() => {
+        if (this.pending.has(id)) { this.pending.delete(id); reject(new Error(`${method} timed out`)); }
+      }, 20000);
+    });
+  }
+  async eval(expression) {
+    const r = await this.send("Runtime.evaluate", {
+      expression, returnByValue: true, awaitPromise: true,
+    });
+    if (r.exceptionDetails) throw new Error(r.exceptionDetails.exception?.description || "page threw");
+    return r.result.value;
+  }
+}
+
+const PROBE = `(() => {
+  const canvas = document.getElementById('scroll-canvas');
+  if (!canvas) return { error: 'no #scroll-canvas' };
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+
+  const lin = (c) => { c /= 255; return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4); };
+  const relLum = (r, g, b) => 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+  const parseRgb = (s) => {
+    const m = /rgba?\\(([^)]+)\\)/.exec(s);
+    if (!m) return null;
+    const p = m[1].split(',').map(Number);
+    return { r: p[0], g: p[1], b: p[2], a: p.length > 3 ? p[3] : 1 };
+  };
+
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const sampleRect = (cssX, cssY, cssW, cssH) => {
+    const x = Math.max(0, Math.round(cssX * dpr));
+    const y = Math.max(0, Math.round(cssY * dpr));
+    const w = Math.max(1, Math.min(canvas.width - x, Math.round(cssW * dpr)));
+    const h = Math.max(1, Math.min(canvas.height - y, Math.round(cssH * dpr)));
+    if (w < 1 || h < 1) return null;
+    const d = ctx.getImageData(x, y, w, h).data;
+    let lum = 0, n = 0, min = 255, max = 0, sig = 0;
+    const step = Math.max(4, Math.floor(d.length / 4 / 4000) * 4);
+    for (let i = 0; i < d.length; i += step) {
+      const r = d[i], g = d[i + 1], b = d[i + 2];
+      lum += relLum(r, g, b);
+      const y8 = (r * 299 + g * 587 + b * 114) / 1000;
+      if (y8 < min) min = y8;
+      if (y8 > max) max = y8;
+      sig = (sig * 31 + r + g * 3 + b * 7) % 1000000007;
+      n++;
+    }
+    return { lum: lum / n, spread: max - min, sig, samples: n };
+  };
+
+  const full = sampleRect(0, 0, window.innerWidth, window.innerHeight);
+  if (!full) return { error: 'canvas has no readable pixels' };
+
+  const contrasts = [];
+  for (const el of document.querySelectorAll('.section-content')) {
+    const r = el.getBoundingClientRect();
+    if (r.bottom < 0 || r.top > window.innerHeight || r.width < 1 || r.height < 1) continue;
+    if (getComputedStyle(el).opacity === '0') continue;
+    const behind = sampleRect(r.left, Math.max(0, r.top), r.width, Math.min(r.height, window.innerHeight));
+    if (!behind) continue;
+    for (const t of el.querySelectorAll('h2, p, a')) {
+      const tr = t.getBoundingClientRect();
+      if (tr.width < 1 || tr.height < 1) continue;
+      if (!t.textContent.trim()) continue;
+      const cs = getComputedStyle(t);
+      const fg = parseRgb(cs.color);
+      if (!fg) continue;
+
+      const own = parseRgb(cs.backgroundColor);
+      let bgLum, over;
+      if (own && own.a >= 0.95) {
+        bgLum = relLum(own.r, own.g, own.b);
+        over = 'own background';
+      } else {
+        const local = sampleRect(tr.left, Math.max(0, tr.top), tr.width, Math.min(tr.height, window.innerHeight)) || behind;
+        bgLum = local.lum;
+        over = 'frame';
+      }
+
+      const lfRaw = relLum(fg.r, fg.g, fg.b);
+      const lf = fg.a >= 0.999 ? lfRaw : lfRaw * fg.a + bgLum * (1 - fg.a);
+      const ratio = (Math.max(lf, bgLum) + 0.05) / (Math.min(lf, bgLum) + 0.05);
+      contrasts.push({
+        tag: t.tagName.toLowerCase(),
+        text: t.textContent.trim().slice(0, 48),
+        ratio: Math.round(ratio * 100) / 100,
+        alpha: fg.a,
+        over,
+      });
+    }
+  }
+
+  return {
+    scrollY: Math.round(window.scrollY),
+    docHeight: document.documentElement.scrollHeight,
+    overflowX: document.documentElement.scrollWidth > window.innerWidth + 1,
+    canvas: { w: canvas.width, h: canvas.height, lum: full.lum, spread: full.spread, sig: full.sig },
+    contrasts,
+  };
+})()`;
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(
+      "Usage: verify.mjs [--dir dist] [--samples 16] [--width 1280] [--height 800]\n" +
+      "                  [--min-contrast 4.5] [--shots <dir>] [--json]\n\n" +
+      "Loads the built site in headless Chrome, scrolls it, and measures the frames the\n" +
+      "reader actually sees: that the canvas paints, that it advances, and that every line\n" +
+      "of copy clears a contrast ratio against the pixels behind it.\n"
+    );
+    return;
+  }
+
+  const dir = path.resolve(typeof args.dir === "string" ? args.dir : "dist");
+  if (!fs.existsSync(path.join(dir, "index.html"))) fail(`no index.html in ${dir}. Build first.`);
+
+  const samples = Math.max(2, Math.min(60, Number(args.samples) || 16));
+  const width = Math.max(320, Math.min(3840, Number(args.width) || 1280));
+  const height = Math.max(400, Math.min(2160, Number(args.height) || 800));
+  const minContrast = Number(args["min-contrast"]) || 4.5;
+  const shotsDir = typeof args.shots === "string" ? path.resolve(args.shots) : null;
+
+  const chrome = findChrome();
+  if (!chrome) {
+    fail("no Chrome, Chromium or Edge found. Set CHROME_PATH to the binary, or install one.");
+  }
+
+  const { server, missing } = serve(dir);
+  const port = await listen(server);
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "scrollcraft-verify-"));
+
+  const proc = spawn(chrome, [
+    "--headless=new", "--remote-debugging-port=0", `--user-data-dir=${userDataDir}`,
+    "--no-first-run", "--no-default-browser-check", "--disable-gpu", "--hide-scrollbars",
+    "--mute-audio", "--disable-extensions", "--disable-background-networking",
+    `--window-size=${width},${height}`, "about:blank",
+  ], { stdio: "ignore" });
+
+  const problems = [];
+  const warnings = [];
+  let cdp;
+
+  const cleanup = () => {
+    try { cdp?.ws.close(); } catch { /* closed */ }
+    try { proc.kill(); } catch { /* gone */ }
+    try { server.close(); } catch { /* closed */ }
+    try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch { /* gone */ }
+  };
+
+  try {
+    const debugPort = await waitForPort(userDataDir, 15000);
+    const targets = await getJson(`http://127.0.0.1:${debugPort}/json/list`);
+    const page = targets.find((t) => t.type === "page");
+    if (!page) throw new Error("no page target in Chrome");
+
+    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    await new Promise((res, rej) => {
+      ws.addEventListener("open", res, { once: true });
+      ws.addEventListener("error", () => rej(new Error("could not attach to Chrome")), { once: true });
+    });
+    cdp = new Cdp(ws);
+
+    const consoleErrors = [];
+    cdp.on("Runtime.exceptionThrown", (p) => {
+      consoleErrors.push(p.exceptionDetails?.exception?.description || p.exceptionDetails?.text || "exception");
+    });
+    cdp.on("Runtime.consoleAPICalled", (p) => {
+      if (p.type === "error") consoleErrors.push((p.args || []).map((a) => a.value ?? a.description ?? "").join(" "));
+    });
+
+    await cdp.send("Page.enable");
+    await cdp.send("Runtime.enable");
+    await cdp.send("Emulation.setDeviceMetricsOverride", {
+      width, height, deviceScaleFactor: 1, mobile: false,
+    });
+
+    const loaded = new Promise((res) => cdp.on("Page.loadEventFired", res));
+    await cdp.send("Page.navigate", { url: `http://127.0.0.1:${port}/` });
+    await loaded;
+    await cdp.eval("new Promise(r => setTimeout(r, 700))");
+
+    const first = await cdp.eval(PROBE);
+    if (first?.error) throw new Error(first.error);
+
+    const track = first.docHeight - height;
+    if (track <= 0) problems.push(`page is not scrollable: document height ${first.docHeight} vs viewport ${height}`);
+    if (first.overflowX) problems.push("page scrolls horizontally, which it must never do");
+
+    if (shotsDir) fs.mkdirSync(shotsDir, { recursive: true });
+
+    const seen = new Map();
+    const rows = [];
+    let blank = 0;
+    let worst = { ratio: Infinity, text: "", tag: "", at: 0 };
+
+    for (let i = 0; i < samples; i++) {
+      const y = Math.round((track > 0 ? track : 0) * (i / (samples - 1)));
+      await cdp.eval(`window.scrollTo(0, ${y}); new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 90))))`);
+      const s = await cdp.eval(PROBE);
+      if (s?.error) { problems.push(`probe failed at y=${y}: ${s.error}`); break; }
+
+      if (s.canvas.spread < 2) blank++;
+      seen.set(s.canvas.sig, (seen.get(s.canvas.sig) || 0) + 1);
+
+      for (const c of s.contrasts) {
+        if (c.ratio < worst.ratio) worst = { ...c, at: y };
+        if (c.ratio < minContrast) {
+          problems.push(
+            `contrast ${c.ratio}:1 at scrollY ${y} on <${c.tag}> "${c.text}" (needs ${minContrast}:1)`
+          );
+        }
+      }
+
+      rows.push({ y, lum: Math.round(s.canvas.lum * 1000) / 1000, spread: Math.round(s.canvas.spread), copy: s.contrasts.length });
+
+      if (shotsDir) {
+        const shot = await cdp.send("Page.captureScreenshot", { format: "png" });
+        fs.writeFileSync(path.join(shotsDir, `scroll_${String(i).padStart(2, "0")}.png`), Buffer.from(shot.data, "base64"));
+      }
+    }
+
+    if (blank === rows.length) problems.push("the canvas never painted anything at any scroll position");
+    else if (blank > 0) warnings.push(`canvas was flat at ${blank} of ${rows.length} positions`);
+
+    const distinct = seen.size;
+    if (rows.length > 1 && distinct === 1) {
+      problems.push("the background never changed while scrolling, so the scrub does nothing");
+    } else if (rows.length > 2 && distinct < Math.ceil(rows.length / 2)) {
+      warnings.push(`only ${distinct} distinct frames across ${rows.length} positions — the scrub looks steppy`);
+    }
+
+    const missed = [...new Set(missing)];
+    if (missed.length) {
+      problems.push(`the page requested ${missed.length} file(s) that do not exist, e.g. ${missed.slice(0, 3).join(", ")}`);
+    }
+    for (const e of consoleErrors.slice(0, 5)) problems.push(`page error: ${String(e).slice(0, 160)}`);
+
+    if (args.json) {
+      process.stdout.write(JSON.stringify({ rows, problems, warnings, distinctFrames: distinct, worstContrast: worst }, null, 2) + "\n");
+    } else {
+      process.stdout.write(`  scrolled ${rows.length} positions over ${first.docHeight}px\n`);
+      process.stdout.write(`  distinct frames rendered: ${distinct}\n`);
+      if (Number.isFinite(worst.ratio)) {
+        process.stdout.write(`  worst copy contrast: ${worst.ratio}:1 on <${worst.tag}> "${worst.text}" at y=${worst.at}\n`);
+      }
+      if (shotsDir) process.stdout.write(`  screenshots: ${shotsDir}\n`);
+      for (const w of warnings) process.stdout.write("warn: " + w + "\n");
+      for (const p of problems) process.stdout.write("FAIL: " + p + "\n");
+      process.stdout.write(`\n${problems.length} problem(s), ${warnings.length} warning(s)\n`);
+    }
+  } catch (e) {
+    cleanup();
+    fail(e.message);
+  }
+
+  cleanup();
+  process.exit(problems.length ? 1 : 0);
+}
+
+main();

--- a/src/__tests__/skillVerify.test.ts
+++ b/src/__tests__/skillVerify.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SCRIPTS = path.resolve(__dirname, "../../plugins/scrollcraft/skills/scrollcraft/scripts");
+const BUILD = path.join(SCRIPTS, "build-site.mjs");
+const STYLE = path.join(SCRIPTS, "frames-from-style.mjs");
+const VERIFY = path.join(SCRIPTS, "verify.mjs");
+
+const CHROME = [
+  process.env.CHROME_PATH,
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/Applications/Chromium.app/Contents/MacOS/Chromium",
+  "/usr/bin/google-chrome",
+  "/usr/bin/chromium",
+].filter(Boolean).find((p) => { try { return fs.statSync(p as string).isFile(); } catch { return false; } });
+
+const hasFfmpeg = spawnSync("ffmpeg", ["-version"], { stdio: "ignore" }).status === 0;
+const canRender = Boolean(CHROME) && hasFfmpeg;
+const renderIt = canRender ? it : it.skip;
+
+const ONE_PX_JPEG = Buffer.from(
+  "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRof" +
+    "Hh0aHBwcJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPDU0NP/bAEMBCQkJDAsMGA0NGDIhHCEy" +
+    "MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAB" +
+    "AAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAA" +
+    "AAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMB" +
+    "AAIRAxEAPwCdABmX/9k=",
+  "base64"
+);
+
+let tmp: string;
+const node = (script: string, args: string[], timeout = 120000) =>
+  spawnSync(process.execPath, [script, ...args], { encoding: "utf8", cwd: tmp, timeout });
+
+const spec = (o: unknown) => fs.writeFileSync(path.join(tmp, "scrollcraft.json"), JSON.stringify(o));
+const html = () => fs.readFileSync(path.join(tmp, "dist", "index.html"), "utf8");
+
+function stubFrames(n: number) {
+  fs.mkdirSync(path.join(tmp, "frames"), { recursive: true });
+  for (let i = 0; i < n; i++) {
+    fs.writeFileSync(path.join(tmp, "frames", `frame_${String(i).padStart(4, "0")}.jpg`), ONE_PX_JPEG);
+  }
+}
+
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "scrollcraft-verify-")); });
+afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+describe("skill section layouts", () => {
+  it("applies a named layout instead of always centring", () => {
+    stubFrames(1);
+    spec({ sections: [{ heading: "A", layout: "lower-third" }] });
+    expect(node(BUILD, ["--spec", "scrollcraft.json", "--out", "dist"]).status).toBe(0);
+    const out = html();
+    expect(out).toContain("align-items:flex-end");
+    expect(out).toContain("text-align:left");
+  });
+
+  it("keeps distinct layouts distinct in the output", () => {
+    stubFrames(1);
+    spec({
+      sections: [
+        { heading: "A", layout: "left" },
+        { heading: "B", layout: "right" },
+      ],
+    });
+    expect(node(BUILD, ["--spec", "scrollcraft.json", "--out", "dist"]).status).toBe(0);
+    const out = html();
+    expect(out).toContain("justify-content:flex-start");
+    expect(out).toContain("justify-content:flex-end");
+  });
+
+  it("rejects an unknown layout rather than silently centring it", () => {
+    stubFrames(1);
+    spec({ sections: [{ heading: "A", layout: "diagonal" }] });
+    const run = node(BUILD, ["--spec", "scrollcraft.json", "--out", "dist"]);
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain('unknown layout "diagonal"');
+  });
+
+  it("points out when every section shares one shape", () => {
+    stubFrames(1);
+    spec({ sections: [{ heading: "A" }, { heading: "B" }, { heading: "C" }] });
+    const run = node(BUILD, ["--spec", "scrollcraft.json", "--out", "dist"]);
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("same shape");
+  });
+
+  it("stays quiet when the layouts already vary", () => {
+    stubFrames(1);
+    spec({
+      sections: [
+        { heading: "A", layout: "center" },
+        { heading: "B", layout: "left" },
+        { heading: "C", layout: "lower-third" },
+      ],
+    });
+    const run = node(BUILD, ["--spec", "scrollcraft.json", "--out", "dist"]);
+    expect(run.status).toBe(0);
+    expect(run.stdout).not.toContain("same shape");
+  });
+
+  it("left-aligned layouts do not centre their body copy with auto margins", () => {
+    stubFrames(1);
+    spec({ sections: [{ heading: "A", body: "text", layout: "left" }] });
+    expect(node(BUILD, ["--spec", "scrollcraft.json", "--out", "dist"]).status).toBe(0);
+    expect(html()).toContain("margin:0 0 1.5rem");
+  });
+});
+
+describe("skill verify", () => {
+  it("refuses to run against a directory with no build", () => {
+    const run = node(VERIFY, ["--dir", "dist"]);
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("no index.html");
+  });
+
+  renderIt("passes a real built site and reports measured contrast", () => {
+    expect(node(STYLE, ["--style", "aurora", "--count", "8", "--width", "640", "--out", "frames"]).status).toBe(0);
+    spec({
+      name: "Probe",
+      sections: [
+        { eyebrow: "Intro", heading: "Probe", body: "Readable copy over a dark frame.", scrollHeight: 1200 },
+        { heading: "Second", layout: "left", body: "More copy.", scrollHeight: 1200 },
+      ],
+    });
+    expect(node(BUILD, ["--spec", "scrollcraft.json", "--out", "dist"]).status).toBe(0);
+
+    const run = node(VERIFY, ["--dir", "dist", "--samples", "5", "--shots", "shots"]);
+    expect(run.stdout).toMatch(/worst copy contrast: [\d.]+:1/);
+    expect(run.stdout).toContain("0 problem(s)");
+    expect(run.status).toBe(0);
+
+    const shots = fs.readdirSync(path.join(tmp, "shots"));
+    expect(shots).toHaveLength(5);
+    for (const s of shots) {
+      expect(fs.readFileSync(path.join(tmp, "shots", s)).subarray(1, 4).toString()).toBe("PNG");
+    }
+  });
+
+  renderIt("catches the silent black canvas when the frames are gone", () => {
+    expect(node(STYLE, ["--style", "tide", "--count", "6", "--width", "640", "--out", "frames"]).status).toBe(0);
+    spec({ name: "Probe", sections: [{ heading: "Probe", scrollHeight: 1200 }] });
+    expect(node(BUILD, ["--spec", "scrollcraft.json", "--out", "dist"]).status).toBe(0);
+
+    for (const f of fs.readdirSync(path.join(tmp, "dist", "frames"))) {
+      fs.rmSync(path.join(tmp, "dist", "frames", f));
+    }
+
+    const run = node(VERIFY, ["--dir", "dist", "--samples", "4"]);
+    expect(run.status).toBe(1);
+    expect(run.stdout).toContain("never painted");
+  });
+
+  renderIt("fails copy that cannot be read against the frame behind it", () => {
+    expect(node(STYLE, [
+      "--style", "tide", "--count", "6", "--width", "640", "--out", "frames",
+      "--colors", "#ffffff,#fdfdfd,#ffffff",
+    ]).status).toBe(0);
+    spec({ name: "Probe", sections: [{ heading: "Unreadable", body: "White on white.", scrollHeight: 1200 }] });
+    expect(node(BUILD, ["--spec", "scrollcraft.json", "--out", "dist"]).status).toBe(0);
+
+    const run = node(VERIFY, ["--dir", "dist", "--samples", "4"]);
+    expect(run.status).toBe(1);
+    expect(run.stdout).toContain("contrast");
+    expect(run.stdout).toMatch(/needs 4\.5:1/);
+  });
+
+});


### PR DESCRIPTION
# Description

Two changes, aimed at the two places our skill was weakest against a hand-authored scroll engine.

## 1. `verify.mjs` — check the page, not the files

`doctor.mjs` reads files. It cannot tell you the page renders. That mattered because the characteristic failure of this kind of page is **silent**: a missing frame set paints a black canvas, throws nothing, and logs nothing. `SKILL.md` already warned that "a build that succeeded is not evidence the site works" without offering any way to check.

`verify.mjs` loads the built site in headless Chrome over the DevTools Protocol, scrolls it, and measures the composite at each position:

- the canvas is painting at all, rather than the black rectangle a 404 frame produces
- the background genuinely advances, rather than holding one frame the whole way down
- **every line of copy clears 4.5:1 against the pixels actually behind it**, sampled from the real frame at that scroll offset
- nothing 404s, nothing throws, the page never scrolls sideways

Exits non-zero on any of those. `--shots <dir>` writes a PNG per sampled position. `--json` for machine use.

**No npm dependency.** It drives Chrome directly via CDP using Node's global `WebSocket`, and finds Chrome, Chromium or Edge on the machine. Nothing to install.

Three details in the contrast measurement that make the number trustworthy rather than decorative:

- an element painting its **own opaque background** (the CTA button) is measured against that background, not against the canvas behind it, which would have been meaningless
- **semi-transparent text** is composited against what is behind it before the ratio is taken, since `rgba(255,255,255,0.72)` body copy is not white
- the sample is the text element's own rect, so a bright patch under one line is caught even when the frame's average is dark

### It found a real defect in our own defaults

Run against the scaffold, it failed immediately: the default eyebrow accent `#a78bfa` measured **2.84:1** over the aurora background. That fails WCAG AA, and the skill had been shipping it. Default is now `#ddd6fe`, measured **5.6:1**.

That also exposed a design problem worth naming: `accentColor` is used for both eyebrow *text* and CTA *background*, and those roles pull in opposite directions — a colour readable as text on a dark frame is usually too light behind white button text. `references/site-spec.md` now says so and points at `verify`.

## 2. Section layouts

Sections take `layout`: `center`, `left`, `right`, `lower-third`, `upper-third`, setting alignment, measure and padding together. `align`/`justify`/`textAlign` still override individually.

This addresses the strongest criticism of spec-driven generation — that every page it produces shares one skeleton. An unknown layout fails the build, and a spec whose sections all use the same layout gets told:

```
note: all 4 sections use the "center" layout, so every screen has the same shape.
```

`init.mjs` now scaffolds three different layouts so the starter is not uniform.

## Testing

`src/__tests__/skillVerify.test.ts`, 10 cases. Six cover layouts: named layout applied, distinct layouts staying distinct, unknown layout rejected, the sameness note firing and staying quiet, and left-aligned copy not keeping centring auto-margins. Four cover `verify`, driving real Chrome.

Fault injection, run for real against a built site rather than asserted:

| injected fault | result |
| --- | --- |
| one frame deleted | names the exact missing file |
| all frames deleted | caught three ways: never painted, never advanced, 40 missing files |
| engine script removed | canvas never painted |
| white text on white frames | contrast 1.04:1 |
| nothing wrong | 0 problems, exit 0 |

Measured on this branch:

- `npx tsc --noEmit` clean
- `npx eslint` clean — 0 warnings (I introduced 2 and fixed both; baseline is 0)
- `npx vitest run` **161 passed / 11 files**, up from 151 / 10 on `main`
- `npx next build` succeeds
- new test file adds ~8.5s, because it launches Chrome three times. That is the real cost of this PR and the reason I merged the screenshot assertions into an existing case instead of adding a fourth launch.

Not vacuous. Four mutations, each caught: disabling the contrast check, disabling blank-canvas detection, allowing an unknown layout, and collapsing every layout to `center` (that one fails 3).

Chrome- and ffmpeg-dependent cases `it.skip` where those are absent rather than failing.

## Type of change

- [x] ✨ New feature
- [x] 🐛 Bug fix
- [x] 📝 Documentation

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes
- [x] `npm run build` passes
- [x] I updated docs / `.env.example` if config or env vars changed
- [x] I added tests for new logic where practical

## Risks and trade-offs

- **The suite is ~8.5s slower.** Launching Chrome three times is most of it. Worth it for a check that catches a class of silent failure, but it is a real cost on every run.
- **4.5:1 is WCAG AA for normal text**, and large headings are technically allowed 3:1. The check applies 4.5 to everything, so it is slightly stricter than the standard for `<h2>`. `--min-contrast` adjusts it.
- **Contrast is sampled, not exhaustive.** It reads a strided sample of the text rect, so a very small bright detail could slip through. It catches the failure that actually happens, which is a whole region being too light.
- **Five layouts is still a bounded grammar.** Structure comes from a spec, so this reduces sameness rather than eliminating it. A hand-authored engine can produce page shapes this cannot, and that remains true after this PR.