### PR TITLE
Report handled server errors to Sentry; warn on rate-limit fallback

### DIFF
--- a/src/__tests__/loggerSentry.test.ts
+++ b/src/__tests__/loggerSentry.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const captureException = vi.hoisted(() => vi.fn());
+vi.mock("@sentry/nextjs", () => ({ captureException }));
+
+let logger: typeof import("../lib/logger").logger;
+
+beforeEach(async () => {
+  vi.resetModules();
+  captureException.mockReset();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "info").mockImplementation(() => {});
+  ({ logger } = await import("../lib/logger"));
+});
+
+describe("logger → Sentry", () => {
+  it("reports the caught error to Sentry on logger.error", () => {
+    const err = new Error("boom");
+    logger.error("export-site failed", { err });
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException.mock.calls[0][0]).toBe(err);
+  });
+
+  it("wraps a non-Error payload so Sentry still gets an exception", () => {
+    logger.error("something odd", { err: "not-an-error" });
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect((captureException.mock.calls[0][0] as Error).message).toBe("something odd");
+  });
+
+  it("does not report info or warn", () => {
+    logger.info("hello");
+    logger.warn("careful");
+    expect(captureException).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/rateLimitFallback.test.ts
+++ b/src/__tests__/rateLimitFallback.test.ts
@@ -83,6 +83,21 @@ describe("rateLimit — Upstash path", () => {
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(OPTS.limit - 1);
   });
+
+  it("warns once, not per request, that the fallback is per-instance", async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.resetModules();
+    ({ rateLimit } = await import("../lib/rateLimit"));
+
+    await rateLimit("8.8.8.8", OPTS);
+    await rateLimit("8.8.8.8", OPTS);
+    await rateLimit("9.9.9.9", OPTS);
+
+    const upstashWarns = warn.mock.calls.filter((c) => String(c[0]).includes("UPSTASH_"));
+    expect(upstashWarns).toHaveLength(1);
+  });
 });
 
 describe("rateLimit — in-memory fallback when Upstash rejects", () => {

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { rateLimit } from "@/lib/rateLimit";
@@ -531,7 +532,7 @@ export async function POST(req: NextRequest) {
       fps: validatedFps,
     });
   } catch (err) {
-    console.error("export-site error:", err);
+    logger.error("export-site failed", { err });
     return NextResponse.json({ error: "Export failed" }, { status: 500 });
   }
 }

--- a/src/app/api/extract-frames/route.ts
+++ b/src/app/api/extract-frames/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { writeFile, mkdir, rm } from "fs/promises";
 import { createWriteStream } from "fs";
 import path from "path";
@@ -357,7 +358,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ frames, frameCount: frames.length, stored: useBlobStorage });
   } catch (err) {
-    console.error("extract-frames error:", err);
+    logger.error("extract-frames failed", { err });
     return NextResponse.json({ error: "Frame extraction failed" }, { status: 500 });
   } finally {
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {});

--- a/src/app/api/payments/create-order/route.ts
+++ b/src/app/api/payments/create-order/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { z } from "zod";
 import Razorpay from "razorpay";
 import { auth } from "@/auth";
@@ -133,7 +134,7 @@ export async function POST(req: NextRequest) {
       discountPct,
     });
   } catch (err) {
-    console.error("create-order error:", err);
+    logger.error("create-order failed", { err });
     return NextResponse.json({ error: "Failed to create order" }, { status: 500 });
   }
 }

--- a/src/app/api/payments/ls-checkout/route.ts
+++ b/src/app/api/payments/ls-checkout/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { z } from "zod";
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
@@ -105,7 +106,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ checkoutUrl });
   } catch (err) {
-    console.error("LS checkout error:", err);
+    logger.error("lemonsqueezy checkout failed", { err });
     return NextResponse.json({ error: "Failed to create checkout" }, { status: 500 });
   }
 }

