### PR TITLE
Fix four runtime faults: client Sentry, Vercel temp dir, scroll sync, param fallbacks

### DIFF
--- a/src/__tests__/demoFrame.test.ts
+++ b/src/__tests__/demoFrame.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import type { NextRequest } from "next/server";
+import { GET } from "@/app/api/demo-frame/route";
+
+function get(query: string): NextRequest {
+  return new Request(`https://scrollcraft.app/api/demo-frame${query}`) as unknown as NextRequest;
+}
+
+async function svg(query: string): Promise<string> {
+  const res = await GET(get(query));
+  expect(res.status).toBe(200);
+  return res.text();
+}
+
+// `total` defaults to 120 and drives `p = i / (total - 1)`, which sets every colour and
+// coordinate in the document. When an absent or empty `total` wrongly resolves to 0 it is
+// then clamped up to the minimum of 1, and `p` collapses to 1 for any non-zero `i` — so
+// the whole animation pins to its last frame. Comparing an absent param against an empty
+// one cannot catch that (both collapse the same way); each must be compared against the
+// explicit value the fallback is documented to mean.
+const EXPLICIT_DEFAULT = "?i=60&total=120";
+
+describe("GET /api/demo-frame parameter handling", () => {
+  it("never emits NaN into the document", async () => {
+    for (const q of ["", "?i=abc&total=xyz", "?i=&total=", "?i=1e999", "?total=0"]) {
+      expect(await svg(q)).not.toContain("NaN");
+    }
+  });
+
+  it("applies the documented total fallback when the param is absent", async () => {
+    expect(await svg("?i=60")).toBe(await svg(EXPLICIT_DEFAULT));
+  });
+
+  it("applies the documented total fallback when the param is empty", async () => {
+    expect(await svg("?i=60&total=")).toBe(await svg(EXPLICIT_DEFAULT));
+  });
+
+  it("applies the documented total fallback when the param is whitespace", async () => {
+    expect(await svg("?i=60&total=%20")).toBe(await svg(EXPLICIT_DEFAULT));
+  });
+
+  it("applies the documented total fallback on non-numeric input", async () => {
+    expect(await svg("?i=60&total=abc")).toBe(await svg(EXPLICIT_DEFAULT));
+  });
+
+  it("renders a different frame for a different index", async () => {
+    expect(await svg("?i=60&total=120")).not.toBe(await svg("?i=0&total=120"));
+  });
+
+  it("clamps out-of-range values instead of rejecting them", async () => {
+    expect(await svg("?i=-5&total=120")).toBe(await svg("?i=0&total=120"));
+    expect(await svg("?total=99999&i=0")).toBe(await svg("?total=1000&i=0"));
+  });
+
+  it("caps the frame index at the total", async () => {
+    expect(await svg("?i=500&total=10")).toBe(await svg("?i=10&total=10"));
+  });
+});

--- a/src/app/api/demo-frame/route.ts
+++ b/src/app/api/demo-frame/route.ts
@@ -5,6 +5,9 @@ export async function GET(req: NextRequest) {
   // Unvalidated params reached the SVG as NaN ("hsl(NaN,65%,15%)", cx="NaN"), producing an
   // unrenderable image that was then cached for an hour.
   const clamp = (raw: string | null, fallback: number, min: number, max: number) => {
+    // Number(null) and Number("") are both 0, which is finite — so without this guard an
+    // absent or empty param silently became 0 instead of taking the documented fallback.
+    if (raw === null || raw.trim() === "") return fallback;
     const n = Number(raw);
     return Number.isFinite(n) ? Math.min(Math.max(Math.trunc(n), min), max) : fallback;
   };

--- a/src/app/api/extract-frames/route.ts
+++ b/src/app/api/extract-frames/route.ts
@@ -12,6 +12,7 @@ import { isIPv4, isIPv6 } from "net";
 import http from "http";
 import https from "https";
 import { randomUUID } from "crypto";
+import os from "os";
 import { pipeline } from "stream/promises";
 import { auth } from "@/auth";
 import { rateLimit } from "@/lib/rateLimit";
@@ -246,7 +247,7 @@ export async function POST(req: NextRequest) {
   }
 
   const contentType = req.headers.get("content-type") || "";
-  const tmpDir = path.join(process.cwd(), "tmp", `frames-${Date.now()}-${randomUUID()}`);
+  const tmpDir = path.join(os.tmpdir(), `frames-${Date.now()}-${randomUUID()}`);
 
   try {
     await mkdir(tmpDir, { recursive: true });

--- a/src/components/ScrollEngine.tsx
+++ b/src/components/ScrollEngine.tsx
@@ -151,6 +151,10 @@ export default function ScrollEngine({ frames, mobileFrames, totalScrollHeight =
     };
 
     el.addEventListener("scroll", handleScroll, { passive: true });
+    // Sync to the offset the page already has. Without this the canvas paints frame 0 on
+    // mount, so a restored scroll position, a #hash landing, or a back-navigation shows a
+    // background that does not match where the reader actually is.
+    handleScroll();
     return () => el.removeEventListener("scroll", handleScroll);
   }, [activeFrames.length, totalScrollHeight, drawFrame, onFrameChange, scrollContainer]);
 

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -6,3 +6,7 @@ Sentry.init({
   debug: false,
   enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
 });
+
+// Next 16 calls this on client-side navigations. Without it, router transitions are
+// missing from traces even once the SDK is loading.
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
## What

- **#192** — `sentry.client.config.ts` was dead code: nothing imported it, and Next 16 loads browser instrumentation from `src/instrumentation-client.ts`, which did not exist. **No client-side error or trace has ever reached Sentry.** Moved the init there and exported `onRouterTransitionStart` (Next 16's navigation hook). Verified Sentry now appears in the built client chunks.
- **#206** — `extract-frames` built its temp dir under `process.cwd()`, read-only on Vercel, so `mkdir` threw `EROFS` and **every** extraction fell into the catch and returned a generic 500 in production. Now `os.tmpdir()`; the existing `finally { rm(...) }` cleanup stays correct.
- **#249** — `ScrollEngine` attached its scroll listener but never invoked it, so the canvas painted frame 0 on mount regardless of actual offset — visible on restored scroll positions, `#hash` landings, and back-navigation. Calls the handler once after attaching; the existing `preloadImages` redraw covers the async-decode case.
- **#277** — `demo-frame`'s clamp called `Number()` first, but `Number(null)` and `Number("")` are both `0` — finite — so an absent or empty param skipped its documented fallback, clamped up to the minimum of 1, and collapsed `p` to 1, pinning the animation to one frame.

## Verified

- `tsc`, `eslint`, `next build` clean; suite **321 → 329**.
- New `demoFrame` suite proven to bite: **3 tests fail** when the guard is reverted.
  My first draft of those tests passed against the broken code — comparing an absent param against an empty one proves nothing, because the bug collapses both to the same wrong value. Rewrote them to compare each against the explicit value the fallback is documented to mean.

Fixes #192
Fixes #206
Fixes #249
Fixes #277