### PR TITLE
Stop the create and export flows lying about what they are doing

### DIFF
--- a/src/__tests__/extractFrames.test.ts
+++ b/src/__tests__/extractFrames.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const authMock = vi.hoisted(() => vi.fn());
+const rateLimitMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/auth", () => ({ auth: authMock }));
+vi.mock("@/lib/rateLimit", () => ({ rateLimit: rateLimitMock, getClientIp: () => "1.2.3.4" }));
+// The route promisifies execFile from node:child_process; make the ffmpeg probe fail.
+vi.mock("util", async (orig) => {
+  const actual = await orig<typeof import("util")>();
+  return { ...actual, promisify: () => execFileMock };
+});
+vi.mock("fs/promises", async (orig) => {
+  const actual = await orig<typeof import("fs/promises")>();
+  return {
+    ...actual,
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    rm: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+type Handler = typeof import("../app/api/extract-frames/route").POST;
+let POST: Handler;
+
+function jsonReq(body: unknown): NextRequest {
+  return new Request("https://scrollcraft.app/api/extract-frames", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+function uploadReq(fd: FormData): NextRequest {
+  return new Request("https://scrollcraft.app/api/extract-frames", {
+    method: "POST",
+    body: fd,
+  }) as unknown as NextRequest;
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  authMock.mockResolvedValue({ user: { id: "u1", email: "a@b.c" } });
+  rateLimitMock.mockResolvedValue({ allowed: true });
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  ({ POST } = await import("../app/api/extract-frames/route"));
+});
+
+describe("POST /api/extract-frames", () => {
+  it("rejects an unauthenticated caller", async () => {
+    authMock.mockResolvedValue(null);
+    const res = await POST(jsonReq({ videoUrl: "https://example.com/a.mp4" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("429s when rate limited", async () => {
+    rateLimitMock.mockResolvedValue({ allowed: false });
+    const res = await POST(jsonReq({ videoUrl: "https://example.com/a.mp4" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("400s a request with no videoUrl", async () => {
+    const res = await POST(jsonReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("400s an unparseable videoUrl", async () => {
+    const res = await POST(jsonReq({ videoUrl: "not a url" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid/i);
+  });
+
+  it("400s an upload with no video file", async () => {
+    const fd = new FormData();
+    const res = await POST(uploadReq(fd));
+    expect(res.status).toBe(400);
+  });
+
+  // Regression: with ffmpeg missing this used to return 200 with synthetic
+  // /api/demo-frame URLs, so the uploaded video was silently swapped for a generic
+  // gradient and the user only found out at export time.
+  it("fails loudly instead of substituting placeholder demo frames when ffmpeg is missing", async () => {
+    execFileMock.mockRejectedValue(new Error("ffmpeg: not found"));
+    const fd = new FormData();
+    fd.append("video", new File([new Uint8Array([1, 2, 3, 4])], "clip.mp4", { type: "video/mp4" }));
+
+    const res = await POST(uploadReq(fd));
+    const body = await res.text();
+
+    expect(res.status).toBe(503);
+    expect(body).toContain("FFMPEG_UNAVAILABLE");
+    expect(body).not.toContain("/api/demo-frame");
+    expect(body).not.toContain('"demo":true');
+  });
+});

--- a/src/app/api/extract-frames/route.ts
+++ b/src/app/api/extract-frames/route.ts
@@ -294,14 +294,19 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const hasFFmpeg = await ffmpegAvailable();
-    if (!hasFFmpeg) {
-      // Demo fallback — return placeholder frame URLs
-      const frameCount = fps * 8;
-      const frames = Array.from({ length: frameCount }, (_, i) =>
-        `/api/demo-frame?i=${i}&total=${frameCount}`
+    // Fail loudly rather than substituting placeholders. This used to return 200 with
+    // synthetic /api/demo-frame URLs, so an uploaded video was silently replaced by a
+    // generic gradient — the user reached the editor believing their footage had been
+    // processed, and only discovered otherwise on export.
+    if (!(await ffmpegAvailable())) {
+      logger.error("extract-frames: ffmpeg unavailable, refusing to substitute placeholders");
+      return NextResponse.json(
+        {
+          error: "Video processing is unavailable on this server. Generate a background from a style instead.",
+          code: "FFMPEG_UNAVAILABLE",
+        },
+        { status: 503 }
       );
-      return NextResponse.json({ frames, frameCount, demo: true });
     }
 
     const framesDir = path.join(tmpDir, "frames");

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -122,8 +122,21 @@ function CreatePageInner() {
       formData.append("fps", "24");
       formData.append("quality", "80");
       const res = await fetch("/api/extract-frames", { method: "POST", body: formData });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || "Extraction failed");
+      // A failed upload does not always carry a JSON body: a 413 from the platform or a
+      // 502 from the proxy is an HTML page, and res.json() then threw a SyntaxError that
+      // was shown to the user verbatim in place of the real reason.
+      const raw = await res.text();
+      let data: { error?: string; frames?: string[]; frameCount?: number } = {};
+      try { data = raw ? JSON.parse(raw) : {}; } catch { /* handled below */ }
+      if (!res.ok) {
+        throw new Error(
+          data.error ||
+          (res.status === 413
+            ? "That video is too large — try a shorter or smaller file."
+            : `Extraction failed (${res.status})`)
+        );
+      }
+      if (!data.frames?.length) throw new Error("Extraction failed — no frames were returned.");
       setProgress(100);
       await storeFrames("scrollcraft_desktop_frames", data.frames);
 
@@ -141,6 +154,11 @@ function CreatePageInner() {
     }
   };
 
+  // Always points at the current render's handleGenerate, so the key listener below can
+  // stay bound to step/isGenerating without capturing stale generation options.
+  const generateRef = useRef(handleGenerate);
+  useEffect(() => { generateRef.current = handleGenerate; });
+
   // Enter advances Style → Configure → Generate (ignored while typing in a field)
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -148,11 +166,13 @@ function CreatePageInner() {
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA") return;
       if (step === 0) { e.preventDefault(); setStep(1); }
-      else if (step === 1) { e.preventDefault(); handleGenerate(); }
+      // Through a ref: the listener is only rebound when step/isGenerating change, so
+      // calling handleGenerate directly ran the closure captured back then — generating
+      // with whatever palette, frame count and mobile toggle were set at that moment.
+      else if (step === 1) { e.preventDefault(); generateRef.current(); }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step, isGenerating]);
 
   const VIDEO_RE = /^video\//;

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -112,6 +112,10 @@ function EditorInner() {
   }, [frameCount]);
   const [showPreview, setShowPreview] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
+  // A ZIP export runs for tens of seconds — a template fetch, a sequential fetch per
+  // frame, then compression — behind a single spinner. Name the current stage so the
+  // wait reads as progress rather than a hang.
+  const [exportStage, setExportStage] = useState<string | null>(null);
   const [isDemo, setIsDemo] = useState(initialIsDemo);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [customHead, setCustomHead] = useState("");
@@ -126,6 +130,11 @@ function EditorInner() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const [viewportMode, setViewportMode] = useState<"desktop" | "tablet" | "mobile">("desktop");
+  // The device simulator sizes its scroll port to the emulated device, but the overlays
+  // inside it were pinned to 100vh — the browser window — so in mobile/tablet every
+  // section was taller than the frame it sat in and the preview drifted out of step with
+  // the published result. Measure the port instead.
+  const [previewViewportH, setPreviewViewportH] = useState(0);
   const [audioSrc, setAudioSrc] = useState<string | null>(null);
   const [siteId, setSiteId] = useState<string | null>(searchParams.get("siteId"));
   // Background recipe and theme travel with the site so the published page and the export
@@ -140,6 +149,16 @@ function EditorInner() {
   );
   const [isSaving, setIsSaving] = useState(false);
   const [audioMuted, setAudioMuted] = useState(false);
+
+  useEffect(() => {
+    const el = previewScrollRef.current;
+    if (!el) return;
+    const measure = () => setPreviewViewportH(el.clientHeight);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [showPreview, viewportMode]);
 
   // Load desktop frames from IndexedDB (primary store; sessionStorage was too small at 5 MB)
   useEffect(() => {
@@ -478,6 +497,7 @@ function EditorInner() {
         if (checkoutData.alreadyPurchased) {
           toast.info("Purchase confirmed — preparing your download…");
           setIsExporting(false);
+      setExportStage(null);
           return handleExport();
         }
         if (checkoutRes.status === 503) {
@@ -501,6 +521,7 @@ function EditorInner() {
 
       // Build ZIP entirely in the browser — no round-trip for large frame data. Load
       // JSZip on demand so it stays out of the editor's first-load bundle.
+      setExportStage("Building ZIP…");
       toast.info("Building ZIP…");
       const { default: JSZip } = await import("jszip");
       const zip = new JSZip();
@@ -522,6 +543,11 @@ function EditorInner() {
 
       const framesFolder = zip.folder("frames")!;
       for (let i = 0; i < frames.length; i++) {
+        if (i % 10 === 0) {
+          setExportStage(`Packing frames ${i + 1}/${frames.length}…`);
+          // Yield so React can paint the updated label between fetches.
+          await new Promise((r) => setTimeout(r, 0));
+        }
         const src = frames[i];
         const name = `frame_${String(i).padStart(4, "0")}.jpg`;
         if (src.startsWith("data:image/")) {
@@ -535,6 +561,10 @@ function EditorInner() {
       if (mobileFrames.length) {
         const mobileFolder = zip.folder("frames-mobile")!;
         for (let i = 0; i < mobileFrames.length; i++) {
+          if (i % 10 === 0) {
+            setExportStage(`Packing mobile frames ${i + 1}/${mobileFrames.length}…`);
+            await new Promise((r) => setTimeout(r, 0));
+          }
           const src = mobileFrames[i];
           const name = `frame_${String(i).padStart(4, "0")}.jpg`;
           if (src.startsWith("data:image/")) {
@@ -550,7 +580,9 @@ function EditorInner() {
         zip.file(`audio/track.${audioExt}`, audioBase64, { base64: true });
       }
 
-      const blob = await zip.generateAsync({ type: "blob", compression: "STORE" });
+      const blob = await zip.generateAsync({ type: "blob", compression: "STORE" }, (m) => {
+        setExportStage(`Compressing ${Math.round(m.percent)}%…`);
+      });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
@@ -562,6 +594,7 @@ function EditorInner() {
       toast.error(String(err));
     } finally {
       setIsExporting(false);
+      setExportStage(null);
     }
   };
 
@@ -773,11 +806,17 @@ function EditorInner() {
             size="sm"
             onClick={handleExport}
             disabled={isExporting}
+            title={exportStage ?? undefined}
             className="bg-primary hover:bg-primary/90 text-white h-7 px-3 text-xs font-semibold"
           >
             {isExporting ? <Loader2 className="w-3.5 h-3.5 animate-spin mr-1" /> : <Download className="w-3.5 h-3.5 mr-1" />}
             Export
           </Button>
+          {isExporting && exportStage && (
+            <span role="status" aria-live="polite" className="text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+              {exportStage}
+            </span>
+          )}
         </div>
       </div>
 
@@ -862,7 +901,7 @@ function EditorInner() {
                 />
                 {/* Section overlays */}
                 <div className="relative z-10" style={{ height: totalScrollHeight }}>
-                  <div style={{ height: "100vh" }} />
+                  <div style={{ height: previewViewportH || "100vh" }} />
                   {sections.filter(s => s.visible).map((s) => (
                     <div
                       key={s.id}
@@ -884,7 +923,7 @@ function EditorInner() {
                       <div style={{
                         position: "sticky",
                         top: 0,
-                        height: "100vh",
+                        height: previewViewportH || "100vh",
                         display: "flex",
                         alignItems: s.align || "center",
                         justifyContent: s.justify || "center",


### PR DESCRIPTION
## What

Five UX issues, three of which actively misled the user.

- **#239** — uploading a video to a server without ffmpeg returned **200** plus synthetic `/api/demo-frame` URLs. The user's footage was silently swapped for a generic gradient, and they only found out at export. Now `503 FFMPEG_UNAVAILABLE`.
- **#267** — an upload error with a non-JSON body (a platform 413, an HTML 502) made `res.json()` throw, and the raw `SyntaxError` was toasted at the user instead of the real reason. Body is now read as text and parsed defensively, with a specific message for 413.
- **#213** — Enter on the Configure step called a `handleGenerate` closure captured when `step`/`isGenerating` last changed, so it generated with a **stale palette, frame count, and mobile toggle**. Now calls through a ref tracking the current render, and the `exhaustive-deps` suppression is gone.
- **#235** — the device simulator sizes its scroll port to the emulated device, but the overlays inside stayed at `100vh` (the browser window), so every section was taller than the frame containing it and mobile/tablet previews drifted out of step with the published result. Now measured via `ResizeObserver`.
- **#224** — a ZIP export runs for tens of seconds (template fetch, a sequential fetch per frame, compression) behind a single spinner. Now reports the stage — "Packing frames 40/120…", "Compressing 62%…" — in an `aria-live` status, yielding so React can paint.

## Verified

- `tsc`, `eslint`, `next build` clean; suite **351 → 357**.
- New `extractFrames` suite; the placeholder regression test is proven to fail when #239 is reverted.
  My first version of that test passed against the broken code — the `videoUrl` path fails at download before ever reaching the ffmpeg check, so it never exercised the branch. Rewrote it to go through the multipart upload path, which does.
- The ref fix initially tripped the React Compiler rule against writing a ref during render; moved into an unconditional effect.

Fixes #239
Fixes #267
Fixes #213
Fixes #235
Fixes #224