### PR TITLE
fix(seo): single brand suffix, per-page og:url, env-derived origin (#251 #252 #289)

### DIFF
--- a/.github/watchdog/checks.mjs
+++ b/.github/watchdog/checks.mjs
@@ -9,7 +9,7 @@ import { spawnSync } from "node:child_process";
 
 const BASE = process.env.WATCHDOG_BASE_URL || "https://scrollcraft-gilt.vercel.app";
 
-async function get(path, { expectStatus, timeoutMs = 15000 } = {}) {
+async function get(path, { timeoutMs = 15000 } = {}) {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
   try {

--- a/src/app/cookies/page.tsx
+++ b/src/app/cookies/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import Navbar from "@/components/Navbar";
 
-export const metadata = { title: "Cookie Policy — ScrollCraft" };
+export const metadata = { title: "Cookie Policy" };
 
 export default function CookiesPage() {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,26 +5,25 @@ import { Toaster } from "@/components/ui/sonner";
 import SessionProvider from "@/components/SessionProvider";
 import SmoothScroll from "@/components/SmoothScroll";
 import { Analytics } from "@vercel/analytics/next";
+import { siteUrl } from "@/lib/env";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
-const BASE_URL = "https://scrollcraft.app";
 
 export const metadata: Metadata = {
-  metadataBase: new URL(BASE_URL),
+  metadataBase: new URL(siteUrl),
   title: {
-    default: "ScrollCraft — AI Scroll Sites",
+    default: "ScrollCraft — Cinematic Scroll Sites",
     template: "%s | ScrollCraft",
   },
   description: "Build immersive 2D scroll websites with animated canvas backgrounds. Pick a style, customise sections, export as pure HTML. No code needed.",
-  keywords: ["scroll website builder", "animated canvas", "scrollytelling", "no-code", "AI website", "scroll animation"],
+  keywords: ["scroll website builder", "animated canvas", "scrollytelling", "no-code", "scroll animation"],
   authors: [{ name: "ScrollCraft" }],
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: BASE_URL,
     siteName: "ScrollCraft",
-    title: "ScrollCraft — AI Scroll Sites",
+    title: "ScrollCraft — Cinematic Scroll Sites",
     description: "Build immersive 2D scroll websites with animated canvas backgrounds. No code needed.",
     // No images key: src/app/opengraph-image.tsx generates the real 1200x630 card and
     // Next wires it up automatically. The hardcoded /og-image.png overrode that with a
@@ -32,7 +31,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "ScrollCraft — AI Scroll Sites",
+    title: "ScrollCraft — Cinematic Scroll Sites",
     description: "Build immersive 2D scroll websites with animated canvas backgrounds. No code needed.",
   },
   robots: { index: true, follow: true },

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import Navbar from "@/components/Navbar";
 
-export const metadata = { title: "Privacy Policy — ScrollCraft" };
+export const metadata = { title: "Privacy Policy" };
 
 export default function PrivacyPage() {
   return (

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,6 +1,6 @@
 import Navbar from "@/components/Navbar";
 
-export const metadata = { title: "Terms of Service — ScrollCraft" };
+export const metadata = { title: "Terms of Service" };
 
 export default function TermsPage() {
   return (


### PR DESCRIPTION
Three SEO/metadata fixes, verified against a running build.

- **#251** legal pages rendered `Privacy Policy — ScrollCraft | ScrollCraft` (double brand). Now `Privacy Policy | ScrollCraft` — the pages set just the page name and the root template supplies the brand once. Verified live.
- **#252** the root `openGraph.url` was hardcoded to the homepage, so every page reported `og:url` of `/`. Dropped it; `/templates` no longer emits a homepage og:url.
- **#289** the public origin was a hardcoded literal; now reads the env-derived `siteUrl` (same as robots/sitemap), so a non-default `AUTH_URL` deploy emits the correct `metadataBase`.

Also dropped the stale "AI" from the default title (pivot). `tsc`/`eslint`/tests green, build verified.

- [x] tests pass · build verified · rendered titles checked live