### PR TITLE
feat: diagnostic watchdog that files issues under strict rules

### DIFF
--- a/.github/watchdog/allow.json
+++ b/.github/watchdog/allow.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Check keys the watchdog must never open or manage issues for — failures the maintainer has accepted. Remove a key to let the watchdog report it again.",
+  "allow": []
+}

--- a/.github/watchdog/checks.mjs
+++ b/.github/watchdog/checks.mjs
@@ -1,0 +1,162 @@
+// The checks the watchdog runs. Each has a stable `key` (the dedup identity — never reuse or
+// rename a key without meaning to reopen a fresh issue), a human `title`, a `severity` that
+// maps to a priority label, and an `area` for a subsystem label.
+//
+// Production checks probe the live site over HTTP and are cheap enough to run often. Code
+// checks spawn the toolchain and are heavier, so the workflow runs them on a slower cadence.
+
+import { spawnSync } from "node:child_process";
+
+const BASE = process.env.WATCHDOG_BASE_URL || "https://scrollcraft-gilt.vercel.app";
+
+async function get(path, { expectStatus, timeoutMs = 15000 } = {}) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${BASE}${path}`, { redirect: "manual", signal: ctrl.signal });
+    const body = await res.text();
+    return { status: res.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function fail(evidence) { return { ok: false, evidence }; }
+function pass(evidence = "") { return { ok: true, evidence }; }
+
+export const PRODUCTION_CHECKS = [
+  {
+    key: "prod-health",
+    title: "Production health check is not OK",
+    severity: "critical",
+    area: "infrastructure",
+    async run() {
+      const r = await get("/api/health");
+      if (r.status !== 200) return fail(`GET /api/health returned ${r.status}`);
+      let json;
+      try { json = JSON.parse(r.body); } catch { return fail(`/api/health did not return JSON: ${r.body.slice(0, 200)}`); }
+      const bad = [];
+      if (json.status !== "ok") bad.push(`status="${json.status}"`);
+      if (json.checks?.database && json.checks.database !== "up") bad.push(`database="${json.checks.database}"`);
+      if (json.checks?.config && json.checks.config !== "ok") bad.push(`config="${json.checks.config}"`);
+      return bad.length ? fail(`/api/health reports ${bad.join(", ")}`) : pass();
+    },
+  },
+  {
+    key: "prod-home",
+    title: "Home page is not serving",
+    severity: "critical",
+    area: "infrastructure",
+    async run() {
+      const r = await get("/");
+      return r.status === 200 ? pass() : fail(`GET / returned ${r.status}`);
+    },
+  },
+  {
+    key: "prod-templates-gallery",
+    title: "Template gallery is not serving",
+    severity: "high",
+    area: "frontend",
+    async run() {
+      const r = await get("/templates");
+      return r.status === 200 ? pass() : fail(`GET /templates returned ${r.status}`);
+    },
+  },
+  {
+    key: "prod-template-preview",
+    title: "A template preview page is not serving",
+    severity: "high",
+    area: "frontend",
+    async run() {
+      const r = await get("/templates/meridian-watch");
+      return r.status === 200 ? pass() : fail(`GET /templates/meridian-watch returned ${r.status}`);
+    },
+  },
+  {
+    key: "prod-published-route",
+    title: "The published-site route errors instead of 404ing an unknown slug",
+    severity: "high",
+    area: "backend",
+    async run() {
+      // A 500 here means the /s route or its database read is broken; 404 is correct.
+      const r = await get("/s/__watchdog_probe_nonexistent__");
+      if (r.status === 404) return pass();
+      return fail(`GET /s/<unknown> returned ${r.status} (expected 404; a 500 means the publishing route or DB is broken)`);
+    },
+  },
+  {
+    key: "prod-oauth-providers",
+    title: "GitHub sign-in provider is not configured in production",
+    severity: "critical",
+    area: "auth",
+    async run() {
+      const r = await get("/api/auth/providers");
+      if (r.status !== 200) return fail(`GET /api/auth/providers returned ${r.status}`);
+      return r.body.includes('"github"') ? pass() : fail("provider list no longer contains github — the OAuth env vars may be unset");
+    },
+  },
+  {
+    key: "prod-sitemap",
+    title: "Sitemap is missing or empty of templates",
+    severity: "medium",
+    area: "infrastructure",
+    async run() {
+      const r = await get("/sitemap.xml");
+      if (r.status !== 200) return fail(`GET /sitemap.xml returned ${r.status}`);
+      return r.body.includes("/templates/") ? pass() : fail("sitemap.xml contains no /templates/ URLs");
+    },
+  },
+];
+
+function runCmd(cmd, args) {
+  const r = spawnSync(cmd, args, { encoding: "utf8", timeout: 600000 });
+  const out = ((r.stdout || "") + (r.stderr || "")).trim();
+  return { code: r.status ?? 1, out };
+}
+
+function lastLines(s, n) {
+  return s.split("\n").filter(Boolean).slice(-n).join("\n");
+}
+
+export const CODE_CHECKS = [
+  {
+    key: "code-typecheck",
+    title: "TypeScript no longer compiles",
+    severity: "high",
+    area: "backend",
+    run() {
+      const r = runCmd("npx", ["tsc", "--noEmit"]);
+      return r.code === 0 ? pass() : fail("```\n" + lastLines(r.out, 15) + "\n```");
+    },
+  },
+  {
+    key: "code-lint",
+    title: "ESLint is failing",
+    severity: "medium",
+    area: "refactor",
+    run() {
+      const r = runCmd("npx", ["eslint"]);
+      return r.code === 0 ? pass() : fail("```\n" + lastLines(r.out, 20) + "\n```");
+    },
+  },
+  {
+    key: "code-tests",
+    title: "The test suite is failing",
+    severity: "high",
+    area: "testing",
+    run() {
+      const r = runCmd("npx", ["vitest", "run"]);
+      return r.code === 0 ? pass() : fail("```\n" + lastLines(r.out, 25) + "\n```");
+    },
+  },
+  {
+    key: "code-build",
+    title: "The production build is failing",
+    severity: "high",
+    area: "infrastructure",
+    run() {
+      const r = runCmd("npx", ["next", "build"]);
+      return r.code === 0 ? pass() : fail("```\n" + lastLines(r.out, 25) + "\n```");
+    },
+  },
+];

--- a/.github/watchdog/report.mjs
+++ b/.github/watchdog/report.mjs
@@ -1,0 +1,170 @@
+// The rules engine. It reconciles check results against the repo's open issues so the
+// watchdog is useful rather than noisy. The rules, in order:
+//
+//   1. Identity: every check has a stable key. An issue it owns carries a hidden marker
+//      `<!-- watchdog:KEY -->`. That marker, not the title, is how a prior issue is found.
+//   2. Open once: a failing check with no open marked issue opens exactly one. A failing
+//      check that already has an open marked issue never opens a second.
+//   3. Quiet updates: if the issue exists and the failure evidence changed, add one comment;
+//      if it is unchanged, do nothing at all (no comment, no reopen).
+//   4. Recover and close: a passing check whose marked issue is still open gets a "recovered"
+//      comment and is closed. A human who reopened it is respected — see rule 6.
+//   5. Allowlist: keys listed in allow.json are skipped entirely (never opened or closed),
+//      for failures the maintainer has accepted (e.g. transitive audit advisories).
+//   6. Human edits win: the watchdog only ever touches issues that still carry its marker and
+//      the `watchdog` label. Remove either and it leaves the issue alone forever.
+//   7. Safety cap: at most MAX_NEW new issues per run, so a broad outage cannot flood the
+//      tracker. The rest are logged and reported next run.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const MAX_NEW = 5;
+const DRY = process.env.WATCHDOG_DRY_RUN === "1" || process.argv.includes("--dry-run");
+const TOKEN = process.env.GITHUB_TOKEN;
+const REPO = process.env.GITHUB_REPOSITORY || "singhharsh1708/scrollcraft";
+
+const SEVERITY_LABEL = {
+  critical: "priority: critical",
+  high: "priority: high",
+  medium: "priority: medium",
+  low: "priority: low",
+};
+
+function marker(key) { return `<!-- watchdog:${key} -->`; }
+
+function loadAllowlist() {
+  try {
+    const raw = fs.readFileSync(path.join(HERE, "allow.json"), "utf8");
+    const parsed = JSON.parse(raw);
+    return new Set(Array.isArray(parsed.allow) ? parsed.allow : []);
+  } catch {
+    return new Set();
+  }
+}
+
+async function gh(method, apiPath, body) {
+  const res = await fetch(`https://api.github.com/repos/${REPO}${apiPath}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error(`${method} ${apiPath} → ${res.status} ${await res.text()}`);
+  return res.status === 204 ? null : res.json();
+}
+
+// All open watchdog issues, indexed by the key in their marker.
+async function openWatchdogIssues() {
+  const byKey = new Map();
+  for (let page = 1; page <= 10; page++) {
+    const issues = await gh("GET", `/issues?state=open&labels=watchdog&per_page=100&page=${page}`);
+    if (!issues.length) break;
+    for (const issue of issues) {
+      if (issue.pull_request) continue;
+      const m = /<!-- watchdog:([a-z0-9-]+) -->/.exec(issue.body || "");
+      if (m) byKey.set(m[1], issue);
+    }
+    if (issues.length < 100) break;
+  }
+  return byKey;
+}
+
+function issueBody(check, evidence) {
+  return [
+    marker(check.key),
+    "",
+    `**Automated watchdog report** — the \`${check.key}\` check is failing.`,
+    "",
+    "## What broke",
+    check.title + ".",
+    "",
+    "## Evidence",
+    evidence || "_(no detail captured)_",
+    "",
+    "## What this is",
+    "Opened automatically by the watchdog workflow (`.github/workflows/watchdog.yml`). It will",
+    "close this issue on its own once the check passes again. Remove the `watchdog` label to",
+    "have it stop managing this issue.",
+  ].join("\n");
+}
+
+async function reconcile(results) {
+  const allow = loadAllowlist();
+  const open = await openWatchdogIssues();
+  const actions = [];
+  let opened = 0;
+
+  for (const r of results) {
+    if (allow.has(r.key)) { actions.push({ key: r.key, action: "skipped-allowlist" }); continue; }
+    const existing = open.get(r.key);
+
+    if (!r.ok) {
+      const body = issueBody(r, r.evidence);
+      if (existing) {
+        // Rule 3: comment only when the evidence changed.
+        const prior = existing.body || "";
+        const changed = prior.trim() !== body.trim();
+        if (changed) {
+          if (!DRY) await gh("POST", `/issues/${existing.number}/comments`, {
+            body: `Still failing, with new detail:\n\n${r.evidence || "_(no detail)_"}`,
+          });
+          if (!DRY) await gh("PATCH", `/issues/${existing.number}`, { body });
+          actions.push({ key: r.key, action: "updated", issue: existing.number });
+        } else {
+          actions.push({ key: r.key, action: "unchanged", issue: existing.number });
+        }
+      } else {
+        if (opened >= MAX_NEW) { actions.push({ key: r.key, action: "capped" }); continue; }
+        opened++;
+        const labels = ["watchdog", SEVERITY_LABEL[r.severity] || "priority: medium"];
+        if (r.area) labels.push(r.area);
+        if (!DRY) {
+          const created = await gh("POST", "/issues", {
+            title: `watchdog: ${r.title}`,
+            body: issueBody(r, r.evidence),
+            labels,
+          });
+          actions.push({ key: r.key, action: "opened", issue: created.number });
+        } else {
+          actions.push({ key: r.key, action: "would-open", labels });
+        }
+      }
+    } else if (existing) {
+      // Rule 4: recovered → close.
+      if (!DRY) {
+        await gh("POST", `/issues/${existing.number}/comments`, {
+          body: "Recovered — the watchdog check passes again. Closing.",
+        });
+        await gh("PATCH", `/issues/${existing.number}`, { state: "closed", state_reason: "completed" });
+      }
+      actions.push({ key: r.key, action: "closed", issue: existing.number });
+    }
+  }
+  return actions;
+}
+
+async function main() {
+  const input = fs.readFileSync(process.env.WATCHDOG_RESULTS || "/dev/stdin", "utf8");
+  const results = JSON.parse(input);
+  if (!TOKEN && !DRY) {
+    console.error("No GITHUB_TOKEN and not a dry run — refusing to proceed.");
+    process.exit(1);
+  }
+  const actions = await reconcile(results);
+  const failing = results.filter((r) => !r.ok).map((r) => r.key);
+  console.log(JSON.stringify({ dryRun: DRY, failing, actions }, null, 2));
+  // A run where something is broken still exits 0: opening the issue is success, not failure.
+}
+
+// Only run when executed directly, so the reconcile helpers can be imported for testing.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((e) => { console.error(e); process.exit(1); });
+}
+
+export { reconcile, openWatchdogIssues, marker };

