### PR TITLE
Run the test suite in CI; make two test files actually test this codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+# Gates every pull request and every push to main on the same three checks the watchdog
+# runs against the codebase: typecheck, lint, and the test suite. The watchdog catches a
+# break after it lands; this stops it landing.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      # `prisma generate` runs on postinstall, so the generated client the typecheck
+      # needs is present without a separate step.
+      - name: Install
+        run: npm ci
+      - name: Typecheck
+        run: npx tsc --noEmit
+      - name: Lint
+        run: npx eslint
+      - name: Test
+        run: npm test

--- a/src/__tests__/payments.test.ts
+++ b/src/__tests__/payments.test.ts
@@ -1,60 +1,112 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import crypto from "crypto";
+import type { NextRequest } from "next/server";
 
-// Test the HMAC verification logic used in verify/route.ts and webhooks/razorpay/route.ts
-describe("Payment HMAC verification", () => {
-  it("accepts a valid Razorpay payment signature", () => {
-    const secret = "test_secret";
-    const orderId = "order_123";
-    const paymentId = "pay_456";
+// The signature check in POST /api/payments/verify compares buffer lengths before it
+// calls timingSafeEqual, because timingSafeEqual THROWS on a length mismatch. Without
+// that guard a caller sending a short or non-hex signature gets a 500 out of the catch
+// block instead of a 400, which reads as a server fault rather than a rejected payment.
+// These exercise the real route; the HMAC primitive itself is Node's, not ours, to test.
 
-    const expected = crypto
-      .createHmac("sha256", secret)
-      .update(`${orderId}|${paymentId}`)
-      .digest("hex");
+const dbMock = vi.hoisted(() => ({
+  user: { findUnique: vi.fn(), update: vi.fn() },
+  payment: { findUnique: vi.fn(), updateMany: vi.fn() },
+}));
+const authMock = vi.hoisted(() => vi.fn());
+const rateLimitMock = vi.hoisted(() => vi.fn());
 
-    const isValid = crypto.timingSafeEqual(
-      Buffer.from(expected),
-      Buffer.from(expected)
-    );
-    expect(isValid).toBe(true);
+vi.mock("@/lib/db", () => ({ db: dbMock }));
+vi.mock("@/auth", () => ({ auth: authMock }));
+vi.mock("@/lib/rateLimit", () => ({ rateLimit: rateLimitMock, getClientIp: () => "1.2.3.4" }));
+
+const KEY_SECRET = "rzp_secret";
+
+type Verify = typeof import("../app/api/payments/verify/route").POST;
+let verify: Verify;
+
+function req(body: unknown): NextRequest {
+  return new Request("https://scrollcraft.app/api/payments/verify", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+const ORDER = "order_123";
+const PAYMENT = "pay_456";
+
+function validSignature(secret = KEY_SECRET): string {
+  return crypto.createHmac("sha256", secret).update(`${ORDER}|${PAYMENT}`).digest("hex");
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  process.env.RAZORPAY_KEY_SECRET = KEY_SECRET;
+  rateLimitMock.mockResolvedValue({ allowed: true });
+  authMock.mockResolvedValue({ user: { email: "a@b.c" } });
+  dbMock.user.findUnique.mockResolvedValue({ id: "u1" });
+  ({ POST: verify } = await import("../app/api/payments/verify/route"));
+});
+
+afterEach(() => {
+  delete process.env.RAZORPAY_KEY_SECRET;
+});
+
+describe("POST /api/payments/verify — signature handling", () => {
+  it("400s a signature that is too short to compare, without reaching the payment row", async () => {
+    // A length mismatch is exactly the case that makes timingSafeEqual throw.
+    const res = await verify(req({ orderId: ORDER, paymentId: PAYMENT, signature: "abcd" }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid payment signature" });
+    expect(dbMock.payment.findUnique).not.toHaveBeenCalled();
   });
 
-  it("rejects a tampered payment signature", () => {
-    const secret = "test_secret";
-    const orderId = "order_123";
-    const paymentId = "pay_456";
-
-    const expected = crypto
-      .createHmac("sha256", secret)
-      .update(`${orderId}|${paymentId}`)
-      .digest("hex");
-
-    const tampered = expected.replace(/.$/, expected.endsWith("a") ? "b" : "a");
-
-    const isValid = crypto.timingSafeEqual(
-      Buffer.from(expected),
-      Buffer.from(tampered)
-    );
-    expect(isValid).toBe(false);
+  it("400s a non-hex signature rather than throwing a 500", async () => {
+    const res = await verify(req({
+      orderId: ORDER, paymentId: PAYMENT, signature: "zzzz not hex at all zzzz",
+    }));
+    expect(res.status).toBe(400);
+    expect(dbMock.payment.findUnique).not.toHaveBeenCalled();
   });
 
-  it("rejects a valid signature with wrong secret", () => {
-    const realSecret = "real_secret";
-    const wrongSecret = "wrong_secret";
-    const orderId = "order_123";
-    const paymentId = "pay_456";
+  it("400s a signature of the right length signed with the wrong secret", async () => {
+    const res = await verify(req({
+      orderId: ORDER, paymentId: PAYMENT, signature: validSignature("wrong_secret"),
+    }));
+    expect(res.status).toBe(400);
+    expect(dbMock.payment.findUnique).not.toHaveBeenCalled();
+  });
 
-    const withRealSecret = crypto
-      .createHmac("sha256", realSecret)
-      .update(`${orderId}|${paymentId}`)
+  it("400s a signature bound to a different order", async () => {
+    const otherOrder = crypto
+      .createHmac("sha256", KEY_SECRET)
+      .update(`order_999|${PAYMENT}`)
       .digest("hex");
+    const res = await verify(req({ orderId: ORDER, paymentId: PAYMENT, signature: otherOrder }));
+    expect(res.status).toBe(400);
+    expect(dbMock.payment.findUnique).not.toHaveBeenCalled();
+  });
 
-    const withWrongSecret = crypto
-      .createHmac("sha256", wrongSecret)
-      .update(`${orderId}|${paymentId}`)
-      .digest("hex");
+  it("400s a missing signature", async () => {
+    const res = await verify(req({ orderId: ORDER, paymentId: PAYMENT }));
+    expect(res.status).toBe(400);
+    expect(dbMock.payment.findUnique).not.toHaveBeenCalled();
+  });
 
-    expect(withRealSecret).not.toBe(withWrongSecret);
+  it("accepts a correctly signed request and goes on to look up the order", async () => {
+    dbMock.payment.findUnique.mockResolvedValue(null);
+    const res = await verify(req({ orderId: ORDER, paymentId: PAYMENT, signature: validSignature() }));
+    // 404 (no such order) proves the signature passed and the route moved on.
+    expect(res.status).toBe(404);
+    expect(dbMock.payment.findUnique).toHaveBeenCalledWith({ where: { razorpayOrderId: ORDER } });
+  });
+
+  it("503s when the gateway secret is unset, before any signature work", async () => {
+    delete process.env.RAZORPAY_KEY_SECRET;
+    vi.resetModules();
+    ({ POST: verify } = await import("../app/api/payments/verify/route"));
+    const res = await verify(req({ orderId: ORDER, paymentId: PAYMENT, signature: "x" }));
+    expect(res.status).toBe(503);
   });
 });

--- a/src/__tests__/rateLimit.test.ts
+++ b/src/__tests__/rateLimit.test.ts
@@ -1,10 +1,29 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 let rateLimit: typeof import("../lib/rateLimit").rateLimit;
 
+const savedEnv = {
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+
 beforeEach(async () => {
+  // This file covers the in-memory fallback specifically. With UPSTASH_* set in the
+  // environment the limiter takes the Redis path instead: the assertions below would
+  // either hit the network or quietly stop testing the fallback they name.
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  vi.spyOn(console, "warn").mockImplementation(() => {});
   vi.resetModules();
   ({ rateLimit } = await import("../lib/rateLimit"));
+});
+
+afterEach(() => {
+  if (savedEnv.url === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = savedEnv.url;
+  if (savedEnv.token === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = savedEnv.token;
+  vi.restoreAllMocks();
 });
 
 describe("rateLimit (in-memory fallback)", () => {


### PR DESCRIPTION
## What

- **#203** — no workflow ran the tests. `watchdog.yml` runs code checks on a schedule and on push-to-main, which catches a break *after* it lands. Added `ci.yml`: typecheck + lint + `npm test` on every PR and push to main, with `cancel-in-progress` concurrency.
- **#291** — `rateLimit.test.ts` names the in-memory fallback but takes the Redis path whenever `UPSTASH_*` is set in the environment. Verified: with those vars set, 3 of its 6 cases fail after 5s network timeouts each (21s total). Now cleared for the file and restored after.
- **#290** — `payments.test.ts` imported nothing from this repo. It built HMACs with Node's `crypto` and compared them to each other, including `timingSafeEqual(expected, expected)` — a value against itself. Replaced with tests of the verify route's actual invariant: the buffer-length check ahead of `timingSafeEqual`, which throws on a length mismatch and would otherwise surface as a 500.

## Verified

- All three CI steps green locally (`tsc`, `eslint`, `npm test`).
- Suite **317 → 321**.
- Both new test files proven to bite: removing the length-guard from `verify/route.ts` fails 2 of the new payment tests (and logs a 500); removing the env guard fails 3 rate-limit tests under `UPSTASH_*`.

Real signature *rejection* was already covered in `promoConsumption.test.ts:316`; these cover the malformed-input path that sat above it.

Fixes #203
Fixes #291
Fixes #290