### PR TITLE
fix(payments): env redirect, pre-tax price pin, reject invalid promo (#232 #231 #216)

### DIFF
--- a/src/__tests__/promoConsumption.test.ts
+++ b/src/__tests__/promoConsumption.test.ts
@@ -139,18 +139,14 @@ describe("create-order — a promo use is held, not consumed", () => {
     });
   });
 
-  it("counts in-flight orders as held uses so concurrent checkouts cannot all discount", async () => {
+  it("rejects a checkout whose promo is already fully held by in-flight orders", async () => {
     dbMock.promoCode.findUnique.mockResolvedValue(activePromo({ maxUses: 1, uses: 0 }));
     dbMock.payment.count.mockResolvedValue(1); // one checkout already issued
 
     const res = await createOrder(jsonRequest({ plan: "Basic", promoCode: "LAUNCH50" }));
-    const body = await res.json();
-
-    expect(body.discountPct).toBe(0);
-    expect(ordersCreate).toHaveBeenCalledWith(expect.objectContaining({ amount: BASIC_MONTHLY }));
-    expect(dbMock.payment.create).toHaveBeenCalledWith({
-      data: expect.objectContaining({ promoCode: null, discountPct: null }),
-    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("PROMO_INVALID");
+    expect(dbMock.payment.create).not.toHaveBeenCalled();
   });
 
   it("only counts recent PENDING orders as holds, so an abandoned checkout releases its use", async () => {
@@ -167,13 +163,12 @@ describe("create-order — a promo use is held, not consumed", () => {
     expect(Math.abs(cutoff - expected)).toBeLessThan(5_000);
   });
 
-  it("refuses the discount once uses have reached maxUses", async () => {
+  it("rejects the checkout once uses have reached maxUses", async () => {
     dbMock.promoCode.findUnique.mockResolvedValue(activePromo({ maxUses: 5, uses: 5 }));
 
-    const body = await (await createOrder(jsonRequest({ plan: "Basic", promoCode: "LAUNCH50" }))).json();
-
-    expect(body.discountPct).toBe(0);
-    expect(ordersCreate).toHaveBeenCalledWith(expect.objectContaining({ amount: BASIC_MONTHLY }));
+    const res = await createOrder(jsonRequest({ plan: "Basic", promoCode: "LAUNCH50" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("PROMO_INVALID");
   });
 
   it("allows an unlimited promo regardless of how many orders are in flight", async () => {
@@ -186,31 +181,31 @@ describe("create-order — a promo use is held, not consumed", () => {
     expect(dbMock.payment.count).not.toHaveBeenCalled();
   });
 
-  it("ignores an inactive promo", async () => {
+  it("rejects an inactive promo", async () => {
     dbMock.promoCode.findUnique.mockResolvedValue(activePromo({ active: false }));
 
-    const body = await (await createOrder(jsonRequest({ plan: "Basic", promoCode: "LAUNCH50" }))).json();
-
-    expect(body.discountPct).toBe(0);
+    const res = await createOrder(jsonRequest({ plan: "Basic", promoCode: "LAUNCH50" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("PROMO_INVALID");
   });
 
-  it("ignores an expired promo", async () => {
+  it("rejects an expired promo", async () => {
     dbMock.promoCode.findUnique.mockResolvedValue(
       activePromo({ expiresAt: new Date(Date.now() - 1_000) })
     );
 
-    const body = await (await createOrder(jsonRequest({ plan: "Basic", promoCode: "LAUNCH50" }))).json();
-
-    expect(body.discountPct).toBe(0);
+    const res = await createOrder(jsonRequest({ plan: "Basic", promoCode: "LAUNCH50" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("PROMO_INVALID");
   });
 
-  it("ignores an unknown promo code", async () => {
+  it("rejects an unknown promo code", async () => {
     dbMock.promoCode.findUnique.mockResolvedValue(null);
 
-    const body = await (await createOrder(jsonRequest({ plan: "Basic", promoCode: "NOPE" }))).json();
-
-    expect(body.discountPct).toBe(0);
-    expect(ordersCreate).toHaveBeenCalledWith(expect.objectContaining({ amount: BASIC_MONTHLY }));
+    const res = await createOrder(jsonRequest({ plan: "Basic", promoCode: "NOPE" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("PROMO_INVALID");
+    expect(dbMock.payment.create).not.toHaveBeenCalled();
   });
 
   it("charges twelve months up front for annual billing", async () => {

--- a/src/app/api/payments/create-order/route.ts
+++ b/src/app/api/payments/create-order/route.ts
@@ -65,7 +65,8 @@ export async function POST(req: NextRequest) {
       const promo = await db.promoCode.findUnique({
         where: { code: promoCode.toUpperCase() },
       });
-      if (promo && promo.active && (!promo.expiresAt || promo.expiresAt > new Date())) {
+      const usable = promo && promo.active && (!promo.expiresAt || promo.expiresAt > new Date());
+      if (usable) {
         const { maxUses } = promo;
         let withinCap = maxUses === null;
         if (maxUses !== null) {
@@ -86,6 +87,14 @@ export async function POST(req: NextRequest) {
           validPromo = promo.code;
           baseAmount = Math.round(baseAmount * (1 - discountPct / 100));
         }
+      }
+      // A code was entered but could not be applied (unknown, inactive, expired, or fully
+      // used). Say so rather than silently charging full price against a shown discount.
+      if (!validPromo) {
+        return NextResponse.json(
+          { error: "That promo code isn't valid. Remove it or try another.", code: "PROMO_INVALID" },
+          { status: 400 }
+        );
       }
     }
 

--- a/src/app/api/webhooks/lemonsqueezy/route.ts
+++ b/src/app/api/webhooks/lemonsqueezy/route.ts
@@ -61,7 +61,9 @@ export async function POST(req: NextRequest) {
 
     const status = String(attrs.status ?? "");
     // LS `total` is an integer in the smallest currency unit (e.g. cents)
-    const amount = Number(attrs.total);
+    // Pin against the pre-tax subtotal: `total` includes tax, so a taxed order would fail
+    // an exact-price check even when correct. Fall back to total when subtotal is absent.
+    const amount = Number(attrs.subtotal ?? attrs.total);
     const currency = typeof attrs.currency === "string" ? attrs.currency : "USD";
     const storeId = asId(attrs.store_id);
     const firstItem = (attrs.first_order_item ?? {}) as Record<string, unknown>;

--- a/src/lib/lemonsqueezy.ts
+++ b/src/lib/lemonsqueezy.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import crypto from "crypto";
-import { env } from "@/lib/env";
+import { env, siteUrl} from "@/lib/env";
 
 const LS_API_BASE = "https://api.lemonsqueezy.com/v1";
 
@@ -36,7 +36,7 @@ export async function createExportCheckout(params: {
         product_options: {
           name: `ScrollCraft Export — ${siteName}`,
           description: "Download your scroll site as a pure HTML/CSS/JS ZIP",
-          redirect_url: `${process.env.NEXTAUTH_URL ?? "https://scrollcraft.app"}/editor?siteId=${siteId}&purchased=1`,
+          redirect_url: `${siteUrl}/editor?siteId=${siteId}&purchased=1`,
         },
         checkout_options: {
           embed: false,


### PR DESCRIPTION
Three payment-correctness fixes.

- **#232** the LS checkout `redirect_url` read `process.env.NEXTAUTH_URL` with a hardcoded fallback → now the env-derived `siteUrl`.
- **#231** the webhook pinned the export price against the **tax-inclusive** total, failing exact-price checks on taxed orders → now compares the pre-tax `subtotal`.
- **#216** `create-order` silently dropped a rejected promo (unknown/inactive/expired/exhausted) and charged full price while the page showed the discount → now returns **400 PROMO_INVALID**. The five promo tests are updated to assert the rejection.

**#215 deliberately not fixed here** — it's a product decision. The pivot's pricing page says ZIP export is free on every plan, but `export-site` still paywalls FREE users. Reconciling means either removing the paywall (free export for all) or removing the claim — both revenue-affecting, your call. I reverted my first attempt (removing the paywall) because it changes monetization and invalidates the export-purchase security suite.

284 tests, tsc/eslint clean.

- [x] tests updated for the new promo behavior