### PR TITLE
Make marketing copy match what the product actually does

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ArrowRight, Sparkles, Zap, Globe, Users } from "lucide-react";
 import Navbar from "@/components/Navbar";
+import { PRESETS } from "@/lib/presets";
 
 const TEAM = [
   { name: "Harsh Singh", role: "Founder & Engineer", avatar: "HS", bio: "Building the future of no-code web experiences." },
@@ -57,8 +58,8 @@ export default function AboutPage() {
           </div>
           <div className="grid grid-cols-2 gap-4">
             {[
-              { value: "400+", label: "Frames per site" },
-              { value: "12", label: "Presets & counting" },
+              { value: "200", label: "Frames per site" },
+              { value: String(PRESETS.length), label: "Presets & counting" },
               { value: "<2s", label: "Load time target" },
               { value: "100%", label: "Code ownership" },
             ].map(s => (

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -52,7 +52,7 @@ const ENTRIES = [
     tagColor: "bg-emerald-500/15 text-emerald-400 border-emerald-500/30",
     changes: [
       { type: "new", text: "Initial public launch on Vercel" },
-      { type: "new", text: "Canvas-based ScrollEngine — 400+ frames, native browser scroll" },
+      { type: "new", text: "Canvas-based ScrollEngine — up to 200 frames, native browser scroll" },
       { type: "new", text: "/create — 3-step flow: prompt → configure → generate" },
       { type: "new", text: "/editor — full visual editor with sections, style, layout controls" },
       { type: "new", text: "AI video generation API — Luma AI + Runway ML with demo fallback" },

--- a/src/app/contact/layout.tsx
+++ b/src/app/contact/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+// page.tsx is a client component and so cannot export metadata itself. Without this the
+// route is in the sitemap but inherits the homepage title and description.
+export const metadata: Metadata = {
+  title: "Contact",
+  description: "Get in touch with ScrollCraft — questions, bug reports, feature requests, billing and partnership enquiries.",
+};
+
+export default function ContactLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import Navbar from "@/components/Navbar";
 import { planByKey } from "@/lib/plans";
+import { PRESETS } from "@/lib/presets";
 import { deleteFrames } from "@/lib/frameStorage";
 
 interface Site {
@@ -305,7 +306,7 @@ export default function DashboardPage() {
           <div className="grid md:grid-cols-3 gap-4">
             {[
               { icon: Plus, title: "Start from a template", desc: "Pick a ready-made scroll site", href: "/templates", color: "text-primary" },
-              { icon: Sparkles, title: "Browse presets", desc: "12 production-ready templates", href: "/presets", color: "text-violet-400" },
+              { icon: Sparkles, title: "Browse presets", desc: `${PRESETS.length} production-ready templates`, href: "/presets", color: "text-violet-400" },
               { icon: Zap, title: "Upgrade plan", desc: "Keep more websites saved", href: "/pricing", color: "text-amber-400" },
             ].map(action => (
               <Link key={action.title} href={action.href}>

--- a/src/app/launch/page.tsx
+++ b/src/app/launch/page.tsx
@@ -14,7 +14,7 @@ const FEATURES = [
   {
     icon: Sparkles,
     title: "Ready-made scroll templates",
-    desc: "Describe a visual vibe — noir cityscape, golden gradient, neon particles — and get 400+ canvas frames in seconds.",
+    desc: "Pick a style and palette — noir cityscape, golden gradient, neon particles — and get up to 200 canvas frames in seconds.",
   },
   {
     icon: Zap,
@@ -140,7 +140,7 @@ export default function LaunchPage() {
           </div>
 
           <p className="mt-4 text-sm text-muted-foreground">
-            7-day free trial · No credit card required · Deploy anywhere
+            Free plan, no time limit · No credit card required · Deploy anywhere
           </p>
         </div>
       </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { ArrowRight, Sparkles, Zap, Download, Play, Check } from "lucide-react";
 import Navbar from "@/components/Navbar";
 import StylePreview from "@/components/StylePreview";
-import { findPreset } from "@/lib/presets";
+import { findPreset, PRESETS } from "@/lib/presets";
 
 const DEMO_COUNT = 60;
 const demoFrames = Array.from({ length: DEMO_COUNT }, (_, i) => `/api/demo-frame?i=${i}&total=${DEMO_COUNT}`);
@@ -23,7 +23,7 @@ const getMobileHeroSnapshot = () => window.matchMedia(MOBILE_HERO_QUERY).matches
 const getMobileHeroServerSnapshot = () => true;
 
 const PIPELINE = [
-  { step: "01", title: "Pick a preset", desc: "Choose from 12+ production-ready templates across SaaS, agency, e-commerce, and more." },
+  { step: "01", title: "Pick a preset", desc: `Choose from ${PRESETS.length} production-ready templates across SaaS, agency, e-commerce, and more.` },
   { step: "02", title: "Pick a template", desc: "Browse ready-made scroll sites by category and open the one closest to what you want." },
   { step: "03", title: "Frames render in your browser", desc: "The template's palette and style are drawn to canvas locally — instant, and nothing leaves your machine." },
   { step: "04", title: "Tune colors & sections", desc: "Adjust the palette, frame count, and section content live in the editor — no rerendering, no waiting." },
@@ -162,7 +162,7 @@ export default function Home() {
         </div>
 
         <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
-          {["7-day free trial", "No credit card", "Deploy anywhere"].map((t) => (
+          {["Free plan, no time limit", "No credit card", "Deploy anywhere"].map((t) => (
             <div key={t} className="flex items-center gap-1.5">
               <Check className="w-3.5 h-3.5 text-primary" /> {t}
             </div>
@@ -186,7 +186,7 @@ export default function Home() {
       {/* Social proof strip */}
       <section className="py-10 border-y border-white/5 bg-white/2">
         <div className="max-w-5xl mx-auto px-6 flex flex-wrap items-center justify-center gap-8 text-muted-foreground text-sm">
-          {["400+ frames per site", "Sub-2s load time", "10–40 FPS", "Works on every device", "No WebGL required", "Deploy anywhere"].map((t) => (
+          {["Up to 200 frames per site", "Sub-2s load time", "10–40 FPS", "Works on every device", "No WebGL required", "Deploy anywhere"].map((t) => (
             <div key={t} className="flex items-center gap-2">
               <div className="w-1.5 h-1.5 rounded-full bg-primary" />
               {t}
@@ -247,7 +247,7 @@ export default function Home() {
         <div className="max-w-6xl mx-auto">
           <div className="flex items-end justify-between mb-12">
             <div>
-              <Badge variant="outline" className="mb-4 border-white/10">12 presets & counting</Badge>
+              <Badge variant="outline" className="mb-4 border-white/10">{PRESETS.length} presets & counting</Badge>
               <h2 className="text-4xl md:text-5xl font-black tracking-tighter">Start from a preset</h2>
               <p className="text-muted-foreground mt-3 max-w-lg">
                 Production-tested starters with finished scroll layouts, copy structure, and palettes.

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -26,10 +26,10 @@ const PLANS = [
       "1 saved website",
       "Publish to a hosted link, with a ScrollCraft badge",
       "Visual editor",
-      "ZIP export",
       "Community support",
     ],
     missing: [
+      "ZIP export included (buy per site, or upgrade)",
       "More than one saved website",
       "Badge-free published pages",
       "Priority support",
@@ -124,15 +124,15 @@ const PLANS = [
 const FAQ = [
   {
     q: "Are the templates really free?",
-    a: "Yes. Every template is available on every plan, including the free one, and you can export any site you build to a ZIP you own outright.",
+    a: "Yes. Every template is available on every plan, including the free one. Exporting a site to a ZIP you own outright is included on the paid plans, or you can buy an export for a single site.",
   },
   {
     q: "What do the paid plans actually add?",
-    a: "How many websites you can keep saved and published, badge-free published pages that search engines index, and how quickly we answer support. Nothing about the templates themselves is gated.",
+    a: "ZIP export without buying it per site, how many websites you can keep saved and published, badge-free published pages that search engines index, and how quickly we answer support. Nothing about the templates themselves is gated.",
   },
   {
     q: "Can I cancel anytime?",
-    a: "Yes. Cancel from your dashboard at any time — you keep access until the end of your billing period.",
+    a: "Yes. Email hello@scrollcraft.app to cancel — you keep access until the end of your billing period.",
   },
   {
     q: "What's the difference between monthly and annual?",
@@ -303,7 +303,7 @@ export default function PricingPage() {
           </span>
         </h1>
         <p className="text-muted-foreground text-lg max-w-xl mx-auto mb-10">
-          Every plan includes our full animated scroll engine, ZIP export, and canvas generation.
+          Every plan includes the full animated scroll engine and visual editor. ZIP export is included on every paid plan, or buy it per site.
         </p>
 
         {/* Billing toggle */}
@@ -489,7 +489,7 @@ export default function PricingPage() {
                 { label: "Published sites", values: ["1", "2", "4", "7", "30"] },
                 { label: "Badge-free pages", values: [false, true, true, true, true] },
                 { label: "Visual editor", values: [true, true, true, true, true] },
-                { label: "ZIP export", values: [true, true, true, true, true] },
+                { label: "ZIP export", values: [false, true, true, true, true] },
               ].map((row, i) => (
                 <tr key={row.label} className={`border-b border-white/5 ${i % 2 === 0 ? "" : "bg-white/2"}`}>
                   <td className="px-4 py-3 text-muted-foreground">{row.label}</td>
@@ -538,9 +538,9 @@ export default function PricingPage() {
       {/* Bottom CTA */}
       <section className="pb-24 px-6 text-center border-t border-white/5 pt-20">
         <h2 className="text-4xl font-black tracking-tighter mb-4">
-          7 days free. No card required.
+          Start free. No card required.
         </h2>
-        <p className="text-muted-foreground mb-8">Try the full Pro experience — upgrade only when you love it.</p>
+        <p className="text-muted-foreground mb-8">Every template, one saved website, no time limit.</p>
         <Link href="/create">
           <Button size="lg" className="bg-primary hover:bg-primary/90 text-white px-10 py-6 text-base font-semibold shadow-xl shadow-primary/30">
             Start for free <Sparkles className="ml-2 w-4 h-4" />


### PR DESCRIPTION
## What

Six issues, all "the site claims something the code does not do".

- **#286** — preset counts hardcoded as `12` in four places; the catalogue has **57**. Now derived from `PRESETS.length` (verified in built HTML: "Choose from 57 production-ready…", badge "57 presets & counting", about stat `57`).
- **#240** — "400+ frames per site" in four places. Real ceilings: generator slider maxes at **200**, `extract-frames` at **120**. Copy now says "up to 200".
- **#215** — **the product fork.** `/pricing` listed ZIP export as an included Free Trial feature and `true` in the Free comparison column, while `export-site` returns **402** for FREE users unless an `ExportPurchase` exists (`route.ts:99-112`). I fixed the **marketing**, not the paywall — the code already supports per-site purchase *and* paid plans, so this removes a false claim rather than giving away a paid feature. **This is copy-only and trivially reversible** — if you'd rather make export genuinely free, say so and I'll flip the gate instead.
- **#243** — dropped "canvas generation" (not a feature), corrected the FAQ's promise of dashboard self-serve cancellation (no such control exists), and replaced the bottom-CTA "7 days free" claim.
- **#253 / #282** — `/contact` is in the sitemap but is a client component with no layout, so it inherited the homepage title/description. Added `contact/layout.tsx`; built HTML now shows `<title>Contact | ScrollCraft</title>` and its own description. The `/showcase` half of both issues is moot — that route was deleted and is not in the sitemap.

Also removed the phantom **"7-day free trial"** from the homepage and `/launch`: `FREE` has no expiry, it is a permanent one-site plan.

## Changelog policy

Amended the dated changelog entry claiming "400+ frames" (a capability that was never true) but left "Presets gallery — 12 production-ready templates" alone: that was accurate for v0.3.0, and dated history should not be rewritten.

## Verified

- `tsc`, `eslint`, `next build`, suite **321 passed**.
- Claims checked against the built HTML rather than the source, after catching a shell-escaping bug that had silently emptied one interpolation.

Fixes #286
Fixes #240
Fixes #243
Fixes #215
Fixes #253
Fixes #282