--- a/.github/watchdog/run.mjs
+++ b/.github/watchdog/run.mjs
@@ -1,0 +1,19 @@
+// Runs the requested check set and prints a results array to stdout.
+// Usage: node run.mjs <production|code|all>
+import { PRODUCTION_CHECKS, CODE_CHECKS } from "./checks.mjs";
+
+const mode = process.argv[2] || "all";
+const sets = { production: PRODUCTION_CHECKS, code: CODE_CHECKS, all: [...PRODUCTION_CHECKS, ...CODE_CHECKS] };
+const checks = sets[mode];
+if (!checks) { console.error(`unknown mode "${mode}"`); process.exit(2); }
+
+const results = [];
+for (const c of checks) {
+  try {
+    const r = await c.run();
+    results.push({ key: c.key, title: c.title, severity: c.severity, area: c.area, ok: r.ok, evidence: r.evidence || "" });
+  } catch (e) {
+    results.push({ key: c.key, title: c.title, severity: c.severity, area: c.area, ok: false, evidence: `check threw: ${e.message}` });
+  }
+}
+process.stdout.write(JSON.stringify(results));

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -1,0 +1,73 @@
+name: Watchdog
+
+# Diagnostic watchdog. Probes production and (on the slower cadence) the codebase, then opens,
+# updates, or closes GitHub issues under the rules in .github/watchdog/report.mjs. It never
+# opens a duplicate, closes its own issues on recovery, and stops managing any issue whose
+# `watchdog` label a human removes. See docs/WATCHDOG.md.
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"   # production probe, every 6 hours
+    - cron: "17 7 * * *"     # full sweep (code + production), daily
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "prisma/**"
+      - "package.json"
+      - ".github/watchdog/**"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Which checks to run"
+        type: choice
+        options: [production, code, all]
+        default: all
+
+concurrency:
+  group: watchdog
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  watchdog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "mode=${{ github.event.inputs.mode }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event.schedule }}" = "17 */6 * * *" ]; then
+            echo "mode=production" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=all" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        if: steps.mode.outputs.mode != 'production'
+        run: npm ci
+
+      - name: Run checks
+        env:
+          WATCHDOG_BASE_URL: ${{ vars.WATCHDOG_BASE_URL || 'https://scrollcraft-gilt.vercel.app' }}
+          # A placeholder so `next build` in the code checks does not fail env validation;
+          # the build never connects, and production checks probe the real deployment.
+          DATABASE_URL: "postgresql://placeholder:placeholder@localhost:5432/placeholder"
+          AUTH_SECRET: "placeholder-build-only-secret"
+        run: node .github/watchdog/run.mjs "${{ steps.mode.outputs.mode }}" > results.json
+
+      - name: Reconcile issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WATCHDOG_RESULTS: results.json
+        run: node .github/watchdog/report.mjs

