### PR TITLE
Harden editor save and hydration against lost edits and partial failures

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -207,8 +207,14 @@ function EditorInner() {
         }
         const { site } = await res.json();
         if (cancelled || !site) return;
+        // A persisted site is never a demo, even if its frames can't be resolved on this
+        // device — the demo lock is only for browser-generated placeholder frames, and
+        // leaving it on here made a real site refuse to Save or Export.
+        setIsDemo(false);
         // Load frames from IndexedDB (primary). Fall back to DB framesJson for old sites.
-        const storedFrames = await loadFrames(`scrollcraft_frames_${sid}`);
+        // Guard the read: an IndexedDB rejection must not throw past the rest of the
+        // hydration, which would discard the sections, name, and theme already fetched.
+        const storedFrames = await loadFrames(`scrollcraft_frames_${sid}`).catch(() => null);
         const storedMobile = await loadFrames(`scrollcraft_mframes_${sid}`).catch(() => null);
         let framesResolved = false;
         if (storedFrames && storedFrames.length) {
@@ -293,6 +299,11 @@ function EditorInner() {
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
   const [dirty, setDirty] = useState(false);
+  // Bumped on every content edit. A save captures this at its start and only clears the
+  // dirty flag if it is unchanged when the request resolves — otherwise edits the user
+  // made while the save was in flight would be silently marked as saved.
+  const editGenRef = useRef(0);
+  useEffect(() => { editGenRef.current += 1; }, [sections, siteName, customHead, customCss]);
 
   const syncHistoryFlags = useCallback(() => {
     setCanUndo(undoStack.current.length > 0);
@@ -559,6 +570,7 @@ function EditorInner() {
       return null;
     }
     setIsSaving(true);
+    const genAtSave = editGenRef.current;
     try {
       // Frames are NOT sent to the server (would exceed Vercel's 4.5 MB limit).
       // They are stored in sessionStorage keyed by site ID after a successful save.
@@ -596,13 +608,18 @@ function EditorInner() {
       setSiteId(savedId);
 
       // Persist frames in IndexedDB so they survive navigation without hitting sessionStorage quota.
-      await storeFrames(`scrollcraft_frames_${savedId}`, frames).catch(() => {});
+      const framesCached = await storeFrames(`scrollcraft_frames_${savedId}`, frames).then(() => true, () => false);
       if (mobileFrames.length) {
         await storeFrames(`scrollcraft_mframes_${savedId}`, mobileFrames).catch(() => {});
       }
 
-      setDirty(false);
-      if (!opts?.silent) toast.success("Site saved!");
+      // Only clear dirty if nothing was edited while the request was in flight, so those
+      // in-flight edits aren't lost from the unsaved-changes tracking.
+      if (editGenRef.current === genAtSave) setDirty(false);
+      if (!opts?.silent) {
+        if (framesCached) toast.success("Site saved!");
+        else toast.warning("Site saved. Frames couldn't be cached on this device — reopen here to re-cache them.");
+      }
       return savedId;
     } catch {
       toast.error("Failed to save site");


### PR DESCRIPTION
## What

Four editor state bugs, all in `editor/page.tsx`.

- **#219** — `handleSave` cleared the dirty flag *after* the await, so an edit made while the save was in flight was marked saved and dropped from the unsaved-changes tracking. Now an edit-generation ref is captured at save start; dirty clears only if nothing changed during the request.
- **#188** — a failed IndexedDB frame write was swallowed with `.catch(() => {})`, yet the save still toasted "Site saved!". The write result is now checked and a warning is shown when the local cache write fails (the server record still saved).
- **#220** — an IndexedDB rejection during hydration threw past the remaining hydration, discarding the sections/name/theme already fetched. The primary-frames read is now guarded with `.catch(() => null)` like its mobile sibling.
- **#191** — a persisted site opened without local frames stayed in demo mode, so Save/Export refused. A real loaded site now clears the demo lock unconditionally (it is only for browser-generated placeholder frames).

## Verified

- `tsc --noEmit`, `eslint`, and `next build` all clean; full suite 303 passed.

These are React state-timing fixes in a client component; the repo has no jsdom/component-test harness, so they are covered by type/lint/build rather than a new unit test.

Fixes #219
Fixes #188
Fixes #220
Fixes #191