--- a/src/app/api/payments/verify/route.ts
+++ b/src/app/api/payments/verify/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import crypto from "crypto";
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
@@ -84,7 +85,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ success: true, paymentId });
   } catch (err) {
-    console.error("verify error:", err);
+    logger.error("payment verify failed", { err });
     return NextResponse.json({ error: "Verification failed" }, { status: 500 });
   }
 }

--- a/src/app/api/webhooks/razorpay/route.ts
+++ b/src/app/api/webhooks/razorpay/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import crypto from "crypto";
 import Razorpay from "razorpay";
 import { db } from "@/lib/db";
@@ -206,7 +207,7 @@ export async function POST(req: NextRequest) {
       break;
   }
   } catch (err) {
-    console.error("Webhook processing failed:", err);
+    logger.error("razorpay webhook processing failed", { err });
     return NextResponse.json({ error: "Webhook processing failed" }, { status: 500 });
   }
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,8 +1,10 @@
 import "server-only";
+import * as Sentry from "@sentry/nextjs";
 
 type LogLevel = "info" | "warn" | "error";
 
 interface LogPayload {
+  err?: unknown;
   [key: string]: unknown;
 }
 
@@ -20,6 +22,15 @@ function log(level: LogLevel, message: string, payload?: LogPayload) {
   } else {
     const { timestamp, ...rest } = entry;
     console[level](`[${timestamp}] ${level.toUpperCase()} ${message}`, Object.keys(rest).length ? rest : "");
+  }
+
+  // A route that catches an error and returns a 500 JSON never lets it bubble to
+  // Next's onRequestError, so this is the only path that reports handled failures.
+  if (level === "error") {
+    const cause = payload?.err;
+    Sentry.captureException(cause instanceof Error ? cause : new Error(message), {
+      extra: entry,
+    });
   }
 }
 

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -6,6 +6,7 @@ import { logger } from "@/lib/logger";
 // Lazy-init Redis + per-config Ratelimit instances
 let redis: Redis | null = null;
 const limiters = new Map<string, Ratelimit>();
+let warnedNoUpstash = false;
 
 // Upstash is a network hop, so cap how long a request may wait on it, and stop
 // calling it for a cooldown after a failure: an outage then costs one timeout
@@ -15,7 +16,15 @@ const UPSTASH_COOLDOWN_MS = 30_000;
 let upstashDownUntil = 0;
 
 function getRedis(): Redis | null {
-  if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) return null;
+  if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
+    if (!warnedNoUpstash) {
+      warnedNoUpstash = true;
+      // Without this the fallback is silent: limits still enforce, but only per
+      // instance, so the real ceiling is (limit × running instances).
+      logger.warn("UPSTASH_* unset — rate limiting uses the in-memory fallback; limits are per-instance, not shared across instances");
+    }
+    return null;
+  }
   if (!redis) {
     redis = new Redis({
       url: process.env.UPSTASH_REDIS_REST_URL,


### PR DESCRIPTION
## What

Route handlers catch their errors and return a 500 JSON, so nothing bubbles to Next's `onRequestError` — those failures never reached Sentry (#237). Separately, when `UPSTASH_*` is unset the limiter silently degrades to a per-instance in-memory store, with no signal to operators (#248).

## Changes

- `logger.error` now calls `Sentry.captureException` (the caught `err` when it is an `Error`, else a synthesized one carrying the message + structured entry). This is the single chokepoint for handled failures.
- The swallowing `catch` blocks in export-site, extract-frames, verify, ls-checkout, create-order, and the razorpay webhook switch from `console.error` to `logger.error(msg, { err })`.
- `getRedis` warns **once** when `UPSTASH_*` is unset, naming the per-instance limitation.
- Tests: `logger → Sentry` suite (reports on error, wraps non-Error, silent on info/warn); a warn-once test in the fallback suite.

## Verified

- `tsc --noEmit` clean; full suite 298 passed (was 294). Sentry is mocked in the logger test and a safe no-op elsewhere (not initialized under test).

Fixes #237
Fixes #248