--- a/docs/WATCHDOG.md
+++ b/docs/WATCHDOG.md
@@ -1,0 +1,60 @@
+# Watchdog
+
+An automated diagnostic that watches the live site and the codebase and files GitHub issues
+when something breaks — under strict rules so it stays useful instead of noisy.
+
+## What it checks
+
+**Production** (every 6 hours, over HTTP against the live deployment):
+
+| Check | Fails when |
+| --- | --- |
+| `prod-health` | `/api/health` is not `status: ok` (database down, config invalid). |
+| `prod-home` | `/` does not return 200. |
+| `prod-templates-gallery` | `/templates` does not return 200. |
+| `prod-template-preview` | a template page does not return 200. |
+| `prod-published-route` | `/s/<unknown>` returns anything but 404 (a 500 means the publishing route or DB is broken). |
+| `prod-oauth-providers` | `/api/auth/providers` no longer lists GitHub (OAuth env unset). |
+| `prod-sitemap` | `/sitemap.xml` is missing or has no template URLs. |
+
+**Code** (daily, and on every push to `main` that touches `src/`, `prisma/`, or the watchdog):
+
+| Check | Fails when |
+| --- | --- |
+| `code-typecheck` | `tsc --noEmit` errors. |
+| `code-lint` | `eslint` errors. |
+| `code-tests` | `vitest run` fails. |
+| `code-build` | `next build` fails. |
+
+## The rules
+
+1. **One key, one issue.** Each check has a stable key. An issue it owns carries a hidden
+   marker `<!-- watchdog:KEY -->`; that marker, not the title, is its identity.
+2. **Never duplicates.** A failing check with an open marked issue never opens a second one.
+3. **Quiet updates.** If the failure detail changed, it adds one comment; if nothing changed,
+   it does nothing at all.
+4. **Recovers and closes.** When a failing check passes again, its issue is commented and
+   closed automatically.
+5. **Allowlist.** Keys in `.github/watchdog/allow.json` are ignored — for failures you have
+   accepted (e.g. a transitive advisory awaiting an upstream bump).
+6. **Human edits win.** It only touches issues that still carry its marker and the `watchdog`
+   label. Remove either and it never touches that issue again.
+7. **Safety cap.** At most five new issues per run, so a broad outage cannot flood the tracker.
+
+## Running it by hand
+
+Actions tab → **Watchdog** → Run workflow → pick `production`, `code`, or `all`.
+
+Locally, without touching the tracker:
+
+```bash
+node .github/watchdog/run.mjs production | WATCHDOG_DRY_RUN=1 node .github/watchdog/report.mjs
+```
+
+`WATCHDOG_DRY_RUN=1` prints what it *would* do and writes nothing.
+
+## Requirements
+
+Runs on the workflow's built-in `GITHUB_TOKEN` (needs `issues: write`, already granted in the
+workflow). No extra secret. Set the repo variable `WATCHDOG_BASE_URL` if the production URL is
+not `https://scrollcraft-gilt.vercel.app`.


