### PR TITLE
Cap export and audio inputs, fix fixed-mode resize, defer JSZip

### DIFF
--- a/src/__tests__/exportSectionParity.test.ts
+++ b/src/__tests__/exportSectionParity.test.ts
@@ -190,4 +190,30 @@ describe("exported head and resilience", () => {
     expect(html).toContain("img.decode");
     expect(html).toContain("decoding = 'async'");
   });
+
+  it("excludes a hidden section from the HTML and the total scroll height", async () => {
+    const html = await exportHtml([
+      { heading: "Shown", scrollHeight: 1000 },
+      { heading: "Draft", visible: false, scrollHeight: 5000 },
+    ]);
+    expect(html).toContain("Shown");
+    expect(html).not.toContain("Draft");
+    // 1000 (the one visible section) + the 1000px trailing viewport; the hidden 5000 is
+    // never counted.
+    expect(html).toContain("height: 2000px");
+  });
+
+  it("refuses an export with no visible section", async () => {
+    const res = await POST(exportRequest({
+      sections: [{ heading: "Hidden", visible: false, scrollHeight: 1000 }],
+      siteName: "Parity", frameCount: 10, fps: 24,
+    }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a sections payload past the count cap", async () => {
+    const many = Array.from({ length: 201 }, (_, i) => ({ heading: `S${i}`, scrollHeight: 1000 }));
+    const res = await POST(exportRequest({ sections: many, siteName: "Big", frameCount: 10, fps: 24 }));
+    expect(res.status).toBe(400);
+  });
 });

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -54,8 +54,24 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    // Frames are assembled client-side — only metadata is sent to the server.
-    const body = await req.json();
+    // Frames are assembled client-side — only metadata is sent to the server. Every other
+    // input is capped below, but the body itself was not, so a caller could still ship
+    // megabytes of `sections`. Cap the raw body before parsing it.
+    const MAX_BODY = 12_000_000;
+    const declaredLen = Number(req.headers.get("content-length") ?? "");
+    if (Number.isFinite(declaredLen) && declaredLen > MAX_BODY) {
+      return NextResponse.json({ error: "Request body too large." }, { status: 413 });
+    }
+    const raw = await req.text();
+    if (raw.length > MAX_BODY) {
+      return NextResponse.json({ error: "Request body too large." }, { status: 413 });
+    }
+    let body;
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
     const {
       mobileFrameCount = 0,
       hasAudio = false,
@@ -135,6 +151,11 @@ export async function POST(req: NextRequest) {
 
     if (!Array.isArray(sections) || sections.length === 0) {
       return NextResponse.json({ error: "sections must be a non-empty array" }, { status: 400 });
+    }
+    // Cap the section payload to match the save-time limit. Sections loaded via siteId
+    // come from the DB (already bounded); this guards the request-sourced path.
+    if (sections.length > 200 || JSON.stringify(sections).length > 1_000_000) {
+      return NextResponse.json({ error: "sections payload is too large" }, { status: 400 });
     }
     // Number.isInteger, not just "> 1": JSON.parse turns 1e999 into Infinity, which
     // passed the old check and emitted `new Array(Infinity)` into the exported script —

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useState, useEffect, useRef, useCallback, Suspense } from "react";
-import JSZip from "jszip";
 import { loadFrames, storeFrames } from "@/lib/frameStorage";
 import { useSearchParams } from "next/navigation";
 import RequireAuth from "@/components/RequireAuth";
@@ -500,8 +499,10 @@ function EditorInner() {
       }
       const { html, audioExt } = await res.json();
 
-      // Build ZIP entirely in the browser — no round-trip for large frame data.
+      // Build ZIP entirely in the browser — no round-trip for large frame data. Load
+      // JSZip on demand so it stays out of the editor's first-load bundle.
       toast.info("Building ZIP…");
+      const { default: JSZip } = await import("jszip");
       const zip = new JSZip();
       zip.file("index.html", html);
 
@@ -1113,6 +1114,12 @@ function EditorInner() {
                     onChange={(e) => {
                       const file = e.target.files?.[0];
                       if (!file) return;
+                      const MAX_AUDIO_BYTES = 8 * 1024 * 1024;
+                      if (file.size > MAX_AUDIO_BYTES) {
+                        toast.error("Audio file too large — please use a file under 8 MB.");
+                        if (audioFileRef.current) audioFileRef.current.value = "";
+                        return;
+                      }
                       const reader = new FileReader();
                       reader.onload = (ev) => setAudioSrc(ev.target?.result as string);
                       reader.readAsDataURL(file);

--- a/src/components/ScrollEngine.tsx
+++ b/src/components/ScrollEngine.tsx
@@ -163,8 +163,11 @@ export default function ScrollEngine({ frames, mobileFrames, totalScrollHeight =
       // In simulator mode the canvas is pinned inside a scroll container, so its own
       // offset size is not the visible area — measure the container instead.
       const host = position === "absolute" ? scrollContainer?.current : null;
-      const cssW = host?.clientWidth || canvas.offsetWidth || window.innerWidth;
-      const cssH = host?.clientHeight || canvas.offsetHeight || window.innerHeight;
+      // In fixed mode the canvas fills the viewport. Measure the viewport directly, not
+      // canvas.offsetWidth — the inline width/height set below pin the canvas to its last
+      // size, so reading it back makes every subsequent resize a no-op.
+      const cssW = host?.clientWidth || window.innerWidth;
+      const cssH = host?.clientHeight || window.innerHeight;
       canvas.width = cssW * dpr;
       canvas.height = cssH * dpr;
       canvas.style.width = cssW + "px";


### PR DESCRIPTION
## What

Five hardening/perf fixes across the export path and the scroll engine.

- **#226** — `POST /api/export-site` capped frameCount, customCss, customHead, etc. but not the request body, so `sections` could amplify ~190x. Cap the raw body (413 before parse) and the section payload (400: >200 sections or >1 MB serialized). DB-loaded sections are already bounded at save time.
- **#284** — the editor read an uploaded audio file into a base64 data URL in React state with no cap. Reject files over 8 MB before reading.
- **#201** — `ScrollEngine`'s fixed-mode resize read `canvas.offsetWidth`, which the inline width/height it sets pin to the last size — so every window resize was a no-op. Measure the viewport directly (the absolute/simulator path already uses the container).
- **#283** — `JSZip` was a static top-level import in the editor, shipped in its first-load bundle for a path only hit on Export click. Now `await import("jszip")` inside `handleExport`.
- **#255** — the export hidden-section filter and all-hidden 400 ran in tests but nothing asserted them; added assertions (plus the #226 cap).

## Verified

- `tsc`, `eslint`, `next build` clean; full suite **317 passed**. The #226 cap test fails when the guard is reverted (checked); the hidden-section test asserts both the HTML exclusion and the corrected total scroll height (2000px).

Fixes #226
Fixes #284
Fixes #201
Fixes #283
Fixes #255