### PR TITLE
Namespace rate-limit buckets per endpoint and key cost routes by user

### DIFF
--- a/src/__tests__/getClientIp.test.ts
+++ b/src/__tests__/getClientIp.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { getClientIp } from "@/lib/rateLimit";
+
+function reqWith(headers: Record<string, string>): Request {
+  return new Request("https://scrollcraft.app/api/x", { headers });
+}
+
+describe("getClientIp", () => {
+  it("prefers the Vercel-signed header over x-forwarded-for", () => {
+    const ip = getClientIp(reqWith({
+      "x-vercel-forwarded-for": "9.9.9.9",
+      "x-forwarded-for": "1.1.1.1, 2.2.2.2",
+    }));
+    expect(ip).toBe("9.9.9.9");
+  });
+
+  it("falls back to x-real-ip before x-forwarded-for", () => {
+    const ip = getClientIp(reqWith({
+      "x-real-ip": "9.9.9.9",
+      "x-forwarded-for": "1.1.1.1",
+    }));
+    expect(ip).toBe("9.9.9.9");
+  });
+
+  it("reads x-forwarded-for right-to-left so a spoofed left entry is ignored", () => {
+    // A client can prepend anything; only the rightmost hop is trustworthy.
+    const ip = getClientIp(reqWith({ "x-forwarded-for": "6.6.6.6, 3.3.3.3" }));
+    expect(ip).toBe("3.3.3.3");
+  });
+
+  it("skips junk hops and returns the rightmost valid IP", () => {
+    const ip = getClientIp(reqWith({ "x-forwarded-for": "3.3.3.3, not-an-ip" }));
+    expect(ip).toBe("3.3.3.3");
+  });
+
+  it("strips a port from an IPv4 address", () => {
+    expect(getClientIp(reqWith({ "x-real-ip": "1.2.3.4:5678" }))).toBe("1.2.3.4");
+  });
+
+  it("unwraps a bracketed IPv6 address with a port", () => {
+    expect(getClientIp(reqWith({ "x-real-ip": "[2001:db8::1]:443" }))).toBe("2001:db8::1");
+  });
+
+  it("accepts a bare IPv6 address", () => {
+    expect(getClientIp(reqWith({ "x-real-ip": "2001:db8::1" }))).toBe("2001:db8::1");
+  });
+
+  it("returns 'unknown' when nothing attributable is present", () => {
+    expect(getClientIp(reqWith({}))).toBe("unknown");
+    expect(getClientIp(reqWith({ "x-forwarded-for": "garbage, also-garbage" }))).toBe("unknown");
+  });
+
+  it("shares one 'unknown' bucket so unattributable traffic stays capped in aggregate", () => {
+    // Two requests with no usable header must map to the same key, not a fresh allowance each.
+    expect(getClientIp(reqWith({ "x-real-ip": "" }))).toBe("unknown");
+    expect(getClientIp(reqWith({ "x-forwarded-for": "" }))).toBe("unknown");
+  });
+});

