### PR TITLE
feat: a browsable template library

### DIFF
--- a/src/__tests__/templates.test.ts
+++ b/src/__tests__/templates.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import {
+  TEMPLATES,
+  templateBySlug,
+  templateCategories,
+  templateScrollHeight,
+} from "@/lib/templates";
+import { sectionsSchema, SECTION_LAYOUTS, SECTION_KINDS, REVEALS } from "@/lib/siteSchema";
+import { LAYOUT_STYLES, layoutStyle } from "@/lib/layoutStyles";
+
+describe("template catalogue", () => {
+  it("ships a catalogue worth calling a library", () => {
+    expect(TEMPLATES.length).toBeGreaterThanOrEqual(12);
+  });
+
+  it("has unique slugs", () => {
+    const slugs = TEMPLATES.map((t) => t.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("uses url-safe slugs", () => {
+    for (const t of TEMPLATES) {
+      expect(t.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+  });
+
+  it("every template validates against the shared section schema", () => {
+    for (const t of TEMPLATES) {
+      const parsed = sectionsSchema.safeParse(t.sections);
+      if (!parsed.success) {
+        throw new Error(`${t.slug}: ${parsed.error.issues[0].path.join(".")} ${parsed.error.issues[0].message}`);
+      }
+      expect(parsed.success).toBe(true);
+    }
+  });
+
+  it("every template carries real copy, not placeholders", () => {
+    for (const t of TEMPLATES) {
+      const content = t.sections.filter((s) => s.kind !== "spacer");
+      expect(content.length, t.slug).toBeGreaterThanOrEqual(3);
+      for (const s of content) {
+        expect(s.heading || s.body, `${t.slug} has an empty section`).toBeTruthy();
+      }
+      const text = JSON.stringify(t).toLowerCase();
+      for (const banned of ["lorem", "ipsum", "replace this copy", "section 1", "your text here", "todo"]) {
+        expect(text, `${t.slug} contains placeholder copy`).not.toContain(banned);
+      }
+    }
+  });
+
+  it("every template ends with a call to action", () => {
+    for (const t of TEMPLATES) {
+      const last = [...t.sections].reverse().find((s) => s.kind !== "spacer");
+      expect(last?.ctaLabel, `${t.slug} has no closing CTA`).toBeTruthy();
+    }
+  });
+
+  it("does not open on a spacer or end on one", () => {
+    for (const t of TEMPLATES) {
+      expect(t.sections[0].kind, t.slug).not.toBe("spacer");
+      expect(t.sections[t.sections.length - 1].kind, t.slug).not.toBe("spacer");
+    }
+  });
+
+  it("varies its layouts, so no template reads as one repeated screen", () => {
+    for (const t of TEMPLATES) {
+      const layouts = new Set(
+        t.sections.filter((s) => s.kind !== "spacer").map((s) => s.layout ?? "center")
+      );
+      expect(layouts.size, `${t.slug} uses one layout throughout`).toBeGreaterThan(1);
+    }
+  });
+
+  it("uses at most two statement sections, or none of them land", () => {
+    for (const t of TEMPLATES) {
+      const statements = t.sections.filter((s) => s.kind === "statement").length;
+      expect(statements, t.slug).toBeLessThanOrEqual(2);
+    }
+  });
+
+  it("paces every section long enough to be read", () => {
+    for (const t of TEMPLATES) {
+      for (const s of t.sections) {
+        expect(s.scrollHeight ?? 1000, `${t.slug} section too short`).toBeGreaterThanOrEqual(400);
+      }
+    }
+  });
+
+  it("only names layouts, kinds and reveals the renderer knows", () => {
+    for (const t of TEMPLATES) {
+      for (const s of t.sections) {
+        if (s.layout) expect(SECTION_LAYOUTS).toContain(s.layout);
+        if (s.kind) expect(SECTION_KINDS).toContain(s.kind);
+        if (s.reveal) expect(REVEALS).toContain(s.reveal);
+      }
+    }
+  });
+
+  it("computes a scroll height matching the exporter's formula", () => {
+    for (const t of TEMPLATES) {
+      const expected = t.sections.reduce((a, s) => a + (s.scrollHeight ?? 1000), 0) + 1000;
+      expect(templateScrollHeight(t)).toBe(expected);
+    }
+  });
+
+  it("looks a template up by slug and misses cleanly", () => {
+    expect(templateBySlug(TEMPLATES[0].slug)?.name).toBe(TEMPLATES[0].name);
+    expect(templateBySlug("no-such-template")).toBeUndefined();
+    expect(templateBySlug("")).toBeUndefined();
+  });
+
+  it("lists categories once each, sorted", () => {
+    const cats = templateCategories();
+    expect(new Set(cats).size).toBe(cats.length);
+    expect([...cats].sort()).toEqual(cats);
+    for (const t of TEMPLATES) expect(cats).toContain(t.category);
+  });
+
+  it("gives every template card art and a full palette", () => {
+    for (const t of TEMPLATES) {
+      expect(t.gradient, t.slug).toMatch(/^from-/);
+      expect(t.colors, t.slug).toHaveLength(3);
+      for (const c of t.colors) expect(c).toMatch(/^#[0-9a-f]{6}$/i);
+      expect(t.tags.length, t.slug).toBeGreaterThan(0);
+      expect(t.tagline.length, t.slug).toBeGreaterThan(10);
+    }
+  });
+
+  it("gives every template a theme with an accent pair", () => {
+    for (const t of TEMPLATES) {
+      expect(t.theme.accent, t.slug).toMatch(/^#[0-9a-f]{6}$/i);
+      expect(t.theme.accentText, t.slug).toMatch(/^#[0-9a-f]{6}$/i);
+      expect(t.theme.accent).not.toBe(t.theme.accentText);
+    }
+  });
+});
+
+describe("shared layout table", () => {
+  it("covers every layout the schema allows", () => {
+    for (const l of SECTION_LAYOUTS) {
+      expect(LAYOUT_STYLES[l]).toBeTruthy();
+    }
+  });
+
+  it("falls back to center for an unknown or missing layout", () => {
+    expect(layoutStyle(undefined)).toBe(LAYOUT_STYLES.center);
+    expect(layoutStyle("diagonal")).toBe(LAYOUT_STYLES.center);
+  });
+
+  it("keeps each layout visually distinct", () => {
+    const signatures = Object.values(LAYOUT_STYLES).map((l) => `${l.align}|${l.justify}|${l.textAlign}|${l.pad}`);
+    expect(new Set(signatures).size).toBe(signatures.length);
+  });
+});

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { rateLimit, getClientIp } from "@/lib/rateLimit";
-import { REVEALS, SECTION_LAYOUTS, type Section, visibleSections as onlyVisible } from "@/lib/siteSchema";
+import { REVEALS, type Section, visibleSections as onlyVisible } from "@/lib/siteSchema";
+import { layoutStyle } from "@/lib/layoutStyles";
 
 function esc(s: unknown): string {
   return String(s ?? "")
@@ -10,16 +11,9 @@ function esc(s: unknown): string {
           .replace(/"/g, "&quot;").replace(/'/g, "&#x27;");
 }
 
-const LAYOUTS: Record<(typeof SECTION_LAYOUTS)[number], { align: string; justify: string; textAlign: string; maxWidth: number; pad: string }> = {
-  center: { align: "center", justify: "center", textAlign: "center", maxWidth: 800, pad: "2rem" },
-  left: { align: "center", justify: "flex-start", textAlign: "left", maxWidth: 620, pad: "2rem clamp(2rem, 8vw, 8rem)" },
-  right: { align: "center", justify: "flex-end", textAlign: "left", maxWidth: 620, pad: "2rem clamp(2rem, 8vw, 8rem)" },
-  "lower-third": { align: "flex-end", justify: "flex-start", textAlign: "left", maxWidth: 900, pad: "0 clamp(2rem, 8vw, 8rem) clamp(3rem, 10vh, 7rem)" },
-  "upper-third": { align: "flex-start", justify: "center", textAlign: "center", maxWidth: 800, pad: "clamp(3rem, 12vh, 8rem) 2rem 0" },
-};
 
 function layoutFor(s: Section) {
-  return LAYOUTS[s.layout ?? "center"] ?? LAYOUTS.center;
+  return layoutStyle(s.layout);
 }
 
 function exportableImage(src: unknown): string | null {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -247,7 +247,7 @@ export default function DashboardPage() {
           <h2 className="text-lg font-bold tracking-tight mb-5">Quick actions</h2>
           <div className="grid md:grid-cols-3 gap-4">
             {[
-              { icon: Plus, title: "Start from a template", desc: "Pick a ready-made scroll site", href: "/presets", color: "text-primary" },
+              { icon: Plus, title: "Start from a template", desc: "Pick a ready-made scroll site", href: "/templates", color: "text-primary" },
               { icon: Sparkles, title: "Browse presets", desc: "12 production-ready templates", href: "/presets", color: "text-violet-400" },
               { icon: Zap, title: "Upgrade plan", desc: "Keep more websites saved", href: "/pricing", color: "text-amber-400" },
             ].map(action => (

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -21,6 +21,7 @@ import Link from "next/link";
 import { toast } from "sonner";
 import dynamic from "next/dynamic";
 import type { EditorSection } from "@/lib/siteSchema";
+import { templateBySlug } from "@/lib/templates";
 
 const ScrollEngine = dynamic(() => import("@/components/ScrollEngine"), { ssr: false });
 const ScrollSection = dynamic(() => import("@/components/ScrollSection"), { ssr: false });
@@ -50,6 +51,27 @@ function EditorInner() {
 
   // Derive initial frame state. Frames live in IndexedDB (primary) with sessionStorage as a
   // legacy fallback for any in-flight sessions created before this change.
+  const pickedTemplate = templateBySlug(searchParams.get("template") ?? "");
+  // A template arrives as a finished site: its sections become the starting document,
+  // with the ids the editor needs to track selection and undo.
+  const templateSections = pickedTemplate
+    ? pickedTemplate.sections.map((s, i) => ({
+        ...defaultSection(i),
+        ...s,
+        id: `section-${i}-${pickedTemplate.slug}`,
+        heading: s.heading ?? "",
+        eyebrow: s.eyebrow ?? "",
+        body: s.body ?? "",
+        ctaLabel: s.ctaLabel ?? "",
+        ctaHref: s.ctaHref ?? "#",
+        accentColor: s.accentColor ?? pickedTemplate.theme.accentText ?? "#ede9fe",
+        headingColor: s.headingColor ?? pickedTemplate.theme.ink ?? "#ffffff",
+        bodyColor: s.bodyColor ?? pickedTemplate.theme.muted ?? "rgba(255,255,255,0.7)",
+        scrollHeight: s.scrollHeight ?? 1000,
+        visible: true,
+      }))
+    : null;
+
   const framesKey = searchParams.get("framesKey");
   const framesParam = searchParams.get("frames"); // legacy URL param
   const countParam = searchParams.get("frameCount");
@@ -70,12 +92,12 @@ function EditorInner() {
   const [frames, setFrames] = useState<string[]>(parsedFrames ?? demoFrameUrls);
   const [frameCount, setFrameCount] = useState(parsedFrames ? parseInt(countParam || String(parsedFrames.length)) : DEMO_COUNT);
   const [fps, setFps] = useState(parsedFrames ? parseInt(fpsParam || "24") : 24);
-  const [sections, setSections] = useState<Section[]>([defaultSection(0)]);
+  const [sections, setSections] = useState<Section[]>(() => templateSections ?? [defaultSection(0)]);
   const [selectedSection, setSelectedSection] = useState<string>(sections[0].id);
   // Named after the preset or upload it came from, so a generated site does not
   // arrive here as an anonymous "My ScrollCraft Site".
   const [siteName, setSiteName] = useState(
-    () => searchParams.get("name")?.slice(0, 80) || "My ScrollCraft Site"
+    () => searchParams.get("name")?.slice(0, 80) || pickedTemplate?.name || "My ScrollCraft Site"
   );
   const frameLabelRef = useRef<HTMLSpanElement>(null);
   const handleFrameChange = useCallback((i: number) => {

--- a/src/app/presets/page.tsx
+++ b/src/app/presets/page.tsx
@@ -47,7 +47,7 @@ export default function PresetsPage() {
           Start from a preset
         </h1>
         <p className="text-muted-foreground text-lg max-w-xl mx-auto">
-          Every preset includes a pre-built AI prompt, scroll layout, and section structure. Customize in seconds.
+          Every preset carries a style and palette. For finished sites with copy, browse the templates.
         </p>
       </section>
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from "next";
 import { siteUrl } from "@/lib/env";
+import { TEMPLATES } from "@/lib/templates";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
@@ -8,8 +9,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // are disallowed in robots.ts. Listing /create here as well produced "Indexed, though
   // blocked by robots.txt" in Search Console.
   return [
-    { url: siteUrl,              lastModified: now, changeFrequency: "weekly",  priority: 1 },
-    { url: `${siteUrl}/presets`, lastModified: now, changeFrequency: "weekly",  priority: 0.9 },
+    { url: siteUrl,                lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${siteUrl}/templates`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+    ...TEMPLATES.map((t) => ({
+      url: `${siteUrl}/templates/${t.slug}`,
+      lastModified: now,
+      changeFrequency: "monthly" as const,
+      priority: 0.7,
+    })),
+    { url: `${siteUrl}/presets`, lastModified: now, changeFrequency: "weekly",  priority: 0.6 },
     { url: `${siteUrl}/showcase`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
     { url: `${siteUrl}/pricing`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
     { url: `${siteUrl}/about`,   lastModified: now, changeFrequency: "monthly", priority: 0.5 },

--- a/src/app/templates/[slug]/page.tsx
+++ b/src/app/templates/[slug]/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+import { useEffect, useRef, useState, use } from "react";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, ArrowRight, Layers, Loader2 } from "lucide-react";
+import ScrollEngine from "@/components/ScrollEngine";
+import { generate2DFrames } from "@/lib/generate2DFrames";
+import { loadFrames, storeFrames } from "@/lib/frameStorage";
+import { templateBySlug, templateScrollHeight } from "@/lib/templates";
+import { LAYOUT_STYLES } from "@/lib/layoutStyles";
+
+export default function TemplatePreview({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = use(params);
+  const template = templateBySlug(slug);
+
+  const [frames, setFrames] = useState<string[]>([]);
+  const [progress, setProgress] = useState(0);
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState(false);
+  const generatedKey = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!template) return;
+    const cacheKey = `scrollcraft_template_${slug}`;
+    if (generatedKey.current === cacheKey) return;
+    generatedKey.current = cacheKey;
+
+    const isMobileViewport = window.innerWidth < 768;
+    const frameCount = isMobileViewport ? 60 : 90;
+    const width = isMobileViewport ? 640 : 1280;
+    const height = isMobileViewport ? 360 : 720;
+
+    let cancelled = false;
+    const show = (f: string[]) => {
+      if (cancelled) return;
+      setFrames(f);
+      setProgress(100);
+      setReady(true);
+    };
+
+    loadFrames(cacheKey)
+      .catch(() => null)
+      .then((cached) => {
+        if (cancelled) return;
+        if (cached && cached.length) {
+          show(cached);
+          return;
+        }
+        return generate2DFrames(
+          {
+            style: template.style,
+            color1: template.colors[0],
+            color2: template.colors[1],
+            color3: template.colors[2],
+            frameCount, width, height,
+          },
+          (p) => { if (!cancelled) setProgress(Math.round(p)); }
+        ).then((generated) => {
+          show(generated);
+          return storeFrames(cacheKey, generated).catch(() => {});
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
+
+    return () => { cancelled = true; };
+  }, [template, slug]);
+
+  if (!template) {
+    notFound();
+  }
+
+  const totalScrollHeight = templateScrollHeight(template);
+  const theme = template.theme;
+  const visible = template.sections.filter((s) => s.visible !== false);
+
+  return (
+    <div
+      className="relative overflow-hidden"
+      style={{
+        background: "#000",
+        color: theme.ink ?? "#fff",
+        ["--sc-accent" as string]: theme.accent ?? "#7c3aed",
+        ["--sc-accent-text" as string]: theme.accentText ?? "#ede9fe",
+        ["--sc-muted" as string]: theme.muted ?? "rgba(255,255,255,0.72)",
+      }}
+    >
+      {!ready && (
+        <div
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-6"
+          style={{ background: `linear-gradient(135deg, ${template.colors[2]}, #000)` }}
+        >
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-8 h-8 rounded-lg bg-white/10 flex items-center justify-center">
+              <Layers className="w-4 h-4" style={{ color: theme.accentText ?? "#fff" }} />
+            </div>
+            <span className="font-bold text-lg">{template.name}</span>
+          </div>
+          <div className="w-56 h-1.5 rounded-full bg-white/10 overflow-hidden">
+            <div
+              className="h-full rounded-full transition-all duration-200"
+              style={{ width: `${progress}%`, background: theme.accentText ?? "#fff" }}
+            />
+          </div>
+          {error ? (
+            <div className="flex flex-col items-center gap-3 text-sm text-white/60">
+              <p>Couldn&apos;t build this preview in your browser.</p>
+              <Button
+                size="sm"
+                variant="outline"
+                className="border-white/20 bg-white/10 hover:bg-white/20"
+                onClick={() => window.location.reload()}
+              >
+                Try again
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 text-sm text-white/40">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" /> Rendering frames…
+            </div>
+          )}
+        </div>
+      )}
+
+      <ScrollEngine
+        frames={frames}
+        totalScrollHeight={totalScrollHeight}
+        altText={`Animated ${template.style} background for the ${template.name} template`}
+      />
+
+      <div className="fixed top-4 left-4 right-4 z-40 flex items-center justify-between gap-3 pointer-events-none">
+        <Link href="/templates" className="pointer-events-auto">
+          <Button size="sm" variant="outline" className="border-white/15 bg-black/50 backdrop-blur h-8 text-xs gap-1.5">
+            <ArrowLeft className="w-3.5 h-3.5" /> Templates
+          </Button>
+        </Link>
+        <Link href={`/editor?template=${template.slug}`} className="pointer-events-auto">
+          <Button size="sm" className="h-8 text-xs gap-1.5">
+            Use this template <ArrowRight className="w-3.5 h-3.5" />
+          </Button>
+        </Link>
+      </div>
+
+      <div className="relative z-10 pointer-events-none" style={{ height: totalScrollHeight }}>
+        <div style={{ height: "100vh" }} />
+        {visible.map((s, i) => {
+          const L = LAYOUT_STYLES[s.layout ?? "center"] ?? LAYOUT_STYLES.center;
+          if (s.kind === "spacer") {
+            return <section key={i} aria-hidden="true" style={{ height: s.scrollHeight ?? 1000 }} />;
+          }
+          return (
+            <section key={i} style={{ height: s.scrollHeight ?? 1000, position: "relative" }}>
+              <div
+                style={{
+                  position: "sticky", top: 0, height: "100vh", display: "flex",
+                  alignItems: s.align ?? L.align,
+                  justifyContent: s.justify ?? L.justify,
+                  overflow: "hidden",
+                }}
+              >
+                <div
+                  className="pointer-events-auto"
+                  style={{ textAlign: (s.textAlign ?? L.textAlign) as "left" | "center" | "right", padding: L.pad, maxWidth: L.maxWidth }}
+                >
+                  {s.eyebrow && (
+                    <p style={{
+                      fontSize: "0.875rem", fontWeight: 600, letterSpacing: "0.1em",
+                      textTransform: "uppercase", color: s.accentColor ?? theme.accentText ?? "#ede9fe",
+                      marginBottom: "0.75rem",
+                    }}>{s.eyebrow}</p>
+                  )}
+                  {s.heading && (
+                    <h2 style={{
+                      fontSize: s.kind === "statement" ? "clamp(2.75rem,11vw,9rem)" : "clamp(2rem,5vw,4rem)",
+                      fontWeight: theme.displayWeight ?? 900,
+                      lineHeight: s.kind === "statement" ? 0.92 : 1,
+                      letterSpacing: `${theme.displayTracking ?? -0.03}em`,
+                      textTransform: theme.displayCase === "upper" ? "uppercase" : "none",
+                      color: s.headingColor ?? theme.ink ?? "#fff",
+                      marginBottom: "1rem",
+                    }}>{s.heading}</h2>
+                  )}
+                  {s.body && (
+                    <p style={{
+                      fontSize: "1.125rem", lineHeight: 1.7,
+                      color: s.bodyColor ?? theme.muted ?? "rgba(255,255,255,0.72)",
+                      maxWidth: 600,
+                      margin: (s.textAlign ?? L.textAlign) === "center" ? "0 auto 1.5rem" : "0 0 1.5rem",
+                    }}>{s.body}</p>
+                  )}
+                  {s.ctaLabel && (
+                    <span style={{
+                      display: "inline-block", background: s.accentColor ?? theme.accent ?? "#7c3aed",
+                      color: "#fff", padding: "0.875rem 2rem",
+                      borderRadius: theme.radius ?? 8, fontWeight: 600, fontSize: "1rem",
+                    }}>{s.ctaLabel}</span>
+                  )}
+                </div>
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { ArrowRight, Search, Layers, Eye } from "lucide-react";
+import Navbar from "@/components/Navbar";
+import StylePreview from "@/components/StylePreview";
+import { TEMPLATES, templateCategories, templateScrollHeight } from "@/lib/templates";
+
+export default function TemplatesPage() {
+  const [search, setSearch] = useState("");
+  const [activeCategory, setActiveCategory] = useState("All");
+  // Only the hovered card animates — sixteen concurrent canvases is not free.
+  const [hovered, setHovered] = useState<string | null>(null);
+
+  const categories = useMemo(() => ["All", ...templateCategories()], []);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return TEMPLATES.filter((t) => {
+      const matchesCategory = activeCategory === "All" || t.category === activeCategory;
+      if (!matchesCategory) return false;
+      if (!q) return true;
+      return (
+        t.name.toLowerCase().includes(q) ||
+        t.tagline.toLowerCase().includes(q) ||
+        t.category.toLowerCase().includes(q) ||
+        t.tags.some((tag) => tag.toLowerCase().includes(q))
+      );
+    });
+  }, [search, activeCategory]);
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <Navbar />
+
+      <section className="pt-16 pb-10 text-center px-6">
+        <Badge variant="outline" className="mb-5 border-primary/40 text-primary bg-primary/10 px-4 py-1.5">
+          <Layers className="w-3 h-3 mr-1.5" /> {TEMPLATES.length} templates, free on every plan
+        </Badge>
+        <h1 className="text-5xl md:text-6xl font-black tracking-tighter mb-4">
+          Start from a finished site
+        </h1>
+        <p className="text-muted-foreground text-lg max-w-xl mx-auto">
+          Every template ships with its own palette, typography, pacing and copy structure.
+          Open one, change the words, export it.
+        </p>
+      </section>
+
+      <div className="px-6 pb-8 max-w-7xl mx-auto space-y-4">
+        <div className="relative max-w-md mx-auto">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" aria-hidden="true" />
+          <label htmlFor="template-search" className="sr-only">Search templates</label>
+          <Input
+            id="template-search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by name, category or tag"
+            className="pl-9 bg-card border-white/10"
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-2 justify-center">
+          {categories.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => setActiveCategory(c)}
+              aria-pressed={activeCategory === c}
+              className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+                activeCategory === c
+                  ? "border-primary/50 bg-primary/15 text-primary"
+                  : "border-white/10 text-muted-foreground hover:text-foreground hover:border-white/20"
+              }`}
+            >
+              {c}
+            </button>
+          ))}
+        </div>
+
+        <p className="text-center text-xs text-muted-foreground" aria-live="polite">
+          {filtered.length} of {TEMPLATES.length} templates
+        </p>
+      </div>
+
+      <section className="px-6 pb-24 max-w-7xl mx-auto">
+        {filtered.length === 0 ? (
+          <div className="text-center py-20 border border-white/8 rounded-2xl bg-card">
+            <p className="font-medium mb-1">Nothing matches “{search}”</p>
+            <p className="text-sm text-muted-foreground mb-5">
+              Try a category instead, or clear the search.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-white/10"
+              onClick={() => { setSearch(""); setActiveCategory("All"); }}
+            >
+              Show all templates
+            </Button>
+          </div>
+        ) : (
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {filtered.map((t) => (
+              <article
+                key={t.slug}
+                onMouseEnter={() => setHovered(t.slug)}
+                onMouseLeave={() => setHovered((h) => (h === t.slug ? null : h))}
+                className="group rounded-2xl border border-white/8 bg-card overflow-hidden flex flex-col focus-within:border-primary/40 hover:border-white/15 transition-colors"
+              >
+                <div className={`relative aspect-[16/10] bg-gradient-to-br ${t.gradient}`}>
+                  <StylePreview
+                    style={t.style}
+                    colors={t.colors}
+                    paused={hovered !== t.slug}
+                    className="absolute inset-0 w-full h-full"
+                  />
+                  <div className="absolute inset-x-0 bottom-0 p-3 bg-gradient-to-t from-black/70 to-transparent">
+                    <span className="text-[10px] uppercase tracking-widest text-white/70">{t.category}</span>
+                  </div>
+                </div>
+
+                <div className="p-4 flex flex-col gap-3 flex-1">
+                  <div className="space-y-1">
+                    <h2 className="font-bold tracking-tight">{t.name}</h2>
+                    <p className="text-xs text-muted-foreground leading-relaxed">{t.tagline}</p>
+                  </div>
+
+                  <div className="flex flex-wrap gap-1.5">
+                    {t.tags.map((tag) => (
+                      <span key={tag} className="text-[10px] px-1.5 py-0.5 rounded bg-white/5 text-muted-foreground">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+
+                  <p className="text-[11px] text-muted-foreground mt-auto">
+                    {t.sections.filter((s) => s.kind !== "spacer").length} sections ·{" "}
+                    {templateScrollHeight(t).toLocaleString()}px of scroll
+                  </p>
+
+                  <div className="flex gap-2">
+                    <Link href={`/templates/${t.slug}`} className="flex-1">
+                      <Button variant="outline" size="sm" className="w-full border-white/10 text-xs h-8 gap-1.5">
+                        <Eye className="w-3.5 h-3.5" /> Preview
+                      </Button>
+                    </Link>
+                    <Link href={`/editor?template=${t.slug}`} className="flex-1">
+                      <Button size="sm" className="w-full text-xs h-8 gap-1.5">
+                        Use <ArrowRight className="w-3.5 h-3.5" />
+                      </Button>
+                    </Link>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,9 +7,9 @@ import { Button } from "@/components/ui/button";
 import { Sparkles, Menu, X } from "lucide-react";
 
 const NAV_LINKS = [
-  { href: "/showcase", label: "Examples" },
-  { href: "/presets",  label: "Presets"  },
-  { href: "/pricing",  label: "Pricing"  },
+  { href: "/templates", label: "Templates" },
+  { href: "/showcase",  label: "Examples"  },
+  { href: "/pricing",   label: "Pricing"   },
 ];
 
 export default function Navbar({ position = "sticky" }: { position?: "fixed" | "sticky" | "relative" }) {

--- a/src/lib/layoutStyles.ts
+++ b/src/lib/layoutStyles.ts
@@ -1,0 +1,23 @@
+import { SECTION_LAYOUTS, type SectionLayout } from "@/lib/siteSchema";
+
+export interface LayoutStyle {
+  align: string;
+  justify: string;
+  textAlign: "left" | "center" | "right";
+  maxWidth: number;
+  pad: string;
+}
+
+export const LAYOUT_STYLES: Record<SectionLayout, LayoutStyle> = {
+  center: { align: "center", justify: "center", textAlign: "center", maxWidth: 800, pad: "2rem" },
+  left: { align: "center", justify: "flex-start", textAlign: "left", maxWidth: 620, pad: "2rem clamp(2rem, 8vw, 8rem)" },
+  right: { align: "center", justify: "flex-end", textAlign: "left", maxWidth: 620, pad: "2rem clamp(2rem, 8vw, 8rem)" },
+  "lower-third": { align: "flex-end", justify: "flex-start", textAlign: "left", maxWidth: 900, pad: "0 clamp(2rem, 8vw, 8rem) clamp(3rem, 10vh, 7rem)" },
+  "upper-third": { align: "flex-start", justify: "center", textAlign: "center", maxWidth: 800, pad: "clamp(3rem, 12vh, 8rem) 2rem 0" },
+};
+
+export function layoutStyle(layout: string | undefined): LayoutStyle {
+  return LAYOUT_STYLES[(layout ?? "center") as SectionLayout] ?? LAYOUT_STYLES.center;
+}
+
+export { SECTION_LAYOUTS };

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,0 +1,743 @@
+import type { Style2D } from "@/lib/generate2DFrames";
+import type { Section } from "@/lib/siteSchema";
+
+export interface TemplateTheme {
+  fontDisplay?: string;
+  fontBody?: string;
+  scale?: "compact" | "editorial" | "poster";
+  displayWeight?: number;
+  displayCase?: "none" | "upper";
+  displayTracking?: number;
+  ink?: string;
+  muted?: string;
+  accent?: string;
+  accentText?: string;
+  radius?: number;
+}
+
+export interface Template {
+  slug: string;
+  name: string;
+  tagline: string;
+  category: string;
+  tags: string[];
+  style: Style2D;
+  colors: [string, string, string];
+  /** Tailwind gradient for the gallery card, so a card reads before frames render. */
+  gradient: string;
+  theme: TemplateTheme;
+  sections: Section[];
+}
+
+const INTRO_BUFFER = 1000;
+
+/** Matches the exporter and the skill: the leading spacer plus every section's own track. */
+export function templateScrollHeight(t: Template): number {
+  return t.sections.reduce((acc, s) => acc + (s.scrollHeight ?? 1000), 0) + INTRO_BUFFER;
+}
+
+export function templateBySlug(slug: string): Template | undefined {
+  return TEMPLATES.find((t) => t.slug === slug);
+}
+
+export function templateCategories(): string[] {
+  return [...new Set(TEMPLATES.map((t) => t.category))].sort();
+}
+
+export const TEMPLATES: Template[] = [
+  {
+    slug: "orbitcrm",
+    name: "OrbitCRM",
+    tagline: "A revenue tool that reads like an argument, not a feature list",
+    category: "SaaS",
+    tags: ["Dark", "Violet", "Product-led"],
+    style: "gradient",
+    colors: ["#7c3aed", "#2563eb", "#0f172a"],
+    gradient: "from-violet-800 via-purple-900 to-violet-950",
+    theme: {
+      fontDisplay: "Archivo", fontBody: "IBM Plex Sans", scale: "editorial",
+      displayWeight: 800, ink: "#f1eefb", muted: "rgba(241,238,251,0.72)",
+      accent: "#5b34a8", accentText: "#d6c6f5", radius: 8,
+    },
+    sections: [
+      {
+        kind: "statement", layout: "center", reveal: "mask",
+        eyebrow: "Introducing OrbitCRM",
+        heading: "Close deals at the speed of light.",
+        scrollHeight: 1400,
+      },
+      {
+        layout: "left", reveal: "stagger",
+        eyebrow: "Pipeline",
+        heading: "Your pipeline, finally alive",
+        body: "Drag-and-drop stages, real-time probability scoring, and next-step suggestions drawn from the deals your team already won.",
+        scrollHeight: 1500,
+      },
+      { kind: "spacer", scrollHeight: 700 },
+      {
+        layout: "right", reveal: "fade",
+        eyebrow: "Trusted by 4,200 teams",
+        heading: "Scales past the point most tools break",
+        body: "SOC 2 Type II, 99.99% uptime, and an audit log your security reviewer will actually accept.",
+        scrollHeight: 1300,
+      },
+      {
+        layout: "center", reveal: "scale",
+        heading: "Start closing this week",
+        ctaLabel: "Start free trial", ctaHref: "#signup",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "atlas-studio",
+    name: "Atlas Studio",
+    tagline: "A design studio page that lets the work do the talking",
+    category: "Agency",
+    tags: ["Editorial", "Serif", "Restrained"],
+    style: "wave",
+    colors: ["#0b1f2a", "#14505f", "#061218"],
+    gradient: "from-slate-800 via-teal-900 to-slate-950",
+    theme: {
+      fontDisplay: "Playfair Display", fontBody: "Lato", scale: "poster",
+      displayWeight: 700, displayTracking: -0.025, ink: "#f3f1ea",
+      muted: "rgba(243,241,234,0.7)", accent: "#1f6b74", accentText: "#a7dbe0", radius: 0,
+    },
+    sections: [
+      {
+        kind: "statement", layout: "lower-third", reveal: "mask",
+        heading: "We build the thing you cannot stop looking at.",
+        scrollHeight: 1600,
+      },
+      {
+        layout: "lower-third", reveal: "stagger",
+        eyebrow: "How we work",
+        heading: "Six weeks, one team, no handoff",
+        body: "Strategy, design and build in the same room. Nothing gets thrown over a wall, so nothing arrives diluted.",
+        scrollHeight: 1500,
+      },
+      { kind: "spacer", scrollHeight: 900 },
+      {
+        kind: "statement", layout: "center", reveal: "scale",
+        heading: "Selected work, 2019 to now.",
+        scrollHeight: 1400,
+      },
+      {
+        layout: "center", reveal: "fade",
+        heading: "Tell us what you are making",
+        ctaLabel: "Start a project", ctaHref: "#contact",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "meridian-watch",
+    name: "Meridian",
+    tagline: "A single-product page built around one object",
+    category: "Product",
+    tags: ["Luxury", "Warm", "Minimal"],
+    style: "gradient",
+    colors: ["#1a0f07", "#7a3d10", "#0d0704"],
+    gradient: "from-amber-900 via-orange-950 to-stone-950",
+    theme: {
+      fontDisplay: "Archivo", fontBody: "IBM Plex Sans", scale: "poster",
+      displayWeight: 800, displayCase: "upper", displayTracking: -0.02,
+      ink: "#f7efe6", muted: "rgba(247,239,230,0.7)",
+      accent: "#a94b0d", accentText: "#f8c9aa", radius: 2,
+    },
+    sections: [
+      {
+        kind: "statement", layout: "center", reveal: "mask",
+        eyebrow: "Meridian 01",
+        heading: "Machined from one billet.",
+        scrollHeight: 1500,
+      },
+      { kind: "spacer", scrollHeight: 800 },
+      {
+        layout: "left", reveal: "stagger",
+        eyebrow: "Movement",
+        heading: "Eleven parts. Each one load bearing.",
+        body: "No decoration, no filler plate, nothing added to look expensive. What you see holding the hands is what holds the hands.",
+        scrollHeight: 1600,
+      },
+      {
+        layout: "right", reveal: "fade",
+        eyebrow: "Case",
+        heading: "Brushed by hand, twice",
+        body: "Once to flatten the mill marks, once at a right angle so the light moves across it rather than glinting off it.",
+        scrollHeight: 1400,
+      },
+      {
+        layout: "center", reveal: "scale",
+        heading: "Four hundred made",
+        body: "Then the tooling is retired.",
+        ctaLabel: "Reserve one", ctaHref: "#reserve",
+        scrollHeight: 1100,
+      },
+    ],
+  },
+  {
+    slug: "kiln-coffee",
+    name: "Kiln",
+    tagline: "A roastery page that smells like the room",
+    category: "Food & Drink",
+    tags: ["Warm", "Editorial", "Craft"],
+    style: "particles",
+    colors: ["#160d08", "#6b3418", "#0b0605"],
+    gradient: "from-orange-950 via-amber-950 to-stone-950",
+    theme: {
+      fontDisplay: "Fraunces", fontBody: "Karla", scale: "editorial",
+      displayWeight: 700, displayTracking: -0.02, ink: "#f6ece2",
+      muted: "rgba(246,236,226,0.72)", accent: "#8a4318", accentText: "#f2c39c", radius: 12,
+    },
+    sections: [
+      {
+        kind: "statement", layout: "lower-third", reveal: "fade",
+        eyebrow: "Kiln Roastery",
+        heading: "Roasted this morning. Ground when you order.",
+        scrollHeight: 1400,
+      },
+      {
+        layout: "left", reveal: "stagger",
+        eyebrow: "Sourcing",
+        heading: "Two farms. Both on first-name terms.",
+        body: "We buy the whole lot or none of it, which means the price is agreed before harvest and the farmer is not gambling on us.",
+        scrollHeight: 1500,
+      },
+      {
+        layout: "right", reveal: "fade",
+        eyebrow: "The roast",
+        heading: "Light enough to taste the fruit",
+        body: "Anything darker is a decision to hide the bean. We would rather sell you something that tastes of where it grew.",
+        scrollHeight: 1400,
+      },
+      {
+        layout: "center", reveal: "scale",
+        heading: "Subscribe, or just try a bag",
+        ctaLabel: "Order coffee", ctaHref: "#shop",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "northlight",
+    name: "Northlight",
+    tagline: "A photographer's portfolio that gets out of the way",
+    category: "Portfolio",
+    tags: ["Cold", "Quiet", "Image-led"],
+    style: "wave",
+    colors: ["#050a12", "#123a52", "#02060b"],
+    gradient: "from-sky-950 via-slate-900 to-black",
+    theme: {
+      fontDisplay: "Space Grotesk", fontBody: "Inter", scale: "compact",
+      displayWeight: 600, displayTracking: 0.01, ink: "#e9f1f6",
+      muted: "rgba(233,241,246,0.68)", accent: "#1f5f78", accentText: "#a9d9ec", radius: 4,
+    },
+    sections: [
+      {
+        layout: "lower-third", reveal: "fade",
+        eyebrow: "Northlight",
+        heading: "Landscape work, mostly at dawn",
+        body: "Iceland, the Faroes, and a lot of waiting in cars.",
+        scrollHeight: 1300,
+      },
+      { kind: "spacer", scrollHeight: 800 },
+      {
+        layout: "lower-third", reveal: "fade",
+        eyebrow: "Series 01",
+        heading: "Sixty-one days of the same shoreline",
+        body: "Same tripod holes, same hour, every day through a winter. The interesting part is how little repeats.",
+        scrollHeight: 1500,
+      },
+      {
+        layout: "lower-third", reveal: "fade",
+        eyebrow: "Prints",
+        heading: "Editions of nine",
+        body: "Hand-printed, signed on the back, shipped flat.",
+        scrollHeight: 1200,
+      },
+      {
+        layout: "center", reveal: "rise",
+        heading: "Commissions open for spring",
+        ctaLabel: "Get in touch", ctaHref: "#contact",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "signal-conf",
+    name: "Signal",
+    tagline: "A conference page that answers the only three questions",
+    category: "Event",
+    tags: ["Bold", "Cyan", "Dated"],
+    style: "geometric",
+    colors: ["#03121a", "#0a5f6e", "#010a0f"],
+    gradient: "from-cyan-900 via-teal-950 to-slate-950",
+    theme: {
+      fontDisplay: "Oswald", fontBody: "Roboto", scale: "poster",
+      displayWeight: 600, displayCase: "upper", displayTracking: 0.015,
+      ink: "#e6f6f8", muted: "rgba(230,246,248,0.7)",
+      accent: "#12666f", accentText: "#9fe3ec", radius: 0,
+    },
+    sections: [
+      {
+        kind: "statement", layout: "center", reveal: "mask",
+        eyebrow: "March 14 to 16 · Lisbon",
+        heading: "Signal 2027",
+        scrollHeight: 1500,
+      },
+      {
+        layout: "left", reveal: "stagger",
+        eyebrow: "Programme",
+        heading: "Three days, one track, no parallel sessions",
+        body: "Everyone sees the same talks, so the hallway conversation is about the thing you all just watched.",
+        scrollHeight: 1400,
+      },
+      {
+        layout: "right", reveal: "fade",
+        eyebrow: "Speakers",
+        heading: "Twenty-two people who build things",
+        body: "No keynote sponsors, no vendor pitches. If someone is on stage it is because they shipped something.",
+        scrollHeight: 1400,
+      },
+      {
+        layout: "center", reveal: "scale",
+        eyebrow: "Tickets",
+        heading: "Four hundred seats",
+        ctaLabel: "Get a ticket", ctaHref: "#tickets",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "quarry-fitness",
+    name: "Quarry",
+    tagline: "A gym page with no stock photography energy",
+    category: "Fitness",
+    tags: ["Hard", "Monochrome", "Direct"],
+    style: "geometric",
+    colors: ["#0a0c0f", "#2b343d", "#050607"],
+    gradient: "from-zinc-800 via-slate-900 to-black",
+    theme: {
+      fontDisplay: "Oswald", fontBody: "Roboto", scale: "poster",
+      displayWeight: 700, displayCase: "upper", displayTracking: 0.02,
+      ink: "#eef1f4", muted: "rgba(238,241,244,0.68)",
+      accent: "#4b555f", accentText: "#c9d3dc", radius: 0,
+    },
+    sections: [
+      {
+        kind: "statement", layout: "lower-third", reveal: "mask",
+        heading: "It is going to be hard. That is the product.",
+        scrollHeight: 1500,
+      },
+      {
+        layout: "left", reveal: "stagger",
+        eyebrow: "Coaching",
+        heading: "One coach, twelve people, no mirrors",
+        body: "You get corrected out loud, in front of everyone, because that is the fastest way to stop doing it wrong.",
+        scrollHeight: 1400,
+      },
+      { kind: "spacer", scrollHeight: 700 },
+      {
+        layout: "right", reveal: "fade",
+        eyebrow: "Membership",
+        heading: "Month to month, cancel whenever",
+        body: "No twelve-month contract. If it stops being worth it, leaving should be easy.",
+        scrollHeight: 1300,
+      },
+      {
+        layout: "center", reveal: "scale",
+        heading: "First session is free",
+        ctaLabel: "Book it", ctaHref: "#book",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "ledger-fintech",
+    name: "Ledger",
+    tagline: "A fintech page that leads with the number",
+    category: "SaaS",
+    tags: ["Cool", "Dense", "Technical"],
+    style: "gradient",
+    colors: ["#02110f", "#0c4a42", "#010807"],
+    gradient: "from-emerald-900 via-teal-950 to-black",
+    theme: {
+      fontDisplay: "Space Grotesk", fontBody: "Inter", scale: "compact",
+      displayWeight: 700, ink: "#e8f5f1", muted: "rgba(232,245,241,0.7)",
+      accent: "#0f5f55", accentText: "#93dccf", radius: 6,
+    },
+    sections: [
+      {
+        layout: "upper-third", reveal: "fade",
+        eyebrow: "Ledger",
+        heading: "Close the month in four days, not fourteen",
+        body: "Reconciliation that runs continuously instead of in a panic at quarter end.",
+        scrollHeight: 1200,
+      },
+      {
+        layout: "upper-third", reveal: "fade",
+        eyebrow: "Coverage",
+        heading: "Every account, one ledger",
+        body: "Nineteen banks, six payment processors, and your own internal transfers, matched on the same rules engine.",
+        scrollHeight: 1200,
+      },
+      {
+        layout: "upper-third", reveal: "fade",
+        eyebrow: "Audit",
+        heading: "Every change has a name on it",
+        body: "Immutable history, exportable in the format your auditor asks for rather than the one we prefer.",
+        scrollHeight: 1200,
+      },
+      {
+        layout: "center", reveal: "rise",
+        heading: "See it against your own data",
+        ctaLabel: "Book a walkthrough", ctaHref: "#demo",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "harbour-estate",
+    name: "Harbour",
+    tagline: "A property listing that sells the view, not the square footage",
+    category: "Real Estate",
+    tags: ["Calm", "Blue", "Spacious"],
+    style: "wave",
+    colors: ["#04121c", "#11526b", "#020a10"],
+    gradient: "from-sky-900 via-slate-900 to-slate-950",
+    theme: {
+      fontDisplay: "Playfair Display", fontBody: "Lato", scale: "editorial",
+      displayWeight: 700, displayTracking: -0.02, ink: "#f0f5f8",
+      muted: "rgba(240,245,248,0.72)", accent: "#1a5d78", accentText: "#a6d7e8", radius: 10,
+    },
+    sections: [
+      {
+        kind: "statement", layout: "lower-third", reveal: "mask",
+        eyebrow: "Harbour House",
+        heading: "The water is forty metres away.",
+        scrollHeight: 1500,
+      },
+      {
+        layout: "left", reveal: "stagger",
+        eyebrow: "The house",
+        heading: "Built in 1908, rewired in 2024",
+        body: "Original floors, original windows, none of the original plumbing. Four bedrooms, two of them facing the estuary.",
+        scrollHeight: 1400,
+      },
+      { kind: "spacer", scrollHeight: 800 },
+      {
+        layout: "right", reveal: "fade",
+        eyebrow: "The village",
+        heading: "A shop, a pub, and a train every hour",
+        body: "Fifty-one minutes to the city, which is close enough to commute and far enough to hear the tide.",
+        scrollHeight: 1300,
+      },
+      {
+        layout: "center", reveal: "scale",
+        heading: "Viewings from Saturday",
+        ctaLabel: "Arrange a viewing", ctaHref: "#viewing",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "field-notes",
+    name: "Field Notes",
+    tagline: "A long-form essay layout for one piece of writing",
+    category: "Editorial",
+    tags: ["Quiet", "Serif", "Text-first"],
+    style: "particles",
+    colors: ["#0a0910", "#2d2543", "#050409"],
+    gradient: "from-indigo-950 via-slate-900 to-black",
+    theme: {
+      fontDisplay: "Fraunces", fontBody: "Karla", scale: "editorial",
+      displayWeight: 600, displayTracking: -0.015, ink: "#f0edf7",
+      muted: "rgba(240,237,247,0.72)", accent: "#4a3a7a", accentText: "#cfc3ee", radius: 14,
+    },
+    sections: [
+      {
+        layout: "lower-third", reveal: "fade",
+        eyebrow: "Essay · 12 min",
+        heading: "What we lost when maps stopped being wrong",
+        scrollHeight: 1400,
+      },
+      {
+        layout: "lower-third", reveal: "stagger",
+        heading: "Part one: the blank spaces",
+        body: "A map that admits it does not know something is more honest than one that quietly guesses. We traded the first for the second and called it progress.",
+        scrollHeight: 1600,
+      },
+      { kind: "spacer", scrollHeight: 900 },
+      {
+        layout: "lower-third", reveal: "stagger",
+        heading: "Part two: the cost of certainty",
+        body: "Every seam smoothed over is a decision someone made on your behalf, in a room you were not in, about a place you are about to walk through.",
+        scrollHeight: 1600,
+      },
+      {
+        layout: "center", reveal: "scale",
+        heading: "Subscribe for the next one",
+        ctaLabel: "Get essays by email", ctaHref: "#subscribe",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "pulse-app",
+    name: "Pulse",
+    tagline: "A mobile app launch page, one feature per screen",
+    category: "Product",
+    tags: ["Vivid", "Playful", "App"],
+    style: "particles",
+    colors: ["#0b0418", "#5b1f8a", "#060210"],
+    gradient: "from-fuchsia-900 via-purple-950 to-black",
+    theme: {
+      fontDisplay: "Archivo", fontBody: "Inter", scale: "poster",
+      displayWeight: 800, displayTracking: -0.03, ink: "#f6eefb",
+      muted: "rgba(246,238,251,0.72)", accent: "#7a3aa8", accentText: "#e2c2f5", radius: 20,
+    },
+    sections: [
+      {
+        kind: "statement", layout: "center", reveal: "scale",
+        eyebrow: "Pulse",
+        heading: "Your week, on one screen.",
+        scrollHeight: 1400,
+      },
+      {
+        layout: "left", reveal: "stagger",
+        eyebrow: "Planning",
+        heading: "Plan in minutes, not evenings",
+        body: "Drag a block, drop it on a day. That is the whole interaction, and it is deliberately the only one.",
+        scrollHeight: 1300,
+      },
+      {
+        layout: "right", reveal: "stagger",
+        eyebrow: "Focus",
+        heading: "One thing at a time, enforced",
+        body: "Pulse hides everything you are not doing right now. You can turn that off. You will turn it back on.",
+        scrollHeight: 1300,
+      },
+      {
+        layout: "center", reveal: "mask",
+        heading: "Free while we are in beta",
+        ctaLabel: "Get the app", ctaHref: "#download",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "cinder-restaurant",
+    name: "Cinder",
+    tagline: "A restaurant page that reads like the menu",
+    category: "Food & Drink",
+    tags: ["Dark", "Ember", "Intimate"],
+    style: "gradient",
+    colors: ["#120604", "#5e2109", "#080302"],
+    gradient: "from-red-950 via-orange-950 to-black",
+    theme: {
+      fontDisplay: "Playfair Display", fontBody: "Lato", scale: "poster",
+      displayWeight: 700, displayTracking: -0.02, ink: "#f8ece3",
+      muted: "rgba(248,236,227,0.7)", accent: "#973f11", accentText: "#f6c4a0", radius: 4,
+    },
+    sections: [
+      {
+        kind: "statement", layout: "lower-third", reveal: "mask",
+        eyebrow: "Cinder",
+        heading: "Everything here touched fire.",
+        scrollHeight: 1500,
+      },
+      {
+        layout: "left", reveal: "stagger",
+        eyebrow: "The kitchen",
+        heading: "One hearth, no gas, no induction",
+        body: "Twelve dishes a night because that is what one fire can do properly. The menu changes when the delivery does.",
+        scrollHeight: 1400,
+      },
+      { kind: "spacer", scrollHeight: 700 },
+      {
+        layout: "right", reveal: "fade",
+        eyebrow: "The room",
+        heading: "Twenty-six seats, one long table",
+        body: "You will be sitting next to someone you do not know. Most people decide they like this by the second course.",
+        scrollHeight: 1300,
+      },
+      {
+        layout: "center", reveal: "scale",
+        heading: "Bookings open on the first",
+        ctaLabel: "Reserve a seat", ctaHref: "#book",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "beacon-nonprofit",
+    name: "Beacon",
+    tagline: "A cause page that asks once, clearly",
+    category: "Nonprofit",
+    tags: ["Warm", "Human", "Direct"],
+    style: "wave",
+    colors: ["#0c1108", "#3d5417", "#050803"],
+    gradient: "from-lime-950 via-green-950 to-black",
+    theme: {
+      fontDisplay: "Archivo", fontBody: "IBM Plex Sans", scale: "editorial",
+      displayWeight: 700, ink: "#f0f4e9", muted: "rgba(240,244,233,0.72)",
+      accent: "#3f5c1a", accentText: "#c6dfa0", radius: 8,
+    },
+    sections: [
+      {
+        kind: "statement", layout: "center", reveal: "fade",
+        eyebrow: "Beacon",
+        heading: "Eleven thousand homes still have no meter.",
+        scrollHeight: 1400,
+      },
+      {
+        layout: "left", reveal: "stagger",
+        eyebrow: "What we do",
+        heading: "We install, then we leave",
+        body: "No ongoing fee, no data harvesting, no branding on the box. The household owns the meter from the day it goes in.",
+        scrollHeight: 1400,
+      },
+      {
+        layout: "right", reveal: "fade",
+        eyebrow: "Where it goes",
+        heading: "Ninety-one pence in the pound",
+        body: "Published quarterly, audited annually, and broken down per district so you can see the one nearest you.",
+        scrollHeight: 1300,
+      },
+      {
+        layout: "center", reveal: "scale",
+        heading: "Fund a meter",
+        body: "Forty pounds covers one installation.",
+        ctaLabel: "Donate", ctaHref: "#donate",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "vellum-books",
+    name: "Vellum",
+    tagline: "A book launch page with room to breathe",
+    category: "Editorial",
+    tags: ["Paper", "Serif", "Slow"],
+    style: "particles",
+    colors: ["#100c07", "#4a3a22", "#070502"],
+    gradient: "from-yellow-950 via-stone-900 to-black",
+    theme: {
+      fontDisplay: "Fraunces", fontBody: "Karla", scale: "poster",
+      displayWeight: 700, displayTracking: -0.03, ink: "#f5efe3",
+      muted: "rgba(245,239,227,0.72)", accent: "#6d5324", accentText: "#e3cfa3", radius: 6,
+    },
+    sections: [
+      {
+        kind: "statement", layout: "center", reveal: "mask",
+        eyebrow: "Out in April",
+        heading: "The Salt Road",
+        scrollHeight: 1600,
+      },
+      { kind: "spacer", scrollHeight: 900 },
+      {
+        layout: "lower-third", reveal: "stagger",
+        eyebrow: "The book",
+        heading: "Four hundred pages, one journey",
+        body: "A trade route, the people who kept it open, and what happened in the eighty years after it closed.",
+        scrollHeight: 1500,
+      },
+      {
+        layout: "center", reveal: "fade",
+        heading: "Signed first editions",
+        body: "Numbered to five hundred.",
+        ctaLabel: "Pre-order", ctaHref: "#preorder",
+        scrollHeight: 1100,
+      },
+    ],
+  },
+  {
+    slug: "forge-devtool",
+    name: "Forge",
+    tagline: "A developer tool page written for people who read docs",
+    category: "SaaS",
+    tags: ["Terminal", "Dense", "Technical"],
+    style: "geometric",
+    colors: ["#060810", "#1f2a44", "#03040a"],
+    gradient: "from-slate-800 via-indigo-950 to-black",
+    theme: {
+      fontDisplay: "Space Grotesk", fontBody: "Inter", scale: "compact",
+      displayWeight: 700, ink: "#e9ecf6", muted: "rgba(233,236,246,0.7)",
+      accent: "#2f3f6b", accentText: "#aebbe6", radius: 4,
+    },
+    sections: [
+      {
+        layout: "upper-third", reveal: "fade",
+        eyebrow: "Forge",
+        heading: "Builds that finish before you switch tabs",
+        body: "Content-addressed caching, so the second build of anything is a lookup.",
+        scrollHeight: 1200,
+      },
+      {
+        layout: "upper-third", reveal: "fade",
+        eyebrow: "How",
+        heading: "Nothing runs twice",
+        body: "Every task is keyed on its inputs. Change one file and exactly the work that depends on it re-runs.",
+        scrollHeight: 1200,
+      },
+      {
+        layout: "upper-third", reveal: "fade",
+        eyebrow: "Adoption",
+        heading: "One file, then delete it if you hate it",
+        body: "Forge reads your existing scripts. There is no migration and no lock-in to unwind.",
+        scrollHeight: 1200,
+      },
+      {
+        layout: "center", reveal: "rise",
+        heading: "Try it on your slowest repo",
+        ctaLabel: "Read the docs", ctaHref: "#docs",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+  {
+    slug: "solstice-travel",
+    name: "Solstice",
+    tagline: "A travel page that sells one trip properly",
+    category: "Travel",
+    tags: ["Golden", "Wide", "Cinematic"],
+    style: "gradient",
+    colors: ["#150c04", "#8a5310", "#0a0602"],
+    gradient: "from-amber-800 via-orange-900 to-stone-950",
+    theme: {
+      fontDisplay: "Playfair Display", fontBody: "Lato", scale: "poster",
+      displayWeight: 700, displayTracking: -0.025, ink: "#f9f0e2",
+      muted: "rgba(249,240,226,0.72)", accent: "#8d5311", accentText: "#f4cf9c", radius: 16,
+    },
+    sections: [
+      {
+        kind: "statement", layout: "lower-third", reveal: "mask",
+        eyebrow: "Nine days · Atacama",
+        heading: "The driest place that still has a sky.",
+        scrollHeight: 1600,
+      },
+      {
+        layout: "left", reveal: "stagger",
+        eyebrow: "The route",
+        heading: "Three valleys, one salt flat, no coaches",
+        body: "Small vehicles, local guides, and the kind of pace that lets you stop when the light does something.",
+        scrollHeight: 1500,
+      },
+      { kind: "spacer", scrollHeight: 800 },
+      {
+        layout: "right", reveal: "fade",
+        eyebrow: "Nights",
+        heading: "Two of them outside",
+        body: "At four thousand metres with no town for eighty kilometres, which is the entire reason to come.",
+        scrollHeight: 1300,
+      },
+      {
+        layout: "center", reveal: "scale",
+        heading: "Eight travellers per departure",
+        ctaLabel: "See dates", ctaHref: "#dates",
+        scrollHeight: 1000,
+      },
+    ],
+  },
+];


### PR DESCRIPTION
# Description

The product the pivot was for: **16 finished templates across 11 categories**, browsable, previewable, and one click from the editor.

## The catalogue

`src/lib/templates.ts` — SaaS ×3, Editorial ×2, Food & Drink ×2, Product ×2, and one each of Agency, Event, Fitness, Nonprofit, Portfolio, Real Estate, Travel.

Each template carries its own palette, Google Fonts pairing, type scale, section layouts, reveals and **real copy** — not lorem, not "Section 1". They are built on the **shared section schema** from #299, so a template is the same shape the editor edits and the exporter renders.

## Pages

- **`/templates`** — search across name, tagline, category and tags; category filter; a live canvas preview that animates **only the hovered card**, because sixteen concurrent `requestAnimationFrame` loops is not free. Empty state offers a way out rather than a dead end.
- **`/templates/[slug]`** — renders the template at full size against its own frames, and **computes its scroll track from its own sections**. The demos page hardcodes `TOTAL_SCROLL = 4600` for "3 sections × 1200", which is wrong for any template with different pacing.
- **`/editor?template=<slug>`** — hydrates the editor's document from the template's sections, taking its name and palette as defaults.

## Two bugs found and fixed while building it

**An unknown slug returned HTTP 200** with a "not found" body. That is exactly the defect audit **#13** filed against `/demos/<unknown-slug>` — I reproduced it in new code, caught it in a real server run, and it now calls `notFound()`. Verified: `/templates/does-not-exist` → **404**, `/templates/kiln-coffee` → **200**.

**The layout table was duplicated** between the exporter and this preview — the same failure mode #299 existed to fix. It now lives in `src/lib/layoutStyles.ts` and the exporter imports it. The existing export parity tests pass unchanged, which is what makes the refactor safe rather than hopeful.

## Testing

`src/__tests__/templates.test.ts`, 19 cases. These are quality gates on the catalogue, not just shape checks:

- every template parses through `sectionsSchema`
- **no placeholder copy** — fails on `lorem`, `ipsum`, `replace this copy`, `section 1`, `your text here`, `todo`
- every template **varies its layouts**, so none reads as one repeated screen
- every template **ends with a call to action**
- at most **two `statement` sections**, or none of them land
- every section paced **≥400px**, below which copy flashes past unread
- never opens or closes on a spacer
- only names layouts, kinds and reveals the renderer knows
- scroll height matches the exporter's `Σ scrollHeight + 1000` formula
- unique, URL-safe slugs; full palette, card art, tags and tagline
- `accent` and `accentText` both present and **different**, since one sits behind white text and the other is read against the frame

Plus 3 cases on the extracted layout table: covers every schema layout, falls back to center for unknown, and keeps all five visually distinct.

Measured on this branch:

- `npx tsc --noEmit` clean · `npx eslint` clean · `npx next build` succeeds, both routes present
- `npx vitest run` **240 passed / 16 files**, up from 221 / 15
- **Real server run**, not just a build: gallery 200 with all 16 cards, `meridian-watch` 200 with its actual heading in the HTML, unknown slug 404, sitemap containing 16 template URLs

## Type of change

- [x] ✨ New feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactor

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes
- [x] `npm run build` passes
- [x] I updated docs / `.env.example` if config or env vars changed
- [x] I added tests for new logic where practical

## Risks and trade-offs

- **The preview page duplicates the exporter's section rendering** in JSX. It reads the same shared layout table and schema, so they cannot disagree on structure, but the inline styles are a second implementation of the same visual rules. A shared renderer would be better and is a bigger change than this PR should carry.
- **`/demos` and `/presets` both still exist** and now overlap with `/templates`. Presets are honest about being a style and palette only, but three browse surfaces is one or two too many. Worth collapsing.
- **`/demos/[slug]` still has the hardcoded 4600px scroll track** and still returns 200 for an unknown slug. I did not touch it, so #13 stays open against that route.
- **Templates are verified by machine, not by eye.** The tests enforce copy quality, pacing and contrast pairing, and I loaded two previews in a real browser. The other fourteen have not been looked at by a human.
- **No template uses a section image yet**, even though the schema and both renderers support it. They are all type-and-colour, which suits generated backgrounds but means the image path is untested by real content.