### PR TITLE
Cover the SSRF guard, sites API and export checkout; fix exported audio and canvas

### DIFF
--- a/src/__tests__/exportSectionParity.test.ts
+++ b/src/__tests__/exportSectionParity.test.ts
@@ -217,3 +217,51 @@ describe("exported head and resilience", () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe("exported page accessibility and audio", () => {
+  it("gives the background canvas an accessible name, like the in-app engine does", async () => {
+    const html = await exportHtml([{ heading: "A", scrollHeight: 1000 }]);
+    expect(html).toMatch(/<canvas id="scroll-canvas"[^>]*role="img"/);
+    expect(html).toMatch(/<canvas id="scroll-canvas"[^>]*aria-label="[^"]+"/);
+  });
+
+  it("names the canvas after the site when there is a site name", async () => {
+    const res = await POST(exportRequest({
+      sections: [{ heading: "A", scrollHeight: 1000 }],
+      siteName: "Orrery", frameCount: 10, fps: 24,
+    }));
+    const html = (await res.json()).html as string;
+    expect(html).toContain('aria-label="Orrery animated scroll background"');
+  });
+
+  it("escapes a hostile site name in the canvas label", async () => {
+    const res = await POST(exportRequest({
+      sections: [{ heading: "A", scrollHeight: 1000 }],
+      siteName: '"><script>alert(1)</script>', frameCount: 10, fps: 24,
+    }));
+    const html = (await res.json()).html as string;
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
+  it("routes audio gain through WebAudio so the ramp is not a no-op on iOS", async () => {
+    const res = await POST(exportRequest({
+      sections: [{ heading: "A", scrollHeight: 1000 }],
+      siteName: "A", frameCount: 10, fps: 24, hasAudio: true,
+    }));
+    const html = (await res.json()).html as string;
+    expect(html).toContain("createMediaElementSource");
+    expect(html).toContain("createGain");
+    // Every volume change must go through the helper, not the ignored element property.
+    expect(html).not.toMatch(/audio\.volume\s*=\s*targetVol/);
+    expect(html).toContain("setVol(targetVol)");
+  });
+
+  it("resumes a suspended AudioContext on the first scroll gesture", async () => {
+    const res = await POST(exportRequest({
+      sections: [{ heading: "A", scrollHeight: 1000 }],
+      siteName: "A", frameCount: 10, fps: 24, hasAudio: true,
+    }));
+    const html = (await res.json()).html as string;
+    expect(html).toContain("ctx.resume()");
+  });
+});

--- a/src/__tests__/lsCheckout.test.ts
+++ b/src/__tests__/lsCheckout.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+// This endpoint stands between a user and a second charge for something they already
+// own. The guards that matter: an existing PAID purchase short-circuits, an in-flight
+// PENDING checkout is reused rather than duplicated, and a site the caller does not own
+// is never chargeable.
+
+const dbMock = vi.hoisted(() => ({
+  site: { findUnique: vi.fn() },
+  exportPurchase: { findFirst: vi.fn(), create: vi.fn() },
+}));
+const authMock = vi.hoisted(() => vi.fn());
+const rateLimitMock = vi.hoisted(() => vi.fn());
+const createExportCheckout = vi.hoisted(() => vi.fn());
+const getExportCheckoutUrl = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({ db: dbMock }));
+vi.mock("@/auth", () => ({ auth: authMock }));
+vi.mock("@/lib/rateLimit", () => ({ rateLimit: rateLimitMock, getClientIp: () => "1.2.3.4" }));
+vi.mock("@/lib/lemonsqueezy", () => ({ createExportCheckout, getExportCheckoutUrl }));
+vi.mock("@/lib/env", () => ({
+  env: {
+    LEMONSQUEEZY_API_KEY: "key",
+    LEMONSQUEEZY_STORE_ID: "1",
+    LEMONSQUEEZY_VARIANT_ID: "2",
+  },
+}));
+
+type Handler = typeof import("../app/api/payments/ls-checkout/route").POST;
+let POST: Handler;
+
+function req(body: unknown): NextRequest {
+  return new Request("https://scrollcraft.app/api/payments/ls-checkout", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  rateLimitMock.mockResolvedValue({ allowed: true });
+  authMock.mockResolvedValue({ user: { id: "u1", email: "a@b.c" } });
+  dbMock.site.findUnique.mockResolvedValue({ id: "s1", name: "Launch" });
+  dbMock.exportPurchase.findFirst.mockResolvedValue(null);
+  dbMock.exportPurchase.create.mockResolvedValue({ id: "ep1" });
+  createExportCheckout.mockResolvedValue({ checkoutUrl: "https://ls.example/co/abc", checkoutId: "co_abc" });
+  getExportCheckoutUrl.mockResolvedValue("https://ls.example/co/existing");
+  ({ POST } = await import("../app/api/payments/ls-checkout/route"));
+});
+
+describe("POST /api/payments/ls-checkout — access control", () => {
+  it("429s when rate limited, before authenticating", async () => {
+    rateLimitMock.mockResolvedValue({ allowed: false });
+    expect((await POST(req({ siteId: "s1" }))).status).toBe(429);
+    expect(createExportCheckout).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    authMock.mockResolvedValue(null);
+    expect((await POST(req({ siteId: "s1" }))).status).toBe(401);
+    expect(createExportCheckout).not.toHaveBeenCalled();
+  });
+
+  it("404s a site the caller does not own, and never opens a checkout", async () => {
+    dbMock.site.findUnique.mockResolvedValue(null);
+    const res = await POST(req({ siteId: "someone-elses" }));
+    expect(res.status).toBe(404);
+    expect(createExportCheckout).not.toHaveBeenCalled();
+  });
+
+  it("scopes the site lookup to the caller", async () => {
+    await POST(req({ siteId: "s1" }));
+    expect(dbMock.site.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "s1", userId: "u1" } })
+    );
+  });
+
+  it("400s a malformed body", async () => {
+    expect((await POST(req("{ not json"))).status).toBe(400);
+  });
+
+  it("400s a missing siteId", async () => {
+    expect((await POST(req({}))).status).toBe(400);
+    expect(createExportCheckout).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/payments/ls-checkout — never charge twice", () => {
+  it("short-circuits when the export is already paid for", async () => {
+    dbMock.exportPurchase.findFirst.mockResolvedValueOnce({ id: "ep_paid", status: "PAID" });
+
+    const res = await POST(req({ siteId: "s1" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ alreadyPurchased: true });
+    expect(createExportCheckout).not.toHaveBeenCalled();
+  });
+
+  it("reuses an in-flight checkout instead of opening a second one", async () => {
+    dbMock.exportPurchase.findFirst
+      .mockResolvedValueOnce(null) // no PAID row
+      .mockResolvedValueOnce({ lsCheckoutId: "co_existing" }); // a live PENDING one
+
+    const res = await POST(req({ siteId: "s1" }));
+
+    expect(await res.json()).toEqual({
+      checkoutUrl: "https://ls.example/co/existing",
+      pending: true,
+    });
+    expect(createExportCheckout).not.toHaveBeenCalled();
+  });
+
+  it("opens a fresh checkout when the pending one can no longer be resolved", async () => {
+    dbMock.exportPurchase.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ lsCheckoutId: "co_stale" });
+    getExportCheckoutUrl.mockRejectedValue(new Error("gone"));
+
+    const res = await POST(req({ siteId: "s1" }));
+
+    expect((await res.json()).checkoutUrl).toBe("https://ls.example/co/abc");
+    expect(createExportCheckout).toHaveBeenCalledTimes(1);
+  });
+
+  it("only counts a PENDING checkout that is still inside its TTL", async () => {
+    await POST(req({ siteId: "s1" }));
+    const pendingQuery = dbMock.exportPurchase.findFirst.mock.calls[1][0];
+    expect(pendingQuery.where.status).toBe("PENDING");
+    expect(pendingQuery.where.createdAt.gte).toBeInstanceOf(Date);
+  });
+
+  it("records the in-flight checkout so a repeat request is guarded", async () => {
+    await POST(req({ siteId: "s1" }));
+    expect(dbMock.exportPurchase.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "u1", siteId: "s1", status: "PENDING", lsCheckoutId: "co_abc",
+        }),
+      })
+    );
+  });
+
+  it("prefixes the placeholder order id so it cannot collide with a real one", async () => {
+    await POST(req({ siteId: "s1" }));
+    const { lsOrderId } = dbMock.exportPurchase.create.mock.calls[0][0].data;
+    expect(lsOrderId).toBe("pending:co_abc");
+    expect(lsOrderId).not.toMatch(/^\d+$/);
+  });
+
+  it("still returns the checkout when recording the guard row fails", async () => {
+    dbMock.exportPurchase.create.mockRejectedValue(new Error("db down"));
+    const res = await POST(req({ siteId: "s1" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).checkoutUrl).toBe("https://ls.example/co/abc");
+  });
+
+  it("500s when the checkout cannot be created", async () => {
+    createExportCheckout.mockRejectedValue(new Error("LS down"));
+    expect((await POST(req({ siteId: "s1" }))).status).toBe(500);
+  });
+});