### PR DESCRIPTION
# Description

A bot that watches the live site and the codebase and files GitHub issues when something breaks — with strict dedup rules so it stays useful instead of noisy. It would have caught the production `database: down` outage that just broke sign-in, and its code sweep gives the repo the CI run audit #203 asked for.

## What it checks

**Production** — every 6 hours, over HTTP against the live deployment: `/api/health` is OK, the home page, the template gallery, a template preview, the published-site route (`/s/<unknown>` must 404, not 500), the GitHub OAuth provider is still configured, and the sitemap has template URLs.

**Code** — daily and on every push to `main` touching `src/`, `prisma/`, or the watchdog: `tsc --noEmit`, `eslint`, `vitest run`, `next build`.

## The rules (`.github/watchdog/report.mjs`)

1. **One key, one issue** — each check has a stable key, identified by a hidden `<!-- watchdog:KEY -->` marker, not the title.
2. **Never duplicates** — a failing check with an open marked issue never opens a second.
3. **Quiet updates** — comments only when the failure detail changed; silent otherwise.
4. **Recovers and closes** — when a check passes again, its issue is commented and closed.
5. **Allowlist** — keys in `allow.json` are ignored, for accepted failures.
6. **Human edits win** — it only touches issues that still carry its marker *and* the `watchdog` label; remove either and it never touches that issue again.
7. **Safety cap** — at most five new issues per run, so a broad outage can't flood the tracker.

