### PR TITLE
Unguessable frame blobs; reclaim frame storage on site delete

### DIFF
--- a/src/__tests__/siteDelete.test.ts
+++ b/src/__tests__/siteDelete.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const dbMock = vi.hoisted(() => ({
+  user: { findUnique: vi.fn() },
+  site: { findFirst: vi.fn(), delete: vi.fn() },
+  exportPurchase: { count: vi.fn(), deleteMany: vi.fn() },
+}));
+const authMock = vi.hoisted(() => vi.fn());
+const delMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({ db: dbMock }));
+vi.mock("@/auth", () => ({ auth: authMock }));
+vi.mock("@vercel/blob", () => ({ del: delMock }));
+
+type Handler = typeof import("../app/api/sites/[id]/route").DELETE;
+let DELETE: Handler;
+
+const ctx = { params: Promise.resolve({ id: "s1" }) };
+function req(): NextRequest {
+  return new Request("https://scrollcraft.app/api/sites/s1", { method: "DELETE" }) as unknown as NextRequest;
+}
+
+const FRAMES = JSON.stringify(["https://blob.example/a.jpg", "https://blob.example/b.jpg"]);
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  authMock.mockResolvedValue({ user: { email: "a@b.c" } });
+  dbMock.user.findUnique.mockResolvedValue({ id: "u1" });
+  dbMock.site.findFirst.mockResolvedValue({ id: "s1", userId: "u1", framesJson: FRAMES });
+  dbMock.exportPurchase.count.mockResolvedValue(0);
+  dbMock.exportPurchase.deleteMany.mockResolvedValue({ count: 0 });
+  dbMock.site.delete.mockResolvedValue({ id: "s1" });
+  delMock.mockResolvedValue(undefined);
+  ({ DELETE } = await import("../app/api/sites/[id]/route"));
+});
+
+describe("DELETE /api/sites/[id]", () => {
+  it("blocks the delete only for PAID or REFUNDED purchases", async () => {
+    dbMock.exportPurchase.count.mockResolvedValue(1);
+    const res = await DELETE(req(), ctx);
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("HAS_PURCHASE");
+    // The blocking count must be scoped to money-movement statuses, not every row.
+    expect(dbMock.exportPurchase.count).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { siteId: "s1", status: { in: ["PAID", "REFUNDED"] } } })
+    );
+    expect(dbMock.site.delete).not.toHaveBeenCalled();
+  });
+
+  it("clears abandoned PENDING/FAILED checkouts so they can't wedge the delete", async () => {
+    const res = await DELETE(req(), ctx);
+    expect(res.status).toBe(200);
+    expect(dbMock.exportPurchase.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { siteId: "s1", status: { in: ["PENDING", "FAILED"] } } })
+    );
+    expect(dbMock.site.delete).toHaveBeenCalledWith({ where: { id: "s1" } });
+  });
+
+  it("reclaims the site's hosted frame blobs after deletion", async () => {
+    await DELETE(req(), ctx);
+    expect(delMock).toHaveBeenCalledWith([
+      "https://blob.example/a.jpg",
+      "https://blob.example/b.jpg",
+    ]);
+  });
+
+  it("does not call blob delete when the site has no hosted frames", async () => {
+    dbMock.site.findFirst.mockResolvedValue({ id: "s1", userId: "u1", framesJson: null });
+    const res = await DELETE(req(), ctx);
+    expect(res.status).toBe(200);
+    expect(delMock).not.toHaveBeenCalled();
+  });
+
+  it("still succeeds when blob reclamation fails", async () => {
+    delMock.mockRejectedValue(new Error("blob down"));
+    const res = await DELETE(req(), ctx);
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/extract-frames/route.ts
+++ b/src/app/api/extract-frames/route.ts
@@ -341,7 +341,10 @@ export async function POST(req: NextRequest) {
 
     const useBlobStorage = !!process.env.BLOB_READ_WRITE_TOKEN;
     const frames: string[] = [];
-    const sessionId = `scrollcraft/${Date.now()}`;
+    // Scope the prefix by user and a random id, not a bare timestamp: frames are public,
+    // so a shared timestamp prefix plus fixed frame_NNNNNN names let one user enumerate
+    // another's, and two same-millisecond extractions collide.
+    const sessionId = `scrollcraft/${session.user.id}/${randomUUID()}`;
 
     for (const file of frameFiles) {
       const buf = await readFile(path.join(framesDir, file));
@@ -349,6 +352,7 @@ export async function POST(req: NextRequest) {
         const { url } = await put(`${sessionId}/${file}`, buf, {
           access: "public",
           contentType: "image/jpeg",
+          addRandomSuffix: true,
         });
         frames.push(url);
       } else {

--- a/src/app/api/sites/[id]/route.ts
+++ b/src/app/api/sites/[id]/route.ts
@@ -1,6 +1,30 @@
 import { NextRequest, NextResponse } from "next/server";
+import { del } from "@vercel/blob";
 import { db } from "@/lib/db";
 import { auth } from "@/auth";
+import { logger } from "@/lib/logger";
+
+// Delete a site's hosted frame blobs. Best-effort: a blob that is already gone, or a
+// storage hiccup, must not fail the site delete the user already succeeded at.
+async function deleteSiteBlobs(framesJson: string | null) {
+  if (!framesJson) return;
+  let urls: unknown;
+  try {
+    urls = JSON.parse(framesJson);
+  } catch {
+    return;
+  }
+  if (!Array.isArray(urls)) return;
+  const blobUrls = urls.filter(
+    (u): u is string => typeof u === "string" && /^https?:\/\//i.test(u)
+  );
+  if (!blobUrls.length) return;
+  try {
+    await del(blobUrls);
+  } catch (err) {
+    logger.error("failed to reclaim frame blobs on site delete", { err });
+  }
+}
 
 // GET /api/sites/[id] — load a site by ID
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -33,21 +57,32 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const existing = await db.site.findFirst({ where: { id, userId: user.id } });
   if (!existing) return NextResponse.json({ error: "Site not found" }, { status: 404 });
 
-  // ExportPurchase now restricts this delete rather than cascading, so a site someone paid
-  // to export can't be removed along with the record of that payment.
-  const purchases = await db.exportPurchase.count({ where: { siteId: id } });
-  if (purchases > 0) {
+  // Only real money movement blocks the delete: a PAID or REFUNDED export is a record a
+  // refund or chargeback reconciles against. A PENDING or FAILED row is an abandoned or
+  // failed checkout — no money changed hands, and the Restrict FK would otherwise wedge
+  // the delete forever, so clear those first.
+  const blocking = await db.exportPurchase.count({
+    where: { siteId: id, status: { in: ["PAID", "REFUNDED"] } },
+  });
+  if (blocking > 0) {
     return NextResponse.json(
       { error: "This site has a purchased export and can't be deleted.", code: "HAS_PURCHASE" },
       { status: 409 }
     );
   }
+  await db.exportPurchase.deleteMany({
+    where: { siteId: id, status: { in: ["PENDING", "FAILED"] } },
+  });
 
   try {
     await db.site.delete({ where: { id } });
   } catch {
-    // Covers the race where a purchase lands between the count above and the delete.
+    // Covers the race where a PAID purchase lands between the count above and the delete.
     return NextResponse.json({ error: "Couldn't delete this site." }, { status: 409 });
   }
+
+  // Reclaim the site's hosted frames — nothing else references them once the row is gone.
+  await deleteSiteBlobs(existing.framesJson);
+
   return NextResponse.json({ success: true });
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import Navbar from "@/components/Navbar";
 import { planByKey } from "@/lib/plans";
+import { deleteFrames } from "@/lib/frameStorage";
 
 interface Site {
   id: string;
@@ -119,6 +120,12 @@ export default function DashboardPage() {
         return;
       }
       setSites(prev => prev.filter(s => s.id !== id));
+      // Reclaim the locally cached frames for this site so a delete doesn't leave its
+      // desktop and mobile frame sets orphaned in IndexedDB forever.
+      await Promise.all([
+        deleteFrames(`scrollcraft_frames_${id}`),
+        deleteFrames(`scrollcraft_mframes_${id}`),
+      ]).catch(() => {});
       toast.success("Site deleted");
     } catch {
       toast.error("Failed to delete site");


### PR DESCRIPTION
## What

Three frame-storage lifecycle defects plus the delete guard that wedged on them.

- **#217 / #250** — extracted frames are public, and the blob prefix was `scrollcraft/<Date.now()>` with fixed `frame_NNNNNN` names. That is enumerable across users and collides for same-millisecond extractions. Now `scrollcraft/<userId>/<uuid>` plus `addRandomSuffix`.
- **#189** — nothing ever deleted a blob. Deleting a site now `del()`s its hosted frame URLs (best-effort — a storage error is logged, not surfaced, so it can't fail a delete that already committed).
- **#218** — the dashboard delete now clears the site's desktop + mobile IndexedDB frame sets, which were orphaned forever.
- **#190** — the delete guard counted *every* `ExportPurchase`, so an abandoned PENDING/FAILED checkout blocked deletion permanently behind the `Restrict` FK. Now only PAID/REFUNDED block; PENDING/FAILED are cleared first.

## Verified

- New `siteDelete` suite: PAID/REFUNDED blocks 409, PENDING/FAILED cleared, blobs reclaimed, no-frames skips `del`, delete survives a blob failure. Reverting the status scope fails the guard test (checked).
- `tsc` clean; full suite 303 passed (was 298).

Note: frames from sessions abandoned before any save leave no server record, so a scheduled sweep would be the follow-up for those; deleting on site-delete closes the tracked leak safely.

Fixes #217
Fixes #250
Fixes #189
Fixes #218
Fixes #190