### PR TITLE
fix(mobile): touch actions, horizontal scroll, editor clipping (#234 #233 #279 #280)

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -20,7 +20,7 @@ const VALUES = [
 
 export default function AboutPage() {
   return (
-    <main className="min-h-screen bg-background text-foreground">
+    <main className="relative min-h-screen bg-background text-foreground overflow-x-hidden">
       <Navbar />
 
       {/* Hero */}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -94,7 +94,7 @@ function SignInForm() {
   };
 
   return (
-    <main className="min-h-screen bg-background text-foreground flex items-center justify-center px-6">
+    <main className="relative min-h-screen bg-background text-foreground overflow-x-hidden flex items-center justify-center px-6">
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] rounded-full bg-primary/8 blur-[120px] pointer-events-none" />
 
       <div className="relative w-full max-w-sm space-y-8">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -247,7 +247,7 @@ export default function DashboardPage() {
                     <p className="text-xs text-muted-foreground">{site.frameCount} frames · {site.fps} fps · {new Date(site.updatedAt).toLocaleDateString("en-IN")}</p>
                   </div>
 
-                  <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="flex items-center gap-2 opacity-100 [@media(hover:hover)]:opacity-0 group-hover:[@media(hover:hover)]:opacity-100 group-focus-within:opacity-100 transition-opacity">
                     {site.published && site.publishSlug && (
                       <a href={`/s/${site.publishSlug}`} target="_blank" rel="noreferrer">
                         <Button size="sm" variant="outline" className="border-white/10 h-7 px-2 text-xs gap-1">

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -644,7 +644,7 @@ function EditorInner() {
   return (
     <div className="h-screen flex flex-col bg-background text-foreground overflow-hidden">
       {/* Top bar */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-white/5 bg-card/50 flex-shrink-0">
+      <div className="flex items-center justify-between gap-2 flex-wrap px-4 py-2 border-b border-white/5 bg-card/50 flex-shrink-0">
         <div className="flex items-center gap-3">
           <Link href="/create" className="flex items-center gap-1 text-muted-foreground hover:text-foreground text-sm transition-colors">
             <ArrowLeft className="w-3.5 h-3.5" /> Back
@@ -735,7 +735,7 @@ function EditorInner() {
         </div>
       </div>
 
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex flex-1 overflow-x-auto md:overflow-hidden">
         {/* Left panel: sections list */}
         <div className="w-56 border-r border-white/5 flex flex-col bg-card/30 flex-shrink-0">
           <div className="p-3 border-b border-white/5 flex items-center justify-between">

--- a/src/app/presets/page.tsx
+++ b/src/app/presets/page.tsx
@@ -123,7 +123,7 @@ export default function PresetsPage() {
                     <p className="text-xs text-white/60">{preset.category}</p>
                   </div>
                   {/* Hover overlay — z-20 keeps it above the tags row (z-10) */}
-                  <div className="absolute inset-0 z-20 flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity bg-black/60 backdrop-blur-sm">
+                  <div className="absolute inset-0 z-20 flex items-center justify-center gap-2 opacity-100 [@media(hover:hover)]:opacity-0 group-hover:[@media(hover:hover)]:opacity-100 group-focus-within:opacity-100 transition-opacity bg-black/60 backdrop-blur-sm">
                     <Link href={`/create?template=${encodeURIComponent(preset.name)}`}>
                       <Button size="sm" className="bg-primary text-white shadow-lg shadow-primary/30 text-xs h-8 px-3">
                         Use preset <ArrowRight className="ml-1 w-3 h-3" />

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -286,7 +286,7 @@ export default function PricingPage() {
   };
 
   return (
-    <main className="min-h-screen bg-background text-foreground">
+    <main className="relative min-h-screen bg-background text-foreground overflow-x-hidden">
       {/* Nav */}
       <Navbar />
 


### PR DESCRIPTION
Four responsive fixes, verified in a 375px headless-Chrome viewport.

- **#234 / #233** dashboard and preset-gallery actions were `opacity-0` until `group-hover` — invisible on touch. Now visible by default, fading to reveal only on hover-capable pointers, with `group-focus-within` for keyboard.
- **#279** a centred 500px blur let /pricing, /about, /auth/signin scroll sideways on narrow screens. Their `<main>` is now `relative overflow-x-hidden`; **verified a 375px viewport cannot scroll horizontally** (`scrollTo(9999,0)` → `scrollX 0`).
- **#280** editor top bar wraps instead of clipping Save/Export off-screen; the panel row scrolls on phones instead of hiding the properties panel. A full mobile editor is a follow-up — this stops content being unreachable.

`tsc`/`eslint`/280 tests green.

- [x] verified at 375px · tests pass