### PR TITLE
fix: scroll-hint click-through, SmoothScroll leak, seamless preview loop (#273 #288 #276)

### DIFF
--- a/src/__tests__/exportSectionParity.test.ts
+++ b/src/__tests__/exportSectionParity.test.ts
@@ -161,3 +161,12 @@ describe("exported sections honour the scrim", () => {
     expect(html).toContain("rgba(0,0,0,1) 0%");
   });
 });
+
+describe("exported scroll hint", () => {
+  it("does not capture clicks over the copy beneath it", async () => {
+    const html = await exportHtml([{ heading: "A", ctaLabel: "Buy", ctaHref: "https://x.com", scrollHeight: 1000 }]);
+    const hint = /#scroll-hint\s*\{([^}]*)\}/.exec(html);
+    expect(hint).toBeTruthy();
+    expect(hint[1]).toContain("pointer-events: none");
+  });
+});

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -263,6 +263,7 @@ export async function POST(req: NextRequest) {
     }
     #scroll-hint {
       position: fixed; bottom: 2rem; left: 50%; transform: translateX(-50%);
+      pointer-events: none;
       display: flex; flex-direction: column; align-items: center; gap: 0.5rem;
       color: rgba(255,255,255,0.4); font-size: 0.75rem; letter-spacing: 0.1em;
       text-transform: uppercase; z-index: 20; transition: opacity 0.5s;

--- a/src/components/SmoothScroll.tsx
+++ b/src/components/SmoothScroll.tsx
@@ -10,14 +10,15 @@ export default function SmoothScroll({ children }: { children: React.ReactNode }
       smoothWheel: true,
     });
 
+    let rafId = 0;
     function raf(time: number) {
       lenis.raf(time);
-      requestAnimationFrame(raf);
+      rafId = requestAnimationFrame(raf);
     }
-    const id = requestAnimationFrame(raf);
+    rafId = requestAnimationFrame(raf);
 
     return () => {
-      cancelAnimationFrame(id);
+      cancelAnimationFrame(rafId);
       lenis.destroy();
     };
   }, []);

--- a/src/components/StylePreview.tsx
+++ b/src/components/StylePreview.tsx
@@ -73,7 +73,10 @@ export default function StylePreview({
     const tick = (ts: number) => {
       if (!start) start = ts;
       const elapsed = (ts - start) / 1000;
-      const p = (elapsed % durationSec) / durationSec; // 0..1 loop
+      // Ping-pong 0->1->0 instead of a 0..1 sawtooth: the draw functions are not periodic
+      // in p, so a sawtooth snaps at the wrap. A triangle wave is continuous at both ends.
+      const phase = (elapsed / durationSec) % 2;
+      const p = phase <= 1 ? phase : 2 - phase;
       const { w, h } = sizeRef.current;
       drawFrame2D(ctx, w, h, p, optsRef.current);
       rafId = requestAnimationFrame(tick);


### PR DESCRIPTION
Three correctness fixes.

- **#273** the exported page's fixed `#scroll-hint` (z-index 20) captured clicks over a bottom-aligned CTA even when faded. It's decorative — now `pointer-events: none`, pinned by a test on the generated CSS.
- **#288** `SmoothScroll`'s rAF loop reschedules itself but stored only the *first* frame's id, so cleanup cancelled one frame and the loop leaked past unmount. Now tracks the latest id.
- **#276** `StylePreview` drove a 0..1 sawtooth phase, but the draw functions aren't periodic in `p`, so the loop snapped at the wrap. Now ping-pongs 0→1→0, continuous at both ends.

`tsc`/`eslint` clean, 281 tests (one added).

- [x] tests pass