### PR TITLE
fix(export): no-JS fallback, social meta, off-path decode (#227 #229 #228)

### DIFF
--- a/src/__tests__/exportSectionParity.test.ts
+++ b/src/__tests__/exportSectionParity.test.ts
@@ -170,3 +170,24 @@ describe("exported scroll hint", () => {
     expect(hint![1]).toContain("pointer-events: none");
   });
 });
+
+describe("exported head and resilience", () => {
+  it("emits a meta description and social tags", async () => {
+    const html = await exportHtml([{ heading: "A", scrollHeight: 1000 }]);
+    expect(html).toContain('<meta name="description"');
+    expect(html).toContain('property="og:title"');
+    expect(html).toContain('name="twitter:card"');
+  });
+
+  it("carries a noscript fallback so a no-JS visitor sees content", async () => {
+    const html = await exportHtml([{ heading: "A", scrollHeight: 1000 }]);
+    expect(html).toContain("<noscript>");
+    expect(html).toMatch(/<noscript>[\s\S]*data-reveal\][\s\S]*opacity: 1 !important/);
+  });
+
+  it("decodes frames off the scroll path", async () => {
+    const html = await exportHtml([{ heading: "A", scrollHeight: 1000 }]);
+    expect(html).toContain("img.decode");
+    expect(html).toContain("decoding = 'async'");
+  });
+});

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -231,6 +231,11 @@ export async function POST(req: NextRequest) {
   ${themeFontLinks}
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>${esc(siteName || "My ScrollCraft Site")}</title>
+  <meta name="description" content="${esc(siteName || "A cinematic scroll website")}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="${esc(siteName || "My ScrollCraft Site")}" />
+  <meta property="og:description" content="${esc(siteName || "A cinematic scroll website")}" />
+  <meta name="twitter:card" content="summary_large_image" />
   <style>
     ${themeVarsCss}
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -279,6 +284,13 @@ export async function POST(req: NextRequest) {
     #audio-mute:hover { background: rgba(255,255,255,0.1); }
   </style>
   ${safeCustomCss ? `<style>\n${safeCustomCss}\n  </style>` : ""}
+  <noscript><style>
+    .section-content[data-reveal] { opacity: 1 !important; transform: none !important; clip-path: none !important; }
+    .section-content[data-reveal="stagger"] > * { opacity: 1 !important; transform: none !important; }
+    .section-sticky { position: static !important; height: auto !important; }
+    #scroll-container { height: auto !important; }
+    #scroll-hint, #scroll-canvas { display: none !important; }
+  </style></noscript>
   ${safeCustomHead || ""}
   <script src="lenis.min.js"></script>
 </head>
@@ -346,10 +358,15 @@ export async function POST(req: NextRequest) {
 
         function loadFrame(idx) {
           var img = new Image();
+          img.decoding = 'async';
           img.src = folder + '/frame_' + String(idx).padStart(4, '0') + '.jpg';
           img.onload = function() {
-            target[idx] = img;
-            if ((idx === 0 && isPrimary) || idx === currentFrame) drawFrame(idx);
+            var put = function() {
+              target[idx] = img;
+              if ((idx === 0 && isPrimary) || idx === currentFrame) drawFrame(idx);
+            };
+            // Decode off the scroll path so drawImage never pays a synchronous decode.
+            if (img.decode) { img.decode().then(put).catch(put); } else { put(); }
           };
           // onerror intentionally left empty — slot stays undefined, drawFrame skips it
         }
@@ -365,10 +382,14 @@ export async function POST(req: NextRequest) {
               }
             }
           }
+          img.decoding = 'async';
           img.onload = function() {
-            target[i] = img;
-            if (i === 0 && isPrimary) drawFrame(0);
-            if (i === currentFrame) drawFrame(i);
+            var put = function() {
+              target[i] = img;
+              if (i === 0 && isPrimary) drawFrame(0);
+              if (i === currentFrame) drawFrame(i);
+            };
+            if (img.decode) { img.decode().then(put).catch(put); } else { put(); }
             advance();
           };
           img.onerror = advance; // count failure so we don't hang


### PR DESCRIPTION
Three fixes to the exported bundle, pinned by tests on the generated HTML.

- **#227** sections start `opacity:0` and the inline script reveals them, so a no-JS visitor (CSP, JS off, script error) got a **blank black page**. A `<noscript>` block now neutralises the reveal + sticky scaffolding so content is readable without JS.
- **#229** the head had only a `<title>`; now emits a meta description and og:/twitter tags.
- **#228** frames are decoded via `img.decode()` before storing, so `drawImage` on the scroll path no longer pays a synchronous decode.

284 tests (3 added), tsc/eslint clean.

- [x] tests assert the generated HTML