## Verification

Every branch of the reconciler was exercised against **real GitHub and real production**, in dry-run (writes nothing):

- All 11 checks run against the live site + local toolchain → **all pass**, zero false positives (it would open nothing right now).
- Injected failures → `would-open` with the correct `watchdog` + `priority:` + area labels.
- With a real marked issue open: a failing check resolves to `updated`/`unchanged` (not a duplicate), and a passing check resolves to `closed`. The one apparent miss during testing was GitHub's list-indexing lag from creating and reading an issue within milliseconds — with a few seconds' delay (and in the real workflow, runs hours apart) it reconciles correctly.
- `report.mjs` guards `main()` so its helpers import cleanly.

Runs on the workflow's built-in `GITHUB_TOKEN` (`issues: write`), no extra secret. Set repo variable `WATCHDOG_BASE_URL` if the production URL differs. Docs and the local dry-run command are in `docs/WATCHDOG.md`.

The app test suite is unchanged (280 passing) — these scripts live in `.github/`, outside `src/`.

## Type of change

- [x] ✨ New feature
- [x] 🔧 Chore / tooling

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes
- [x] Verified the reconciler against real GitHub + production in dry-run

## Risks and trade-offs

- **The code sweep runs `next build`** on the daily cron and on qualifying pushes — a few minutes of Actions time. It doubles as the missing CI, so that cost buys the #203 coverage too.
- **Production checks are unauthenticated**, so they cannot verify the *logged-in* experience (dashboard, actually saving/publishing). They catch outages and route/DB regressions, which is the high-value set; a deeper authenticated canary could follow.
- **`next build` in CI runs with a placeholder `DATABASE_URL`/`AUTH_SECRET`** so env validation does not fail the build; the build never connects, and the production probes hit the real deployment.
- **Issue titles/labels are created by the bot.** It reuses existing labels (`priority: *`, area labels) and the `watchdog` label; the GitHub API auto-creates any missing label.