### PR TITLE
test: stop the flaky ffmpeg/Chrome test timeouts

### DIFF
--- a/src/__tests__/skillScaffold.test.ts
+++ b/src/__tests__/skillScaffold.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// These suites spawn ffmpeg, next build, and headless Chrome; the 5s default is exceeded
+// under parallel load, causing flaky timeouts. Give them room.
+vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 });
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";

--- a/src/__tests__/skillVerify.test.ts
+++ b/src/__tests__/skillVerify.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// These suites spawn ffmpeg, next build, and headless Chrome; the 5s default is exceeded
+// under parallel load, causing flaky timeouts. Give them room.
+vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 });
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";


### PR DESCRIPTION
The `skillVerify` and `skillScaffold` suites spawn ffmpeg, `next build`, and headless Chrome. Vitest's 5s default timeout is exceeded under parallel load, so 2–3 of 22 tests timed out intermittently — which would also make the new watchdog's `code-tests` check flap on and off.

A 60s per-test timeout on those two files (via `vi.setConfig`) fixes it. **Three consecutive full runs clean** (280/280 each). Pure test-infra change, no source touched.