--- a/src/__tests__/rateLimit.test.ts
+++ b/src/__tests__/rateLimit.test.ts
@@ -9,42 +9,50 @@ beforeEach(async () => {
 
 describe("rateLimit (in-memory fallback)", () => {
   it("allows requests within the limit", async () => {
-    const result = await rateLimit("1.2.3.4", { limit: 3, windowMs: 60_000 });
+    const result = await rateLimit("1.2.3.4", { bucket: "test", limit: 3, windowMs: 60_000 });
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(2);
   });
 
   it("tracks count across calls", async () => {
-    await rateLimit("1.2.3.4", { limit: 3, windowMs: 60_000 });
-    await rateLimit("1.2.3.4", { limit: 3, windowMs: 60_000 });
-    const third = await rateLimit("1.2.3.4", { limit: 3, windowMs: 60_000 });
+    await rateLimit("1.2.3.4", { bucket: "test", limit: 3, windowMs: 60_000 });
+    await rateLimit("1.2.3.4", { bucket: "test", limit: 3, windowMs: 60_000 });
+    const third = await rateLimit("1.2.3.4", { bucket: "test", limit: 3, windowMs: 60_000 });
     expect(third.allowed).toBe(true);
     expect(third.remaining).toBe(0);
   });
 
   it("blocks requests over the limit", async () => {
-    await rateLimit("1.2.3.4", { limit: 2, windowMs: 60_000 });
-    await rateLimit("1.2.3.4", { limit: 2, windowMs: 60_000 });
-    const over = await rateLimit("1.2.3.4", { limit: 2, windowMs: 60_000 });
+    await rateLimit("1.2.3.4", { bucket: "test", limit: 2, windowMs: 60_000 });
+    await rateLimit("1.2.3.4", { bucket: "test", limit: 2, windowMs: 60_000 });
+    const over = await rateLimit("1.2.3.4", { bucket: "test", limit: 2, windowMs: 60_000 });
     expect(over.allowed).toBe(false);
     expect(over.remaining).toBe(0);
   });
 
   it("resets after window expires", async () => {
     vi.useFakeTimers();
-    await rateLimit("1.2.3.4", { limit: 1, windowMs: 1_000 });
-    const blocked = await rateLimit("1.2.3.4", { limit: 1, windowMs: 1_000 });
+    await rateLimit("1.2.3.4", { bucket: "test", limit: 1, windowMs: 1_000 });
+    const blocked = await rateLimit("1.2.3.4", { bucket: "test", limit: 1, windowMs: 1_000 });
     expect(blocked.allowed).toBe(false);
 
     vi.advanceTimersByTime(1_001);
-    const after = await rateLimit("1.2.3.4", { limit: 1, windowMs: 1_000 });
+    const after = await rateLimit("1.2.3.4", { bucket: "test", limit: 1, windowMs: 1_000 });
     expect(after.allowed).toBe(true);
     vi.useRealTimers();
   });
 
   it("isolates counts per IP", async () => {
-    await rateLimit("1.1.1.1", { limit: 1, windowMs: 60_000 });
-    const other = await rateLimit("2.2.2.2", { limit: 1, windowMs: 60_000 });
+    await rateLimit("1.1.1.1", { bucket: "test", limit: 1, windowMs: 60_000 });
+    const other = await rateLimit("2.2.2.2", { bucket: "test", limit: 1, windowMs: 60_000 });
+    expect(other.allowed).toBe(true);
+  });
+  it("isolates counts per bucket even when IP, limit, and window match", async () => {
+    await rateLimit("3.3.3.3", { bucket: "export-site", limit: 1, windowMs: 60_000 });
+    const blocked = await rateLimit("3.3.3.3", { bucket: "export-site", limit: 1, windowMs: 60_000 });
+    expect(blocked.allowed).toBe(false);
+    // A different endpoint with the same identity and config must not have spent its allowance.
+    const other = await rateLimit("3.3.3.3", { bucket: "extract-frames", limit: 1, windowMs: 60_000 });
     expect(other.allowed).toBe(true);
   });
 });

--- a/src/__tests__/rateLimitFallback.test.ts
+++ b/src/__tests__/rateLimitFallback.test.ts
@@ -29,7 +29,7 @@ vi.mock("@upstash/ratelimit", () => {
 type RateLimit = typeof import("../lib/rateLimit").rateLimit;
 let rateLimit: RateLimit;
 
-const OPTS = { limit: 3, windowMs: 60_000 };
+const OPTS = { bucket: "test", limit: 3, windowMs: 60_000 };
 
 beforeEach(async () => {
   vi.resetModules();
@@ -98,7 +98,7 @@ describe("rateLimit — in-memory fallback when Upstash rejects", () => {
 
   it("still enforces the limit while degraded", async () => {
     limitMock.mockRejectedValue(new Error("ECONNREFUSED"));
-    const opts = { limit: 2, windowMs: 60_000 };
+    const opts = { bucket: "test", limit: 2, windowMs: 60_000 };
 
     const first = await rateLimit("5.5.5.6", opts);
     const second = await rateLimit("5.5.5.6", opts);
@@ -139,10 +139,10 @@ describe("rateLimit — in-memory fallback when Upstash rejects", () => {
   it("keeps per-config buckets separate while degraded", async () => {
     limitMock.mockRejectedValue(new Error("boom"));
 
-    await rateLimit("5.5.5.9", { limit: 1, windowMs: 60_000 });
-    const blocked = await rateLimit("5.5.5.9", { limit: 1, windowMs: 60_000 });
+    await rateLimit("5.5.5.9", { bucket: "test", limit: 1, windowMs: 60_000 });
+    const blocked = await rateLimit("5.5.5.9", { bucket: "test", limit: 1, windowMs: 60_000 });
     // A different limit/window is a different bucket, so it must not inherit the count.
-    const otherBucket = await rateLimit("5.5.5.9", { limit: 1, windowMs: 3_600_000 });
+    const otherBucket = await rateLimit("5.5.5.9", { bucket: "test", limit: 1, windowMs: 3_600_000 });
 
     expect(blocked.allowed).toBe(false);
     expect(otherBucket.allowed).toBe(true);
@@ -154,7 +154,7 @@ describe("rateLimit — Upstash timeout", () => {
     // The Upstash SDK resolves a timed-out call as `success: true` without ever
     // reaching Redis, so trusting it would make an outage a free-for-all.
     limitMock.mockResolvedValue({ success: true, remaining: 500, reset: 1, reason: "timeout" });
-    const opts = { limit: 2, windowMs: 60_000 };
+    const opts = { bucket: "test", limit: 2, windowMs: 60_000 };
 
     const first = await rateLimit("7.7.7.7", opts);
     expect(first.remaining).toBe(1); // in-memory, not the 500 Upstash claimed

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
-import { rateLimit, getClientIp } from "@/lib/rateLimit";
+import { rateLimit } from "@/lib/rateLimit";
 import { REVEALS, type Section, visibleSections as onlyVisible } from "@/lib/siteSchema";
 import { layoutStyle } from "@/lib/layoutStyles";
 import { parseThemeJson } from "@/lib/siteSchema";
@@ -47,7 +47,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rl = await rateLimit(getClientIp(req), { limit: 10, windowMs: 60_000 });
+  const rl = await rateLimit(`user:${session.user.id}`, { bucket: "export-site", limit: 10, windowMs: 60_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests. Try again in a minute." }, { status: 429 });
   }

--- a/src/app/api/extract-frames/route.ts
+++ b/src/app/api/extract-frames/route.ts
@@ -13,7 +13,7 @@ import https from "https";
 import { randomUUID } from "crypto";
 import { pipeline } from "stream/promises";
 import { auth } from "@/auth";
-import { rateLimit, getClientIp } from "@/lib/rateLimit";
+import { rateLimit } from "@/lib/rateLimit";
 import { put } from "@vercel/blob";
 
 const execFile = promisify(_execFile);
@@ -236,7 +236,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rl = await rateLimit(getClientIp(req), { limit: 10, windowMs: 60_000 });
+  const rl = await rateLimit(`user:${session.user.id}`, { bucket: "extract-frames", limit: 10, windowMs: 60_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests. Try again in a minute." }, {
       status: 429,

--- a/src/app/api/payments/create-order/route.ts
+++ b/src/app/api/payments/create-order/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rl = await rateLimit(getClientIp(req), { limit: 5, windowMs: 3_600_000 });
+  const rl = await rateLimit(getClientIp(req), { bucket: "create-order", limit: 5, windowMs: 3_600_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many payment requests. Try again later." }, { status: 429 });
   }

--- a/src/app/api/payments/ls-checkout/route.ts
+++ b/src/app/api/payments/ls-checkout/route.ts
@@ -12,7 +12,7 @@ const schema = z.object({ siteId: z.string().min(1).max(128) });
 const PENDING_CHECKOUT_TTL_MS = 30 * 60_000;
 
 export async function POST(req: NextRequest) {
-  const rl = await rateLimit(getClientIp(req), { limit: 10, windowMs: 60_000 });
+  const rl = await rateLimit(getClientIp(req), { bucket: "ls-checkout", limit: 10, windowMs: 60_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }

--- a/src/app/api/payments/verify/route.ts
+++ b/src/app/api/payments/verify/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rl = await rateLimit(getClientIp(req), { limit: 10, windowMs: 3_600_000 });
+  const rl = await rateLimit(getClientIp(req), { bucket: "payments-verify", limit: 10, windowMs: 3_600_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests. Try again later." }, { status: 429 });
   }

--- a/src/app/api/promo/route.ts
+++ b/src/app/api/promo/route.ts
@@ -14,7 +14,7 @@ export async function POST(req: NextRequest) {
   // Deliberately unauthenticated: visitors apply a code on /pricing before signing in,
   // and only checkout gates on auth. Enumeration is limited by rate and by the uniform
   // response below rather than by requiring an account.
-  const rl = await rateLimit(`promo:${getClientIp(req)}`, { limit: 10, windowMs: 60_000 });
+  const rl = await rateLimit(getClientIp(req), { bucket: "promo", limit: 10, windowMs: 60_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }

--- a/src/app/api/sites/[id]/publish/route.ts
+++ b/src/app/api/sites/[id]/publish/route.ts
@@ -31,7 +31,7 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rl = await rateLimit(getClientIp(req), { limit: 20, windowMs: 60_000 });
+  const rl = await rateLimit(getClientIp(req), { bucket: "publish", limit: 20, windowMs: 60_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests. Try again in a minute." }, { status: 429 });
   }

--- a/src/app/api/sites/route.ts
+++ b/src/app/api/sites/route.ts
@@ -56,7 +56,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rl = await rateLimit(getClientIp(req), { limit: 30, windowMs: 60_000 });
+  const rl = await rateLimit(getClientIp(req), { bucket: "sites", limit: 30, windowMs: 60_000 });
   if (!rl.allowed) {
     return NextResponse.json({ error: "Too many requests. Try again in a minute." }, { status: 429 });
   }

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -25,20 +25,21 @@ function getRedis(): Redis | null {
   return redis;
 }
 
-function getLimiter(limit: number, windowMs: number): Ratelimit | null {
+function getLimiter(bucket: string, limit: number, windowMs: number): Ratelimit | null {
   const r = getRedis();
   if (!r) return null;
-  const cacheKey = `${limit}:${windowMs}`;
+  const cacheKey = `${bucket}:${limit}:${windowMs}`;
   if (!limiters.has(cacheKey)) {
     // Convert ms to nearest whole seconds for Upstash duration string
     const windowSec = Math.ceil(windowMs / 1000);
     limiters.set(cacheKey, new Ratelimit({
       redis: r,
       limiter: Ratelimit.slidingWindow(limit, `${windowSec} s`),
-      // The Redis key is `<prefix>:<ip>:<window index>`, so the config has to be part
-      // of the prefix for the same reason it is part of the in-memory key — otherwise
-      // a 5/hour bucket and a 10/hour bucket share one counter.
-      prefix: `sc_rl:${limit}:${windowMs}`,
+      // The Redis key is `<prefix>:<ip>:<window index>`, so the bucket and config both
+      // have to be part of the prefix for the same reason they are part of the in-memory
+      // key — otherwise a 5/hour bucket and a 10/hour bucket, or two unrelated endpoints
+      // that happen to share a limit and window, collapse into one counter.
+      prefix: `sc_rl:${bucket}:${limit}:${windowMs}`,
       timeout: UPSTASH_TIMEOUT_MS,
     }));
   }
@@ -79,6 +80,7 @@ function evictOldest(count: number) {
 
 function rateLimitMemory(
   ip: string,
+  bucket: string,
   limit: number,
   windowMs: number
 ): { allowed: boolean; remaining: number; resetAt: number } {
@@ -88,9 +90,9 @@ function rateLimitMemory(
     // Still full means the entries are all live: drop the oldest to make room.
     if (store.size >= MAX_ENTRIES) evictOldest(store.size - MAX_ENTRIES + 1);
   }
-  // Endpoints pass different limits and windows, so the config is part of the key —
-  // otherwise a 5/hour bucket and a 10/minute bucket share one counter and resetAt.
-  const key = `${limit}:${windowMs}:${ip}`;
+  // The bucket and config are part of the key: distinct endpoints must not share a
+  // counter, and neither may a 5/hour bucket and a 10/minute one on the same endpoint.
+  const key = `${bucket}:${limit}:${windowMs}:${ip}`;
   const entry = store.get(key);
   if (!entry || entry.resetAt <= now) {
     store.set(key, { count: 1, resetAt: now + windowMs });
@@ -104,17 +106,21 @@ function rateLimitMemory(
 }
 
 export interface RateLimitOptions {
+  // Namespace for the counter, one per protected action. Two endpoints that share a
+  // limit and window still get separate buckets, so traffic to one never spends the
+  // other's allowance.
+  bucket: string;
   limit: number;
   windowMs: number;
 }
 
 export async function rateLimit(
   ip: string,
-  { limit, windowMs }: RateLimitOptions
+  { bucket, limit, windowMs }: RateLimitOptions
 ): Promise<{ allowed: boolean; remaining: number; resetAt: number }> {
   if (Date.now() >= upstashDownUntil) {
     try {
-      const limiter = getLimiter(limit, windowMs);
+      const limiter = getLimiter(bucket, limit, windowMs);
       if (limiter) {
         const result = await limiter.limit(ip);
         // A timed-out call resolves as allowed without ever reaching Redis, so
@@ -132,7 +138,7 @@ export async function rateLimit(
       markUpstashDown(err instanceof Error ? err.message : String(err));
     }
   }
-  return rateLimitMemory(ip, limit, windowMs);
+  return rateLimitMemory(ip, bucket, limit, windowMs);
 }
 
 // Vercel rewrites these at its edge on every request, so a client cannot forge them.


### PR DESCRIPTION
## What

The rate-limit key was built from only `limit`, `windowMs`, and the IP. Any two endpoints that happened to share a config drew from **one** counter — `extract-frames`, `export-site`, and `ls-checkout` all run at 10/min and collided into a single 10/min allowance per IP (#246).

The two most expensive endpoints (`extract-frames`, `export-site`) also authenticate *before* limiting, yet keyed on client IP: a shared NAT throttled unrelated users, and a single account could multiply its true allowance by rotating source IPs (#247).

## Changes

- `RateLimitOptions` gains a required `bucket`, folded into both the Upstash prefix and the in-memory key. Distinct endpoints can no longer share a counter even with identical limit/window.
- Every call site passes its own bucket. `promo` moves its `promo:` namespace from the identity into `bucket`.
- `extract-frames` and `export-site` key on `user:${session.user.id}`.
- Tests: new `getClientIp` suite covering header precedence, right-to-left x-forwarded-for, port stripping, IPv6, and the aggregate `unknown` bucket (#254); a bucket-isolation test that fails without the key change (verified by reverting).

## Verified

- `tsc --noEmit` clean; full suite 294 passed (was 284).
- Isolation test proven to fail on the pre-fix key, pass after.

Fixes #246
Fixes #247
Fixes #254