### PR TITLE
fix(a11y): contrast, keyboard reveal, switch, reduced motion (#264 #208 #207 #210 #209)

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -760,7 +760,7 @@ function EditorInner() {
               >
                 <div className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${s.visible ? "bg-primary" : "bg-white/20"}`} />
                 <span className="text-xs flex-1 truncate">{s.heading || `Section ${i + 1}`}</span>
-                <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
                   <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "up"); }} className="p-0.5 hover:text-primary" title="Move up">
                     <ChevronUp className="w-3 h-3" />
                   </button>
@@ -988,6 +988,9 @@ function EditorInner() {
                 <div className="flex items-center justify-between">
                   <label className="text-xs text-muted-foreground">Visible</label>
                   <button
+                    role="switch"
+                    aria-checked={selectedSectionData.visible}
+                    aria-label="Toggle section visibility"
                     onClick={() => updateSection(selectedSectionData.id, { visible: !selectedSectionData.visible })}
                     className={`w-8 h-4 rounded-full transition-colors ${selectedSectionData.visible ? "bg-primary" : "bg-white/20"}`}
                   >

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,12 +55,12 @@
   --card-foreground: oklch(0.98 0 0);
   --popover: oklch(0.1 0 0);
   --popover-foreground: oklch(0.98 0 0);
-  --primary: oklch(0.65 0.22 290);
+  --primary: oklch(0.52 0.22 290);
   --primary-foreground: oklch(0.98 0 0);
   --secondary: oklch(0.14 0 0);
   --secondary-foreground: oklch(0.98 0 0);
   --muted: oklch(0.14 0 0);
-  --muted-foreground: oklch(0.55 0 0);
+  --muted-foreground: oklch(0.6 0 0);
   --accent: oklch(0.65 0.22 290);
   --accent-foreground: oklch(0.98 0 0);
   --destructive: oklch(0.577 0.245 27.325);
@@ -91,12 +91,12 @@
   --card-foreground: oklch(0.98 0 0);
   --popover: oklch(0.1 0 0);
   --popover-foreground: oklch(0.98 0 0);
-  --primary: oklch(0.65 0.22 290);
+  --primary: oklch(0.52 0.22 290);
   --primary-foreground: oklch(0.98 0 0);
   --secondary: oklch(0.14 0 0);
   --secondary-foreground: oklch(0.98 0 0);
   --muted: oklch(0.14 0 0);
-  --muted-foreground: oklch(0.55 0 0);
+  --muted-foreground: oklch(0.6 0 0);
   --accent: oklch(0.65 0.22 290);
   --accent-foreground: oklch(0.98 0 0);
   --destructive: oklch(0.704 0.191 22.216);
@@ -122,5 +122,14 @@
   }
   html {
     @apply font-sans;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/src/components/ScrollSection.tsx
+++ b/src/components/ScrollSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useRef } from "react";
-import { motion, useInView } from "framer-motion";
+import { motion, useInView, useReducedMotion } from "framer-motion";
 
 interface ScrollSectionProps {
   children: React.ReactNode;
@@ -13,6 +13,7 @@ interface ScrollSectionProps {
 export default function ScrollSection({ children, className, style, onClick, delay = 0 }: ScrollSectionProps) {
   const ref = useRef<HTMLDivElement>(null);
   const inView = useInView(ref, { once: false, margin: "-15% 0px -15% 0px" });
+  const reduce = useReducedMotion();
 
   return (
     <motion.div
@@ -20,9 +21,9 @@ export default function ScrollSection({ children, className, style, onClick, del
       className={className}
       style={style}
       onClick={onClick}
-      initial={{ opacity: 0, y: 32 }}
-      animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 32 }}
-      transition={{ duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94], delay }}
+      initial={reduce ? false : { opacity: 0, y: 32 }}
+      animate={reduce ? { opacity: 1, y: 0 } : inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 32 }}
+      transition={reduce ? { duration: 0 } : { duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94], delay }}
     >
       {children}
     </motion.div>

--- a/src/components/SmoothScroll.tsx
+++ b/src/components/SmoothScroll.tsx
@@ -4,6 +4,7 @@ import Lenis from "@studio-freight/lenis";
 
 export default function SmoothScroll({ children }: { children: React.ReactNode }) {
   useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
     const lenis = new Lenis({
       duration: 1.2,
       easing: (t) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),


### PR DESCRIPTION
Accessibility batch, contrast verified by computation.

- **#264** `--muted-foreground` → oklch(0.6): now **5.04–5.30:1** on all three surfaces (was 4.10–4.31, below AA).
- **#208** `--primary` → oklch(0.52 0.22 290): white CTA text now **5.77:1** (was 3.38).
- **#207** editor row actions reveal on `focus-within` too — keyboard focus no longer lands on invisible controls.
- **#210** the Visible toggle gets `role=switch`, `aria-checked`, `aria-label`.
- **#209** SmoothScroll skips Lenis and ScrollSection drops its entrance under `prefers-reduced-motion`, plus a global CSS backstop — the app now honours what the exported sites already did.

tsc/eslint/281 tests green.

- [x] contrast recomputed, tests pass