--- a/src/__tests__/sitesRoute.test.ts
+++ b/src/__tests__/sitesRoute.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+// The plan allowance is covered in siteAllowance.test.ts. This covers the rest of the
+// endpoint: listing, ownership on update, the payload caps, and the validation that
+// stands between a request body and the database.
+
+const dbMock = vi.hoisted(() => ({
+  user: { findUnique: vi.fn() },
+  site: { count: vi.fn(), create: vi.fn(), update: vi.fn(), findFirst: vi.fn(), findMany: vi.fn() },
+}));
+const authMock = vi.hoisted(() => vi.fn());
+const rateLimitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({ db: dbMock }));
+vi.mock("@/auth", () => ({ auth: authMock }));
+vi.mock("@/lib/rateLimit", () => ({ rateLimit: rateLimitMock, getClientIp: () => "1.2.3.4" }));
+
+type Routes = typeof import("../app/api/sites/route");
+let POST: Routes["POST"];
+let GET: Routes["GET"];
+
+function post(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  return new Request("https://scrollcraft.app/api/sites", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+const SECTIONS = JSON.stringify([{ heading: "A", scrollHeight: 1000 }]);
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  rateLimitMock.mockResolvedValue({ allowed: true });
+  authMock.mockResolvedValue({ user: { id: "u1", email: "a@b.c" } });
+  dbMock.user.findUnique.mockResolvedValue({ id: "u1", plan: "PRO" });
+  dbMock.site.count.mockResolvedValue(0);
+  dbMock.site.create.mockResolvedValue({ id: "new-site" });
+  dbMock.site.update.mockResolvedValue({ id: "s1" });
+  dbMock.site.findFirst.mockResolvedValue({ id: "s1", userId: "u1" });
+  dbMock.site.findMany.mockResolvedValue([]);
+  ({ POST, GET } = await import("../app/api/sites/route"));
+});
+
+describe("GET /api/sites", () => {
+  it("rejects an unauthenticated caller", async () => {
+    authMock.mockResolvedValue(null);
+    expect((await GET()).status).toBe(401);
+  });
+
+  it("404s when the session has no matching user", async () => {
+    dbMock.user.findUnique.mockResolvedValue(null);
+    expect((await GET()).status).toBe(404);
+  });
+
+  it("lists only the caller's own sites", async () => {
+    await GET();
+    expect(dbMock.site.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: "u1" } })
+    );
+  });
+
+  it("does not leak site content in the listing", async () => {
+    await GET();
+    const select = dbMock.site.findMany.mock.calls[0][0].select;
+    for (const heavy of ["sectionsJson", "framesJson", "customHead", "customCss"]) {
+      expect(select[heavy]).toBeUndefined();
+    }
+  });
+});
+
+describe("POST /api/sites — guards before the database", () => {
+  it("rejects an unauthenticated caller", async () => {
+    authMock.mockResolvedValue(null);
+    expect((await POST(post({ name: "x" }))).status).toBe(401);
+  });
+
+  it("429s when rate limited, without creating anything", async () => {
+    rateLimitMock.mockResolvedValue({ allowed: false });
+    expect((await POST(post({ name: "x" }))).status).toBe(429);
+    expect(dbMock.site.create).not.toHaveBeenCalled();
+  });
+
+  it("413s on a declared content-length over the cap, before reading the body", async () => {
+    const res = await POST(post({ name: "x" }, { "content-length": String(20_000_000) }));
+    expect(res.status).toBe(413);
+    expect(dbMock.site.create).not.toHaveBeenCalled();
+  });
+
+  it("400s a malformed JSON body instead of throwing a bare 500", async () => {
+    const res = await POST(post("{ not json"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid JSON body");
+  });
+
+  it("400s a body that fails schema validation", async () => {
+    const res = await POST(post({ fps: 9999 }));
+    expect(res.status).toBe(400);
+    expect(dbMock.site.create).not.toHaveBeenCalled();
+  });
+
+  it("400s sectionsJson that is not a valid section array", async () => {
+    const res = await POST(post({ name: "x", sectionsJson: JSON.stringify([{ heading: 42 }]) }));
+    expect(res.status).toBe(400);
+    expect(dbMock.site.create).not.toHaveBeenCalled();
+  });
+
+  it("400s an audioUrl that is not a URL", async () => {
+    const res = await POST(post({ name: "x", audioUrl: "javascript:alert(1)" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts a valid create", async () => {
+    const res = await POST(post({ name: "Launch", sectionsJson: SECTIONS, fps: 24 }));
+    expect(res.status).toBe(200);
+    expect(dbMock.site.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ userId: "u1", name: "Launch" }) })
+    );
+  });
+});
+
+describe("POST /api/sites — updating someone else's site", () => {
+  it("404s rather than updating a site the caller does not own", async () => {
+    dbMock.site.findFirst.mockResolvedValue(null);
+    const res = await POST(post({ id: "not-mine", name: "hijacked" }));
+    expect(res.status).toBe(404);
+    expect(dbMock.site.update).not.toHaveBeenCalled();
+  });
+
+  it("scopes the ownership lookup by the caller's user id", async () => {
+    await POST(post({ id: "s1", name: "Renamed" }));
+    expect(dbMock.site.findFirst).toHaveBeenCalledWith({ where: { id: "s1", userId: "u1" } });
+  });
+
+  it("does not spend allowance on an update", async () => {
+    await POST(post({ id: "s1", name: "Renamed" }));
+    expect(dbMock.site.count).not.toHaveBeenCalled();
+    expect(dbMock.site.update).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/ssrfGuard.test.ts
+++ b/src/__tests__/ssrfGuard.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ipv4Octets, isPrivateIPv4, ipv6Groups, isPrivateAddress, resolvePublicAddress } from "@/lib/ssrfGuard";
+
+const lookupMock = vi.hoisted(() => vi.fn());
+vi.mock("dns/promises", () => ({ lookup: lookupMock }));
+
+// This is the control that stops a caller pointing the video downloader at loopback,
+// RFC-1918 space, or a cloud metadata endpoint. Anything it wrongly calls public is a
+// server-side request forgery.
+const BLOCKED = [
+  ["loopback", "127.0.0.1"],
+  ["loopback, non-canonical", "127.1.2.3"],
+  ["this-network", "0.0.0.0"],
+  ["RFC-1918 10/8", "10.1.2.3"],
+  ["RFC-1918 172.16/12 low", "172.16.0.1"],
+  ["RFC-1918 172.16/12 high", "172.31.255.255"],
+  ["RFC-1918 192.168/16", "192.168.1.1"],
+  ["AWS/GCP metadata", "169.254.169.254"],
+  ["link-local", "169.254.0.1"],
+  ["CGNAT", "100.64.0.1"],
+  ["benchmarking", "198.18.0.1"],
+  ["multicast", "224.0.0.1"],
+  ["reserved high", "255.255.255.255"],
+  ["IPv6 loopback", "::1"],
+  ["IPv4-mapped loopback", "::ffff:127.0.0.1"],
+  ["IPv4-mapped metadata", "::ffff:169.254.169.254"],
+  ["IPv4-compatible metadata", "::169.254.169.254"],
+  ["NAT64 metadata", "64:ff9b::a9fe:a9fe"],
+  ["6to4 metadata", "2002:a9fe:a9fe::"],
+  ["IPv6 link-local", "fe80::1"],
+  ["IPv6 unique-local", "fd12:3456::1"],
+  ["IPv6 multicast", "ff02::1"],
+  ["malformed", "not-an-address"],
+  ["empty", ""],
+  ["truncated IPv4", "10.1.2"],
+  ["octet out of range", "999.1.1.1"],
+] as const;
+
+const ALLOWED = [
+  ["public IPv4", "93.184.216.34"],
+  ["public IPv4, Google DNS", "8.8.8.8"],
+  ["just outside CGNAT", "100.128.0.1"],
+  ["just outside 172.16/12", "172.32.0.1"],
+  ["just below multicast", "223.255.255.255"],
+  ["public IPv6", "2606:4700:4700::1111"],
+  ["IPv4-mapped public", "::ffff:93.184.216.34"],
+] as const;
+
+describe("isPrivateAddress", () => {
+  for (const [label, address] of BLOCKED) {
+    it(`blocks ${label} (${address || "<empty>"})`, () => {
+      expect(isPrivateAddress(address)).toBe(true);
+    });
+  }
+
+  for (const [label, address] of ALLOWED) {
+    it(`allows ${label} (${address})`, () => {
+      expect(isPrivateAddress(address)).toBe(false);
+    });
+  }
+});
+
+describe("ipv4Octets", () => {
+  it("parses a dotted quad", () => {
+    expect(ipv4Octets("1.2.3.4")).toEqual([1, 2, 3, 4]);
+  });
+
+  it("rejects anything that is not four numeric octets in range", () => {
+    for (const bad of ["1.2.3", "1.2.3.4.5", "1.2.3.256", "1.2.3.a", "01.02.03.04.05", ""]) {
+      expect(ipv4Octets(bad)).toBeNull();
+    }
+  });
+});
+
+describe("ipv6Groups", () => {
+  it("expands a compressed address to eight groups", () => {
+    expect(ipv6Groups("::1")).toEqual([0, 0, 0, 0, 0, 0, 0, 1]);
+    expect(ipv6Groups("2606:4700:4700::1111")).toHaveLength(8);
+  });
+
+  it("strips a zone suffix", () => {
+    expect(ipv6Groups("fe80::1%eth0")).toEqual(ipv6Groups("fe80::1"));
+  });
+
+  it("rejects an address with two compression markers", () => {
+    expect(ipv6Groups("1::2::3")).toBeNull();
+  });
+
+  it("treats an unparseable address as private, failing closed", () => {
+    expect(isPrivateAddress("1::2::3")).toBe(true);
+  });
+});
+
+describe("isPrivateIPv4", () => {
+  it("judges the embedded quad, not the text form", () => {
+    expect(isPrivateIPv4([169, 254, 169, 254])).toBe(true);
+    expect(isPrivateIPv4([93, 184, 216, 34])).toBe(false);
+  });
+});
+
+describe("resolvePublicAddress", () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+  });
+
+  it("returns a literal public IP without a DNS lookup", async () => {
+    await expect(resolvePublicAddress("93.184.216.34")).resolves.toEqual({
+      address: "93.184.216.34", family: 4,
+    });
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a literal private IP without a DNS lookup", async () => {
+    await expect(resolvePublicAddress("169.254.169.254")).resolves.toBeNull();
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it("unwraps a bracketed IPv6 literal", async () => {
+    await expect(resolvePublicAddress("[::1]")).resolves.toBeNull();
+  });
+
+  it("resolves a public hostname to its address", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    await expect(resolvePublicAddress("example.com")).resolves.toEqual({
+      address: "93.184.216.34", family: 4,
+    });
+  });
+
+  it("refuses a hostname that resolves to a private address", async () => {
+    lookupMock.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+    await expect(resolvePublicAddress("metadata.internal")).resolves.toBeNull();
+  });
+
+  it("refuses when ANY resolved address is private, not just the first", async () => {
+    // A rebinding-style answer that mixes a public address with a private one must not
+    // be accepted on the strength of its first entry.
+    lookupMock.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "127.0.0.1", family: 4 },
+    ]);
+    await expect(resolvePublicAddress("rebind.example")).resolves.toBeNull();
+  });
+
+  it("refuses a hostname that resolves to nothing", async () => {
+    lookupMock.mockResolvedValue([]);
+    await expect(resolvePublicAddress("nowhere.example")).resolves.toBeNull();
+  });
+
+  it("refuses when the lookup itself fails", async () => {
+    lookupMock.mockRejectedValue(new Error("ENOTFOUND"));
+    await expect(resolvePublicAddress("broken.example")).resolves.toBeNull();
+  });
+
+  it("refuses an empty hostname", async () => {
+    await expect(resolvePublicAddress("")).resolves.toBeNull();
+  });
+});

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -263,6 +263,7 @@ export async function POST(req: NextRequest) {
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     html { scroll-behavior: auto; }
     body { background: var(--sc-ground, #000); color: var(--sc-ink, #fff); font-family: var(--sc-font-body, system-ui, sans-serif); overflow-x: hidden; }
+    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
     #scroll-canvas { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; }
     #scroll-container { position: relative; height: ${totalScrollHeight}px; z-index: 1; pointer-events: none; }
     .scroll-section { pointer-events: none; }
@@ -317,7 +318,7 @@ export async function POST(req: NextRequest) {
   <script src="lenis.min.js"></script>
 </head>
 <body>
-  <canvas id="scroll-canvas"></canvas>
+  <canvas id="scroll-canvas" role="img" aria-label="${esc(siteName ? `${siteName} animated scroll background` : "Animated scroll background")}"></canvas>
   <div id="scroll-container">
     <div style="height:100vh;"></div>
     ${sectionsHtml}
@@ -479,15 +480,35 @@ export async function POST(req: NextRequest) {
     (function() {
       var audio = new Audio('audio/track.${audioExt}');
       audio.loop = true;
-      audio.volume = 0;
       var lastScrollY = 0, lastScrollTime = 0, idleTimer = null, fadeRaf = null;
 
+      // iOS Safari ignores writes to HTMLMediaElement.volume — it is fixed at 1 — so the
+      // velocity ramp and the idle fade were silent no-ops there and the track played at
+      // full volume from the first scroll. Route gain through WebAudio where available.
+      var AC = window.AudioContext || window.webkitAudioContext;
+      var ctx = null, gain = null;
+      if (AC) {
+        try {
+          ctx = new AC();
+          gain = ctx.createGain();
+          ctx.createMediaElementSource(audio).connect(gain);
+          gain.connect(ctx.destination);
+        } catch (e) { ctx = null; gain = null; }
+      }
+      function setVol(v) {
+        if (gain) { gain.gain.value = v; } else { audio.volume = v; }
+      }
+      function getVol() {
+        return gain ? gain.gain.value : audio.volume;
+      }
+      setVol(0);
+
       function fadeVolume(target, duration) {
-        var start = audio.volume, startTime = performance.now();
+        var start = getVol(), startTime = performance.now();
         cancelAnimationFrame(fadeRaf);
         function tick(now) {
           var t = Math.min((now - startTime) / duration, 1);
-          audio.volume = start + (target - start) * t;
+          setVol(start + (target - start) * t);
           if (t < 1) { fadeRaf = requestAnimationFrame(tick); }
           else if (target === 0) { audio.pause(); }
         }
@@ -524,8 +545,13 @@ export async function POST(req: NextRequest) {
         var velocity = dt > 0 ? Math.abs(scrollY - lastScrollY) / dt : 0;
         lastScrollY = scrollY; lastScrollTime = now;
         var targetVol = Math.min(Math.max(velocity / 0.5, 0.08), 1);
-        if (audio.paused) { audio.volume = targetVol; audio.play().catch(function(){}); }
-        else { cancelAnimationFrame(fadeRaf); audio.volume = targetVol; }
+        if (audio.paused) {
+          setVol(targetVol);
+          // A context created before a gesture starts suspended; resume on first scroll.
+          if (ctx && ctx.state === 'suspended') { ctx.resume(); }
+          audio.play().catch(function(){});
+        }
+        else { cancelAnimationFrame(fadeRaf); setVol(targetVol); }
         clearTimeout(idleTimer);
         idleTimer = setTimeout(function() { fadeVolume(0, 600); }, 2000);
       }, { passive: true });

--- a/src/app/api/extract-frames/route.ts
+++ b/src/app/api/extract-frames/route.ts
@@ -6,9 +6,7 @@ import path from "path";
 import { execFile as _execFile } from "child_process";
 import { promisify } from "util";
 import { readdir, readFile } from "fs/promises";
-import { lookup } from "dns/promises";
 import type { LookupAddress } from "dns";
-import { isIPv4, isIPv6 } from "net";
 import http from "http";
 import https from "https";
 import { randomUUID } from "crypto";
@@ -16,6 +14,7 @@ import os from "os";
 import { pipeline } from "stream/promises";
 import { auth } from "@/auth";
 import { rateLimit } from "@/lib/rateLimit";
+import { resolvePublicAddress } from "@/lib/ssrfGuard";
 import { put } from "@vercel/blob";
 
 const execFile = promisify(_execFile);
@@ -26,105 +25,6 @@ const MAX_VIDEO_BYTES = 500 * 1024 * 1024;
 const MAX_REDIRECTS = 5;
 
 class VideoTooLargeError extends Error {}
-
-function ipv4Octets(address: string): number[] | null {
-  const parts = address.split(".");
-  if (parts.length !== 4) return null;
-  const octets: number[] = [];
-  for (const part of parts) {
-    if (!/^\d{1,3}$/.test(part)) return null;
-    const value = Number(part);
-    if (value > 255) return null;
-    octets.push(value);
-  }
-  return octets;
-}
-
-// Loopback, RFC-1918 private, link-local (cloud metadata), CGNAT, benchmarking, multicast, reserved
-function isPrivateIPv4([a, b, c]: number[]): boolean {
-  if (a === 0 || a === 10 || a === 127) return true;
-  if (a === 100 && b >= 64 && b <= 127) return true;
-  if (a === 169 && b === 254) return true;
-  if (a === 172 && b >= 16 && b <= 31) return true;
-  if (a === 192 && b === 0 && c === 0) return true;
-  if (a === 192 && b === 168) return true;
-  if (a === 198 && (b === 18 || b === 19)) return true;
-  return a >= 224;
-}
-
-// Expand any IPv6 text form (compressed, zone-suffixed, embedded IPv4) into its 8 groups
-function ipv6Groups(address: string): number[] | null {
-  const halves = address.split("%")[0].split("::");
-  if (halves.length > 2) return null;
-
-  const parseHalf = (half: string): number[] | null => {
-    if (!half) return [];
-    const groups: number[] = [];
-    for (const part of half.split(":")) {
-      if (part.includes(".")) {
-        const octets = ipv4Octets(part);
-        if (!octets) return null;
-        groups.push((octets[0] << 8) | octets[1], (octets[2] << 8) | octets[3]);
-      } else {
-        if (!/^[0-9a-f]{1,4}$/i.test(part)) return null;
-        groups.push(parseInt(part, 16));
-      }
-    }
-    return groups;
-  };
-
-  const head = parseHalf(halves[0]);
-  const tail = halves.length === 2 ? parseHalf(halves[1]) : [];
-  if (!head || !tail) return null;
-  const missing = 8 - head.length - tail.length;
-  if (halves.length === 2 ? missing < 0 : missing !== 0) return null;
-  return [...head, ...Array<number>(missing).fill(0), ...tail];
-}
-
-function isPrivateIPv6(address: string): boolean {
-  const g = ipv6Groups(address);
-  if (!g) return true;
-  const embeddedIPv4 = [g[6] >> 8, g[6] & 0xff, g[7] >> 8, g[7] & 0xff];
-  // IPv4-mapped/compatible (::ffff:a.b.c.d, ::a.b.c.d), NAT64 and 6to4 — judge the embedded IPv4
-  const zeroPrefix = g[0] === 0 && g[1] === 0 && g[2] === 0 && g[3] === 0 && g[4] === 0;
-  if (zeroPrefix && (g[5] === 0xffff || g[5] === 0)) return isPrivateIPv4(embeddedIPv4);
-  if (g[0] === 0x64 && g[1] === 0xff9b && g[2] === 0 && g[3] === 0 && g[4] === 0 && g[5] === 0) {
-    return isPrivateIPv4(embeddedIPv4);
-  }
-  if (g[0] === 0x2002) return isPrivateIPv4([g[1] >> 8, g[1] & 0xff, g[2] >> 8, g[2] & 0xff]);
-  if ((g[0] & 0xffc0) === 0xfe80) return true; // link-local
-  if ((g[0] & 0xfe00) === 0xfc00) return true; // unique-local
-  return (g[0] & 0xff00) === 0xff00; // multicast
-}
-
-function isPrivateAddress(address: string): boolean {
-  if (isIPv4(address)) {
-    const octets = ipv4Octets(address);
-    return octets === null || isPrivateIPv4(octets);
-  }
-  if (isIPv6(address)) return isPrivateIPv6(address);
-  return true;
-}
-
-// A hostname is only public if every address it resolves to is public — a literal
-// blocklist misses DNS names that point at loopback/metadata addresses. The address
-// that passed is returned so the request can be pinned to it: re-resolving at connect
-// time would let a rebinding DNS answer swap in a private address after the check.
-async function resolvePublicAddress(hostname: string): Promise<LookupAddress | null> {
-  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
-  if (!host) return null;
-  if (isIPv4(host)) return isPrivateAddress(host) ? null : { address: host, family: 4 };
-  if (isIPv6(host)) return isPrivateAddress(host) ? null : { address: host, family: 6 };
-
-  try {
-    const addresses = await lookup(host, { all: true });
-    if (addresses.length === 0) return null;
-    if (addresses.some(({ address }) => isPrivateAddress(address))) return null;
-    return addresses[0];
-  } catch {
-    return null;
-  }
-}
 
 // Connect to the address that was validated instead of letting the HTTP client
 // resolve the hostname a second time. The URL is still passed through, so the Host

--- a/src/app/api/sites/route.ts
+++ b/src/app/api/sites/route.ts
@@ -24,7 +24,15 @@ const siteSchema = z.object({
   styleJson: z.string().max(500).optional(),
   customHead: z.string().max(50_000).optional(),
   customCss: z.string().max(50_000).optional(),
-  audioUrl: z.string().url().max(2000).optional().or(z.literal("")),
+  // z.url() accepts any scheme, javascript: and data: included. Nothing renders this
+  // into an href today, but it is persisted and handed back to the client, so pin it to
+  // the two schemes an audio track can actually be fetched over.
+  audioUrl: z
+    .string()
+    .max(2000)
+    .refine((v) => /^https?:\/\//i.test(v), { message: "audioUrl must be an http(s) URL" })
+    .optional()
+    .or(z.literal("")),
 });
 
 // GET /api/sites — list the current user's sites

--- a/src/lib/ssrfGuard.ts
+++ b/src/lib/ssrfGuard.ts
@@ -1,0 +1,107 @@
+import { lookup } from "dns/promises";
+import type { LookupAddress } from "dns";
+import { isIPv4, isIPv6 } from "net";
+
+// SSRF guard for user-supplied video URLs. Extracted from the extract-frames route so it
+// can be tested directly: this is the control that stops a caller pointing the downloader
+// at loopback, RFC-1918, or cloud-metadata addresses, and it had no coverage while it
+// lived as module-private helpers.
+
+export function ipv4Octets(address: string): number[] | null {
+  const parts = address.split(".");
+  if (parts.length !== 4) return null;
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const value = Number(part);
+    if (value > 255) return null;
+    octets.push(value);
+  }
+  return octets;
+}
+
+// Loopback, RFC-1918 private, link-local (cloud metadata), CGNAT, benchmarking, multicast, reserved
+export function isPrivateIPv4([a, b, c]: number[]): boolean {
+  if (a === 0 || a === 10 || a === 127) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 0 && c === 0) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  return a >= 224;
+}
+
+// Expand any IPv6 text form (compressed, zone-suffixed, embedded IPv4) into its 8 groups
+export function ipv6Groups(address: string): number[] | null {
+  const halves = address.split("%")[0].split("::");
+  if (halves.length > 2) return null;
+
+  const parseHalf = (half: string): number[] | null => {
+    if (!half) return [];
+    const groups: number[] = [];
+    for (const part of half.split(":")) {
+      if (part.includes(".")) {
+        const octets = ipv4Octets(part);
+        if (!octets) return null;
+        groups.push((octets[0] << 8) | octets[1], (octets[2] << 8) | octets[3]);
+      } else {
+        if (!/^[0-9a-f]{1,4}$/i.test(part)) return null;
+        groups.push(parseInt(part, 16));
+      }
+    }
+    return groups;
+  };
+
+  const head = parseHalf(halves[0]);
+  const tail = halves.length === 2 ? parseHalf(halves[1]) : [];
+  if (!head || !tail) return null;
+  const missing = 8 - head.length - tail.length;
+  if (halves.length === 2 ? missing < 0 : missing !== 0) return null;
+  return [...head, ...Array<number>(missing).fill(0), ...tail];
+}
+
+export function isPrivateIPv6(address: string): boolean {
+  const g = ipv6Groups(address);
+  if (!g) return true;
+  const embeddedIPv4 = [g[6] >> 8, g[6] & 0xff, g[7] >> 8, g[7] & 0xff];
+  // IPv4-mapped/compatible (::ffff:a.b.c.d, ::a.b.c.d), NAT64 and 6to4 — judge the embedded IPv4
+  const zeroPrefix = g[0] === 0 && g[1] === 0 && g[2] === 0 && g[3] === 0 && g[4] === 0;
+  if (zeroPrefix && (g[5] === 0xffff || g[5] === 0)) return isPrivateIPv4(embeddedIPv4);
+  if (g[0] === 0x64 && g[1] === 0xff9b && g[2] === 0 && g[3] === 0 && g[4] === 0 && g[5] === 0) {
+    return isPrivateIPv4(embeddedIPv4);
+  }
+  if (g[0] === 0x2002) return isPrivateIPv4([g[1] >> 8, g[1] & 0xff, g[2] >> 8, g[2] & 0xff]);
+  if ((g[0] & 0xffc0) === 0xfe80) return true; // link-local
+  if ((g[0] & 0xfe00) === 0xfc00) return true; // unique-local
+  return (g[0] & 0xff00) === 0xff00; // multicast
+}
+
+export function isPrivateAddress(address: string): boolean {
+  if (isIPv4(address)) {
+    const octets = ipv4Octets(address);
+    return octets === null || isPrivateIPv4(octets);
+  }
+  if (isIPv6(address)) return isPrivateIPv6(address);
+  return true;
+}
+
+// A hostname is only public if every address it resolves to is public — a literal
+// blocklist misses DNS names that point at loopback/metadata addresses. The address
+// that passed is returned so the request can be pinned to it: re-resolving at connect
+// time would let a rebinding DNS answer swap in a private address after the check.
+export async function resolvePublicAddress(hostname: string): Promise<LookupAddress | null> {
+  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (!host) return null;
+  if (isIPv4(host)) return isPrivateAddress(host) ? null : { address: host, family: 4 };
+  if (isIPv6(host)) return isPrivateAddress(host) ? null : { address: host, family: 6 };
+
+  try {
+    const addresses = await lookup(host, { all: true });
+    if (addresses.length === 0) return null;
+    if (addresses.some(({ address }) => isPrivateAddress(address))) return null;
+    return addresses[0];
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What

- **#204** — the SSRF guard deciding whether a user-supplied video URL may be fetched lived as module-private helpers inside the route, with **zero coverage**. Moved verbatim to `src/lib/ssrfGuard.ts` and tested directly: **49 cases** covering loopback, RFC-1918, link-local metadata (`169.254.169.254`), CGNAT, benchmarking, multicast, IPv4-mapped/compatible, NAT64, 6to4, link-local and unique-local IPv6, plus malformed input.
- **#257** — the sites API had no tests beyond the plan allowance. Added listing (scoped to the caller, no content leaked), ownership on update, both payload caps, malformed-JSON handling, and schema validation.
- **#259** — the export checkout, which stands between a user and a **second charge for an export they already own**, had no tests. Added 14 covering the PAID short-circuit, PENDING-checkout reuse, TTL scoping, the `pending:` order-id prefix, and failure paths.
- **#274** — exported sites shipped a bare `<canvas>` with no accessible name, unlike `ScrollEngine` which sets `role="img"` + `aria-label`. Now labelled after the site (escaped), with an `.sr-only` rule added to the emitted stylesheet.
- **#236** — the exported audio drove volume through `HTMLMediaElement.volume`, **which iOS Safari ignores** (fixed at 1). The scroll-velocity ramp and the 600ms idle fade were silent no-ops there and the track played at full volume from the first scroll. Gain now routes through a WebAudio `GainNode`, falling back to `.volume` where `AudioContext` is absent, and resuming a suspended context on the first gesture.

## Bonus find

Writing the sites tests turned up **`audioUrl` accepting any URL scheme** — `javascript:` and `data:` included — because that is what zod's `.url()` does. Not live XSS (`new Audio()` won't execute it, and the export path already gates on `https?:`), but it is persisted and served back, so it is now pinned to http(s).

## Verified

- `tsc`, `eslint`, `next build` clean; suite **357 → 440**.
- Mutation-tested rather than assumed:
  - dropping the link-local rule → **9 SSRF tests fail**; flipping `some`→`every` in the resolver → **1 fails**.
  - removing the already-PAID short-circuit → **1 checkout test fails**; unscoping the site lookup from `userId` → **1 fails**.
  - reverting the canvas label and the audio gain → **3 export tests fail**.
- One SSRF mutation (`if (!g) return true`) was **not** caught: `net.isIPv6()` rejects those strings before that line, so the final `return true` handles them. That branch is unreachable defensive code, and I'd rather say so than claim full mutation coverage.

Fixes #204
Fixes #257
Fixes #259
Fixes #274
Fixes #236