### PR TITLE
fix(data): frameCount cap, guarded body parse, frames-param validation, dotenv (#270 #268 #293 #285)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitest/coverage-v8": "^4.1.8",
+        "dotenv": "^17.4.2",
         "eslint": "^9",
         "eslint-config-next": "^16.2.12",
         "tailwindcss": "^4",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitest/coverage-v8": "^4.1.8",
+    "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "^16.2.12",
     "tailwindcss": "^4",

--- a/src/__tests__/exportSectionParity.test.ts
+++ b/src/__tests__/exportSectionParity.test.ts
@@ -166,7 +166,7 @@ describe("exported scroll hint", () => {
   it("does not capture clicks over the copy beneath it", async () => {
     const html = await exportHtml([{ heading: "A", ctaLabel: "Buy", ctaHref: "https://x.com", scrollHeight: 1000 }]);
     const hint = /#scroll-hint\s*\{([^}]*)\}/.exec(html);
-    expect(hint).toBeTruthy();
-    expect(hint[1]).toContain("pointer-events: none");
+    expect(hint).not.toBeNull();
+    expect(hint![1]).toContain("pointer-events: none");
   });
 });

--- a/src/app/api/payments/ls-checkout/route.ts
+++ b/src/app/api/payments/ls-checkout/route.ts
@@ -26,7 +26,13 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Export purchases not configured" }, { status: 503 });
   }
 
-  const parsed = schema.safeParse(await req.json());
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const parsed = schema.safeParse(raw);
   if (!parsed.success) {
     return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }

--- a/src/app/api/sites/route.ts
+++ b/src/app/api/sites/route.ts
@@ -17,7 +17,7 @@ const siteSchema = z.object({
   id: z.string().optional(),
   name: z.string().max(255).optional(),
   fps: z.number().int().min(1).max(120).optional(),
-  frameCount: z.number().int().min(0).optional(),
+  frameCount: z.number().int().min(0).max(100_000).optional(),
   framesJson: z.string().max(10_000_000).optional(),
   sectionsJson: z.string().max(1_000_000).optional(),
   themeJson: z.string().max(5_000).optional(),

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -83,7 +83,10 @@ function EditorInner() {
   // Synchronous fast path: check legacy sessionStorage only (may be empty for new sessions)
   const parsedFrames: string[] | null = (() => {
     if (framesParam) {
-      try { return JSON.parse(framesParam) as string[]; } catch { return null; }
+      try {
+        const decoded = JSON.parse(framesParam);
+        return Array.isArray(decoded) && decoded.every((f) => typeof f === "string") ? decoded : null;
+      } catch { return null; }
     }
     return null;
   })();


### PR DESCRIPTION
The data/validation batch.

- **#270** `frameCount` had no upper bound → could overflow the Postgres `INTEGER` column (unhandled 500). Capped at 100,000.
- **#268** `/api/payments/ls-checkout` awaited `req.json()` outside any try, so a malformed body threw a bare 500. Now returns 400.
- **#293** the legacy `?frames=` param was `JSON.parse`d and cast to `string[]` unchecked; a valid non-array passed through as the wrong type. Now accepted only as an array of strings.
- **#285** `prisma.config.ts` imports `dotenv` which was only transitive; declared as a devDependency.

Also fixes a null-safety error in last PR's scroll-hint test — `next build` doesn't type-check test files but `tsc --noEmit` does, and I'd been masking tsc's exit with a pipe. (The watchdog's `code-typecheck` check reads the real exit, so it would have caught it too.)

`tsc`/`eslint` clean, 281 tests.

- [x] tsc (real exit) / eslint / tests pass