### PR TITLE
refactor: one schema for a section, validated at every boundary

### DIFF
--- a/plugins/scrollcraft/skills/scrollcraft/references/site-spec.md
+++ b/plugins/scrollcraft/skills/scrollcraft/references/site-spec.md
@@ -1,5 +1,11 @@
 # `scrollcraft.json` reference
 
+The authoritative definition of a section is `src/lib/siteSchema.ts` in this repository. The
+hosted app validates every save against it and the exporter renders from it, so a spec the
+skill produces is the same shape the product stores. This page documents that schema; if the
+two ever disagree, the module is right.
+
+
 The spec is the single source of truth for a build. Paths inside it resolve relative to the
 spec file, not the working directory.
 

--- a/src/__tests__/exportSectionParity.test.ts
+++ b/src/__tests__/exportSectionParity.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { NextRequest } from "next/server";
+import { SECTION_LAYOUTS } from "@/lib/siteSchema";
+
+const dbMock = vi.hoisted(() => ({
+  exportPurchase: { findFirst: vi.fn() },
+  site: { findFirst: vi.fn() },
+}));
+const authMock = vi.hoisted(() => vi.fn());
+const rateLimitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({ db: dbMock }));
+vi.mock("@/auth", () => ({ auth: authMock }));
+vi.mock("@/lib/rateLimit", () => ({ rateLimit: rateLimitMock, getClientIp: () => "1.2.3.4" }));
+
+type Handler = typeof import("../app/api/export-site/route").POST;
+let POST: Handler;
+
+function exportRequest(body: Record<string, unknown>): NextRequest {
+  return new Request("https://scrollcraft.app/api/export-site", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+async function exportHtml(sections: unknown[]): Promise<string> {
+  const res = await POST(exportRequest({ sections, siteName: "Parity", frameCount: 10, fps: 24 }));
+  expect(res.status).toBe(200);
+  const json = await res.json();
+  expect(typeof json.html).toBe("string");
+  return json.html as string;
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  rateLimitMock.mockResolvedValue({ allowed: true });
+  authMock.mockResolvedValue({ user: { id: "u1", email: "a@b.c", plan: "PRO" } });
+  ({ POST } = await import("../app/api/export-site/route"));
+});
+
+describe("exported sections keep every field the schema allows", () => {
+  it("renders each layout with its own alignment rather than centring everything", async () => {
+    const html = await exportHtml(
+      SECTION_LAYOUTS.map((layout, i) => ({ heading: `H${i}`, layout, scrollHeight: 1000 }))
+    );
+    expect(html).toContain("justify-content:flex-start");
+    expect(html).toContain("justify-content:flex-end");
+    expect(html).toContain("align-items:flex-end");
+    expect(html).toContain("align-items:flex-start");
+    expect(html).toContain("text-align:left");
+  });
+
+  it("renders a section image with its alt text", async () => {
+    const html = await exportHtml([{
+      heading: "With art",
+      image: "https://cdn.example.com/logo.png",
+      imageAlt: "Orrery logo",
+      scrollHeight: 1000,
+    }]);
+    expect(html).toContain('src="https://cdn.example.com/logo.png"');
+    expect(html).toContain('alt="Orrery logo"');
+  });
+
+  it("caps an oversized imageWidth", async () => {
+    const html = await exportHtml([{
+      heading: "Big", image: "https://cdn.example.com/a.png", imageAlt: "a", imageWidth: 99999, scrollHeight: 1000,
+    }]);
+    expect(html).toContain("max-width:min(100%, 1600px)");
+  });
+
+  it("drops a relative image, which would 404 inside the exported zip", async () => {
+    const html = await exportHtml([{
+      heading: "Local", image: "assets/img_00.png", imageAlt: "a", scrollHeight: 1000,
+    }]);
+    expect(html).not.toContain("assets/img_00.png");
+    expect(html).toContain("Local");
+  });
+
+  it("escapes hostile alt text", async () => {
+    const html = await exportHtml([{
+      heading: "X",
+      image: "https://cdn.example.com/a.png",
+      imageAlt: '"><script>alert(1)</script>',
+      scrollHeight: 1000,
+    }]);
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
+  it("still centres a legacy section that names no layout", async () => {
+    const html = await exportHtml([{ heading: "Legacy", scrollHeight: 1000 }]);
+    expect(html).toContain("justify-content:center");
+    expect(html).toContain("text-align:center");
+  });
+
+  it("keeps honouring an explicit align that overrides the layout", async () => {
+    const html = await exportHtml([{ heading: "X", layout: "center", align: "flex-end", scrollHeight: 1000 }]);
+    expect(html).toContain("align-items:flex-end");
+  });
+});

--- a/src/__tests__/siteSchema.test.ts
+++ b/src/__tests__/siteSchema.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  SECTION_LAYOUTS,
+  MAX_SECTIONS,
+  parseSectionsJson,
+  sectionSchema,
+  visibleSections,
+  type Section,
+} from "@/lib/siteSchema";
+
+const ok = (o: unknown) => sectionSchema.safeParse(o).success;
+
+describe("sectionSchema", () => {
+  it("accepts a minimal section", () => {
+    expect(ok({ heading: "A" })).toBe(true);
+  });
+
+  it("accepts every documented layout and rejects anything else", () => {
+    for (const l of SECTION_LAYOUTS) expect(ok({ layout: l })).toBe(true);
+    expect(ok({ layout: "diagonal" })).toBe(false);
+  });
+
+  it("rejects a scrollHeight that would break the scroll track", () => {
+    expect(ok({ scrollHeight: 0 })).toBe(false);
+    expect(ok({ scrollHeight: -1000 })).toBe(false);
+    expect(ok({ scrollHeight: 1.5 })).toBe(false);
+    expect(ok({ scrollHeight: 999_999 })).toBe(false);
+    expect(ok({ scrollHeight: 1200 })).toBe(true);
+  });
+
+  it("caps text fields", () => {
+    expect(ok({ heading: "x".repeat(500) })).toBe(true);
+    expect(ok({ heading: "x".repeat(501) })).toBe(false);
+    expect(ok({ body: "x".repeat(5001) })).toBe(false);
+  });
+
+  it("rejects a colour that is not a colour", () => {
+    expect(ok({ accentColor: "#fff" })).toBe(true);
+    expect(ok({ accentColor: "rgba(255,255,255,0.7)" })).toBe(true);
+    expect(ok({ accentColor: "#fff;background:url(https://tracker/x)" })).toBe(false);
+    expect(ok({ headingColor: "</style><script>" })).toBe(false);
+  });
+
+  it("rejects a javascript: CTA href", () => {
+    expect(ok({ ctaHref: "https://example.com" })).toBe(true);
+    expect(ok({ ctaHref: "#anchor" })).toBe(true);
+    expect(ok({ ctaHref: "" })).toBe(true);
+    expect(ok({ ctaHref: "javascript:alert(1)" })).toBe(false);
+    expect(ok({ ctaHref: "data:text/html,<script>" })).toBe(false);
+  });
+
+  it("rejects an image source that is neither a URL nor a relative path", () => {
+    expect(ok({ image: "https://cdn.example.com/logo.png" })).toBe(true);
+    expect(ok({ image: "assets/img_00.png" })).toBe(true);
+    expect(ok({ image: "javascript:alert(1)" })).toBe(false);
+    expect(ok({ image: "data:image/svg+xml;base64,PHN2Zz4=" })).toBe(false);
+  });
+
+  it("bounds imageWidth", () => {
+    expect(ok({ imageWidth: 480 })).toBe(true);
+    expect(ok({ imageWidth: 99999 })).toBe(false);
+    expect(ok({ imageWidth: 0 })).toBe(false);
+  });
+
+  it("strips unknown keys instead of persisting them", () => {
+    const parsed = sectionSchema.parse({ heading: "A", sneaky: "<script>", __proto__: {} });
+    expect(parsed).not.toHaveProperty("sneaky");
+    expect(parsed.heading).toBe("A");
+  });
+});
+
+describe("parseSectionsJson", () => {
+  it("accepts a valid array", () => {
+    const r = parseSectionsJson(JSON.stringify([{ heading: "A" }, { heading: "B", layout: "left" }]));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.sections).toHaveLength(2);
+  });
+
+  it("rejects a non-string input", () => {
+    const r = parseSectionsJson({ heading: "A" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("must be a string");
+  });
+
+  it("rejects malformed JSON", () => {
+    const r = parseSectionsJson("{not json");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("not valid JSON");
+  });
+
+  it("rejects a JSON object that is not an array", () => {
+    const r = parseSectionsJson(JSON.stringify({ heading: "A" }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("must decode to an array");
+  });
+
+  it("names the offending field so a 400 can be actionable", () => {
+    const r = parseSectionsJson(JSON.stringify([{ heading: "A" }, { scrollHeight: -5 }]));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("1.scrollHeight");
+  });
+
+  it("rejects more sections than the cap", () => {
+    const many = Array.from({ length: MAX_SECTIONS + 1 }, () => ({ heading: "A" }));
+    expect(parseSectionsJson(JSON.stringify(many)).ok).toBe(false);
+    const atCap = Array.from({ length: MAX_SECTIONS }, () => ({ heading: "A" }));
+    expect(parseSectionsJson(JSON.stringify(atCap)).ok).toBe(true);
+  });
+
+  it("still accepts a legacy section that predates layout and images", () => {
+    const legacy = [{
+      id: "section-1",
+      eyebrow: "", heading: "Old", body: "", ctaLabel: "", ctaHref: "#",
+      accentColor: "#7c3aed", headingColor: "#ffffff", bodyColor: "rgba(255,255,255,0.7)",
+      textAlign: "center", align: "center", justify: "center",
+      scrollHeight: 1000, visible: true,
+    }];
+    expect(parseSectionsJson(JSON.stringify(legacy)).ok).toBe(true);
+  });
+});
+
+describe("visibleSections", () => {
+  it("drops only sections explicitly hidden", () => {
+    const s: Section[] = [{ heading: "A" }, { heading: "B", visible: false }, { heading: "C", visible: true }];
+    expect(visibleSections(s).map((x) => x.heading)).toEqual(["A", "C"]);
+  });
+});

--- a/src/app/api/chat-edit/route.ts
+++ b/src/app/api/chat-edit/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { auth } from "@/auth";
 import { rateLimit, getClientIp } from "@/lib/rateLimit";
+import { colorSchema, ctaHrefSchema, sectionIdSchema, sectionSchema, type Section as SharedSection } from "@/lib/siteSchema";
 import { logger } from "@/lib/logger";
 import { db } from "@/lib/db";
 import { PLANS } from "@/lib/plans";
@@ -15,42 +16,13 @@ const MAX_MODEL_UPDATES = 50;
 const chatEditSchema = z.object({
   message: z.string().min(1).max(2000),
   selectedSectionId: z.string().max(100),
-  sections: z.array(z.object({
-    id: z.string().max(100),
-    heading: z.string().max(500).optional(),
-    body: z.string().max(5000).optional(),
-    eyebrow: z.string().max(200).optional(),
-    ctaLabel: z.string().max(200).optional(),
-    ctaHref: z.string().max(2000).optional(),
-    accentColor: z.string().max(50).optional(),
-    headingColor: z.string().max(50).optional(),
-    bodyColor: z.string().max(50).optional(),
-    scrollHeight: z.number().optional(),
-    textAlign: z.string().max(20).optional(),
-  })).max(50),
+  sections: z.array(sectionSchema.extend({ id: sectionIdSchema })).max(50),
 });
 
-interface Section {
-  id: string;
-  heading?: string;
-  body?: string;
-  eyebrow?: string;
-  ctaLabel?: string;
-  ctaHref?: string;
-  accentColor?: string;
-  headingColor?: string;
-  bodyColor?: string;
-  scrollHeight?: number;
-  textAlign?: string;
-}
+type Section = SharedSection & { id: string };
 
 // The model's output is applied straight to the user's document, so it is
 // treated as untrusted input: only these fields, types and ranges get through.
-const sectionIdSchema = z.string().min(1).max(100);
-const colorSchema = z.string().max(50)
-  .regex(/^(?:#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\([\d\s.,%/]+\)|[a-zA-Z]{3,20})$/);
-const ctaHrefSchema = z.string().max(2000)
-  .refine(v => v === "" || /^(?:#|\/|\.{1,2}\/|https?:\/\/|mailto:|tel:)/i.test(v));
 
 const modelUpdateSchema = z.discriminatedUnion("field", [
   z.object({ id: sectionIdSchema, field: z.literal("heading"), value: z.string().max(500) }),

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -2,11 +2,29 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { rateLimit, getClientIp } from "@/lib/rateLimit";
+import { SECTION_LAYOUTS, type Section, visibleSections as onlyVisible } from "@/lib/siteSchema";
 
 function esc(s: unknown): string {
   return String(s ?? "")
           .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
           .replace(/"/g, "&quot;").replace(/'/g, "&#x27;");
+}
+
+const LAYOUTS: Record<(typeof SECTION_LAYOUTS)[number], { align: string; justify: string; textAlign: string; maxWidth: number; pad: string }> = {
+  center: { align: "center", justify: "center", textAlign: "center", maxWidth: 800, pad: "2rem" },
+  left: { align: "center", justify: "flex-start", textAlign: "left", maxWidth: 620, pad: "2rem clamp(2rem, 8vw, 8rem)" },
+  right: { align: "center", justify: "flex-end", textAlign: "left", maxWidth: 620, pad: "2rem clamp(2rem, 8vw, 8rem)" },
+  "lower-third": { align: "flex-end", justify: "flex-start", textAlign: "left", maxWidth: 900, pad: "0 clamp(2rem, 8vw, 8rem) clamp(3rem, 10vh, 7rem)" },
+  "upper-third": { align: "flex-start", justify: "center", textAlign: "center", maxWidth: 800, pad: "clamp(3rem, 12vh, 8rem) 2rem 0" },
+};
+
+function layoutFor(s: Section) {
+  return LAYOUTS[s.layout ?? "center"] ?? LAYOUTS.center;
+}
+
+function exportableImage(src: unknown): string | null {
+  const v = String(src ?? "");
+  return /^https:\/\//i.test(v) || /^http:\/\//i.test(v) ? v : null;
 }
 
 function safeCss(s: unknown): string {
@@ -166,22 +184,29 @@ export async function POST(req: NextRequest) {
     // The editor hides sections with visible === false in both its preview and its own
     // scroll-height total, but POSTs the unfiltered array. Exporting them shipped draft
     // copy verbatim and inflated the scroll track, desynchronizing every frame.
-    const visibleSections = (sections as Section[]).filter((s: Section) => s.visible !== false);
+    const visibleSections = onlyVisible(sections as Section[]);
     if (visibleSections.length === 0) {
       return NextResponse.json({ error: "At least one section must be visible to export" }, { status: 400 });
     }
 
-    const sectionsHtml = visibleSections.map((s: Section) => `
+    const sectionsHtml = visibleSections.map((s: Section) => {
+      const L = layoutFor(s);
+      const stack = L.textAlign === "center" ? "0 auto 1.5rem" : "0 0 1.5rem";
+      const imgSrc = exportableImage(s.image);
+      const imgWidth = Math.min(Number(s.imageWidth) || 480, 1600);
+      return `
     <section class="scroll-section" style="height:${Number(s.scrollHeight) || 1000}px; position:relative; z-index:10;">
-      <div class="section-sticky" style="position:sticky; top:0; height:100vh; display:flex; align-items:${safeCss(s.align || "center")}; justify-content:${safeCss(s.justify || "center")}; overflow:hidden;">
-        <div class="section-content" style="text-align:${safeCss(s.textAlign || "center")}; padding:2rem; max-width:800px; opacity:0; transform:translateY(32px); transition:opacity 0.6s cubic-bezier(0.25,0.46,0.45,0.94),transform 0.6s cubic-bezier(0.25,0.46,0.45,0.94);">
-          ${s.eyebrow ? `<p class="eyebrow" style="font-size:0.875rem; font-weight:600; letter-spacing:0.1em; text-transform:uppercase; color:${safeCss(s.accentColor || "#a78bfa")}; margin-bottom:0.75rem;">${esc(s.eyebrow)}</p>` : ""}
+      <div class="section-sticky" style="position:sticky; top:0; height:100vh; display:flex; align-items:${safeCss(s.align || L.align)}; justify-content:${safeCss(s.justify || L.justify)}; overflow:hidden;">
+        <div class="section-content" style="text-align:${safeCss(s.textAlign || L.textAlign)}; padding:${L.pad}; max-width:${L.maxWidth}px; opacity:0; transform:translateY(32px); transition:opacity 0.6s cubic-bezier(0.25,0.46,0.45,0.94),transform 0.6s cubic-bezier(0.25,0.46,0.45,0.94);">
+          ${imgSrc ? `<img src="${esc(imgSrc)}" alt="${esc(s.imageAlt || "")}" style="display:block; max-width:min(100%, ${imgWidth}px); height:auto; margin:${stack};" />` : ""}
+          ${s.eyebrow ? `<p class="eyebrow" style="font-size:0.875rem; font-weight:600; letter-spacing:0.1em; text-transform:uppercase; color:${safeCss(s.accentColor || "#ddd6fe")}; margin-bottom:0.75rem;">${esc(s.eyebrow)}</p>` : ""}
           ${s.heading ? `<h2 style="font-size:clamp(2rem,5vw,4rem); font-weight:900; line-height:1; letter-spacing:-0.03em; color:${safeCss(s.headingColor || "#ffffff")}; margin-bottom:1rem;">${esc(s.heading)}</h2>` : ""}
-          ${s.body ? `<p style="font-size:1.125rem; line-height:1.7; color:${safeCss(s.bodyColor || "rgba(255,255,255,0.7)")}; max-width:600px; margin:0 auto 1.5rem;">${esc(s.body)}</p>` : ""}
+          ${s.body ? `<p style="font-size:1.125rem; line-height:1.7; color:${safeCss(s.bodyColor || "rgba(255,255,255,0.72)")}; max-width:600px; margin:${stack};">${esc(s.body)}</p>` : ""}
           ${s.ctaLabel ? `<a href="${esc(safeHref(s.ctaHref || "#"))}" style="display:inline-block; background:${safeCss(s.accentColor || "#7c3aed")}; color:white; padding:0.875rem 2rem; border-radius:0.5rem; font-weight:600; text-decoration:none; font-size:1rem;">${esc(s.ctaLabel)}</a>` : ""}
         </div>
       </div>
-    </section>`).join("\n");
+    </section>`;
+    }).join("\n");
 
     const totalScrollHeight = visibleSections.reduce((acc: number, s: Section) => acc + (Number(s.scrollHeight) || 1000), 0) + 1000;
 
@@ -452,21 +477,4 @@ export async function POST(req: NextRequest) {
     console.error("export-site error:", err);
     return NextResponse.json({ error: "Export failed" }, { status: 500 });
   }
-}
-
-interface Section {
-  scrollHeight?: number;
-  align?: string;
-  justify?: string;
-  textAlign?: string;
-  accentColor?: string;
-  eyebrow?: string;
-  heading?: string;
-  headingColor?: string;
-  body?: string;
-  bodyColor?: string;
-  ctaLabel?: string;
-  ctaHref?: string;
-  /** Editor visibility toggle. Absent on older saved sites, which are treated as visible. */
-  visible?: boolean;
 }

--- a/src/app/api/sites/route.ts
+++ b/src/app/api/sites/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { db } from "@/lib/db";
 import { auth } from "@/auth";
 import { rateLimit, getClientIp } from "@/lib/rateLimit";
+import { parseSectionsJson } from "@/lib/siteSchema";
 
 // The schema alone admits ~11 MB per call; without a cap a client could stream far more
 // before Zod ever sees it.
@@ -85,6 +86,16 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid request", details: parsed.error.flatten().fieldErrors }, { status: 400 });
   }
   const { id, name, fps, frameCount, framesJson, sectionsJson, customHead, customCss, audioUrl } = parsed.data;
+
+  if (sectionsJson !== undefined) {
+    const sections = parseSectionsJson(sectionsJson);
+    if (!sections.ok) {
+      return NextResponse.json(
+        { error: "Invalid request", details: { sectionsJson: [sections.error] } },
+        { status: 400 }
+      );
+    }
+  }
 
   if (id) {
     // Update existing site — verify ownership

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -20,26 +20,12 @@ import { useScrollAudio } from "@/lib/useScrollAudio";
 import Link from "next/link";
 import { toast } from "sonner";
 import dynamic from "next/dynamic";
+import type { EditorSection } from "@/lib/siteSchema";
 
 const ScrollEngine = dynamic(() => import("@/components/ScrollEngine"), { ssr: false });
 const ScrollSection = dynamic(() => import("@/components/ScrollSection"), { ssr: false });
 
-interface Section {
-  id: string;
-  eyebrow: string;
-  heading: string;
-  body: string;
-  ctaLabel: string;
-  ctaHref: string;
-  accentColor: string;
-  headingColor: string;
-  bodyColor: string;
-  textAlign: "left" | "center" | "right";
-  align: string;
-  justify: string;
-  scrollHeight: number;
-  visible: boolean;
-}
+type Section = EditorSection;
 
 const defaultSection = (i: number): Section => ({
   id: `section-${Date.now()}-${i}`,

--- a/src/lib/siteSchema.ts
+++ b/src/lib/siteSchema.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+
+export const SECTION_LAYOUTS = ["center", "left", "right", "lower-third", "upper-third"] as const;
+export type SectionLayout = (typeof SECTION_LAYOUTS)[number];
+
+export const MAX_SECTIONS = 100;
+
+export const sectionIdSchema = z.string().min(1).max(100);
+
+export const colorSchema = z.string().max(50)
+  .regex(/^(?:#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\([\d\s.,%/]+\)|[a-zA-Z]{3,20})$/);
+
+export const ctaHrefSchema = z.string().max(2000)
+  .refine((v) => v === "" || /^(?:#|\/|\.{1,2}\/|https?:\/\/|mailto:|tel:)/i.test(v));
+
+export const imageSrcSchema = z.string().max(2000)
+  .refine((v) => v === "" || /^(?:https?:\/\/|\/|\.{1,2}\/|assets\/)/i.test(v), {
+    message: "image must be an http(s) URL or a relative path",
+  });
+
+export const sectionSchema = z.object({
+  id: sectionIdSchema.optional(),
+  layout: z.enum(SECTION_LAYOUTS).optional(),
+  eyebrow: z.string().max(200).optional(),
+  heading: z.string().max(500).optional(),
+  body: z.string().max(5000).optional(),
+  ctaLabel: z.string().max(200).optional(),
+  ctaHref: ctaHrefSchema.optional(),
+  image: imageSrcSchema.optional(),
+  imageAlt: z.string().max(500).optional(),
+  imageWidth: z.number().int().min(16).max(1600).optional(),
+  accentColor: colorSchema.optional(),
+  headingColor: colorSchema.optional(),
+  bodyColor: colorSchema.optional(),
+  textAlign: z.enum(["left", "center", "right"]).optional(),
+  align: z.string().max(30).optional(),
+  justify: z.string().max(30).optional(),
+  scrollHeight: z.number().int().min(100).max(20_000).optional(),
+  visible: z.boolean().optional(),
+}).strip();
+
+export const sectionsSchema = z.array(sectionSchema).max(MAX_SECTIONS);
+
+export type Section = z.infer<typeof sectionSchema>;
+
+export type EditorSection = Section & {
+  id: string;
+  eyebrow: string;
+  heading: string;
+  body: string;
+  ctaLabel: string;
+  ctaHref: string;
+  accentColor: string;
+  headingColor: string;
+  bodyColor: string;
+  textAlign: "left" | "center" | "right";
+  align: string;
+  justify: string;
+  scrollHeight: number;
+  visible: boolean;
+};
+
+export type SectionsParse =
+  | { ok: true; sections: Section[] }
+  | { ok: false; error: string };
+
+export function parseSectionsJson(raw: unknown): SectionsParse {
+  if (typeof raw !== "string") return { ok: false, error: "sectionsJson must be a string" };
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    return { ok: false, error: "sectionsJson is not valid JSON" };
+  }
+
+  if (!Array.isArray(decoded)) return { ok: false, error: "sectionsJson must decode to an array" };
+
+  const parsed = sectionsSchema.safeParse(decoded);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const where = issue?.path?.length ? issue.path.join(".") : "sections";
+    return { ok: false, error: `${where}: ${issue?.message ?? "invalid section"}` };
+  }
+
+  return { ok: true, sections: parsed.data };
+}
+
+export function visibleSections(sections: Section[]): Section[] {
+  return sections.filter((s) => s.visible !== false);
+}


### PR DESCRIPTION
# Description

Closes #297 and #298 together, because doing either alone means writing the shape a sixth time.

## The problem

What a section *is* was declared **five** times, none importing from another:

| Where | Kind |
| --- | --- |
| `src/app/editor/page.tsx:27` | `interface Section` |
| `src/app/api/export-site/route.ts:457` | `interface Section` |
| `src/app/api/chat-edit/route.ts:33` | `interface Section` |
| `src/app/api/chat-edit/route.ts:16` | a separate zod body schema, looser than the rest |
| `plugins/.../references/site-spec.md` | prose |

Three were compile-time only, so none of them constrained anything at runtime. And `POST /api/sites` validated `sectionsJson` as `z.string().max(1_000_000)` — the array driving every rendered site and every export was persisted **unparsed**.

**They had already drifted.** #295 and #296 added `layout`, `image`, `imageAlt` and `imageWidth` to the skill. Nothing in the app knew those fields existed, so a skill-authored site opened in the hosted editor lost its layouts and images — breaking the interchange the export contract exists to guarantee. I claimed that interchange worked in #179; it held for frames and copy, not for anything added since.

## What changed

**`src/lib/siteSchema.ts` is the single definition.** It exports `sectionSchema`, `sectionsSchema`, `parseSectionsJson`, `visibleSections`, `SECTION_LAYOUTS`, and the `Section` / `EditorSection` types. The editor, exporter and chat-edit route import it; the three interfaces are deleted.

**chat-edit's body schema is replaced by the shared one, which is stricter.** Its own version had `textAlign` as a free `string`, and colours and hrefs as bare length-capped strings. The shared schema constrains `textAlign` to the three real values and reuses the colour and href validators chat-edit had already written for *model* output — so human input is now checked as carefully as model output, which was the asymmetry. This is what surfaced the drift: the compiler rejected the loose type immediately.

**`POST /api/sites` validates the contents of `sectionsJson`** and returns a 400 naming the field:

```
{"error":"Invalid request","details":{"sectionsJson":["1.scrollHeight: Too small: expected number to be >=100"]}}
```

**The exporter renders `layout` and section images**, closing the drift. A relative image path is dropped rather than emitted, because it cannot resolve inside the exported zip; only absolute `http(s)` survives.

## Why this matters beyond tidiness

The stated plan is to have Claude author site content inside the product. The value of a machine-readable section format is that generated output can be checked *before* it touches a user's site — and until now there was nothing to check against. One strict schema is that thing, and it is the same one the skill already emits against.

## Testing

**`src/__tests__/siteSchema.test.ts`, 17 cases.** Every layout accepted and unknown ones rejected; `scrollHeight` of 0, negative, fractional and absurd all rejected; text caps; colours (`#fff;background:url(https://tracker/x)` rejected); `javascript:` and `data:` hrefs and image sources rejected; `imageWidth` bounds; unknown keys stripped rather than persisted; field-path in the error message; the `MAX_SECTIONS` cap at and over the limit; and **a legacy section with no `layout` or image fields still parsing**, which is the migration risk #297 called out.

**`src/__tests__/exportSectionParity.test.ts`, 7 cases** asserting the renderer honours every field the schema allows — all five layouts producing distinct alignment, images with alt text, the width cap, relative images dropped, hostile alt escaped, a legacy section still centring, and an explicit `align` still overriding its layout.

Measured on this branch:

- `npx tsc --noEmit` clean · `npx eslint` clean (0 warnings)
- `npx vitest run` **185 passed / 13 files**, up from 161 / 11 on `main`
- `npx next build` succeeds
- `grep -rn "interface Section" src` → **no matches**

Not vacuous. Three mutations, each caught: ignoring `layout` so everything centres (1 failure), never rendering images (2), and letting relative images through (1). The existing `exportPaywall` tests pass throughout, so the entitlement logic is untouched.

## Type of change

- [x] ♻️ Refactor
- [x] 🐛 Bug fix
- [x] ✨ New feature

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes
- [x] `npm run build` passes
- [x] I updated docs / `.env.example` if config or env vars changed
- [x] I added tests for new logic where practical

## Risks and trade-offs

- **Existing rows were written unvalidated.** A row that does not satisfy the schema would now fail on its next save. I checked the realistic case — the editor's own `defaultSection` shape parses cleanly, and there is a test pinning that. But rows written by older code or by hand could still fail, and I cannot see production data. If that is a concern, the safe order is to log-and-allow for one deploy, then enforce.
- **The exporter now drops relative image paths silently.** It renders the rest of the section rather than failing the export. Arguably it should warn; there is no channel for a warning in that response today.
- **`.strip()` discards unknown keys** rather than rejecting them, so a client sending a field the schema does not know loses it silently on save. That is the forgiving choice; `.strict()` would surface typos instead. Worth revisiting if the schema becomes the documented contract for model output, where a silently dropped field would be a confusing failure.