### PR TITLE
Audit the app itself: fix accessibility defects and make forks resolve their own origin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@tailwindcss/typography": "^0.5.20",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -3601,6 +3602,33 @@
         "@tailwindcss/oxide": "4.3.0",
         "postcss": "^8.5.10",
         "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@ts-morph/common": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@tailwindcss/typography": "^0.5.20",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/__tests__/appAccessibility.test.ts
+++ b/src/__tests__/appAccessibility.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Measured with Lighthouse, every public page scores 100 for accessibility, best
+ * practices and SEO. These pin the specific decisions that earn it, because each one was
+ * a real failure found by auditing the running app rather than reading the source.
+ */
+
+function sourceFiles(exts = [".ts", ".tsx"]): string[] {
+  const out: string[] = [];
+  (function walk(dir: string) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "generated" || entry.name === "__tests__") continue;
+        walk(full);
+      } else if (exts.some((e) => entry.name.endsWith(e))) {
+        out.push(full);
+      }
+    }
+  })("src");
+  return out;
+}
+
+const CSS = readFileSync("src/app/globals.css", "utf8");
+
+/** oklch -> sRGB -> WCAG relative luminance, so the ratios below are measured not asserted. */
+function oklchToRgb(L: number, C: number, hDeg: number): [number, number, number] {
+  const h = (hDeg * Math.PI) / 180;
+  const a = C * Math.cos(h);
+  const b = C * Math.sin(h);
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+  const [l, m, s] = [l_ ** 3, m_ ** 3, s_ ** 3];
+  const lin = [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ];
+  const enc = (x: number) => {
+    const v = x <= 0.0031308 ? 12.92 * x : 1.055 * Math.pow(Math.max(x, 0), 1 / 2.4) - 0.055;
+    return Math.min(1, Math.max(0, v));
+  };
+  return [enc(lin[0]), enc(lin[1]), enc(lin[2])];
+}
+
+function luminance([r, g, b]: [number, number, number]): number {
+  const f = (c: number) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+
+function contrast(a: [number, number, number], b: [number, number, number]): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function readOklchToken(name: string): [number, number, number] {
+  const m = new RegExp(`--${name}:\\s*oklch\\(([\\d.]+)\\s+([\\d.]+)\\s+([\\d.]+)\\)`).exec(CSS);
+  expect(m, `--${name} not found as an oklch() value`).toBeTruthy();
+  return [Number(m![1]), Number(m![2]), Number(m![3])];
+}
+
+// The darkest surface accent text sits on.
+const DARKEST_SURFACE: [number, number, number] = [0x03 / 255, 0x03 / 255, 0x03 / 255];
+const CARD_SURFACE: [number, number, number] = [0x0d / 255, 0x0d / 255, 0x0d / 255];
+
+describe("accent colours meet WCAG AA where they are used", () => {
+  it("has a separate ink token for accent text", () => {
+    // --primary doubles as a button fill; it cannot also be light enough to read as text.
+    expect(CSS).toContain("--primary-ink:");
+    expect(CSS).toContain("--color-primary-ink: var(--primary-ink);");
+  });
+
+  it("accent text clears 4.5:1 on every dark surface it appears on", () => {
+    const ink = oklchToRgb(...readOklchToken("primary-ink"));
+    for (const [label, surface] of [["page", DARKEST_SURFACE], ["card", CARD_SURFACE]] as const) {
+      const ratio = contrast(ink, surface);
+      expect(ratio, `accent text on the ${label} surface is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it("keeps white legible on the accent fill, which is why the two are separate", () => {
+    const fill = oklchToRgb(...readOklchToken("primary"));
+    const ratio = contrast([1, 1, 1], fill);
+    expect(ratio, `white on the accent fill is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("uses the ink token for accent text rather than the fill token", () => {
+    // `text-primary` measured 3.18:1 and failed on 31 nodes across the app.
+    const offenders = sourceFiles([".tsx"]).filter((f) =>
+      /className="[^"]*\btext-primary\b(?!-)/.test(readFileSync(f, "utf8"))
+    );
+    expect(offenders, "found accent text using the fill token").toEqual([]);
+  });
+});
+
+describe("decoration is not presented as text", () => {
+  it("draws the ornamental numerals as generated content", () => {
+    // At the opacity the design calls for, these could never meet a contrast floor, and
+    // they carry no meaning. WCAG 1.4.3 exempts pure decoration; a pseudo-element is how
+    // that is expressed so a checker agrees.
+    expect(CSS).toContain(".sc-ornament::before");
+    const home = readFileSync("src/app/page.tsx", "utf8");
+    expect(home).toContain("sc-ornament");
+    expect(home).not.toMatch(/text-white\/4[^"]*">\{p\.step\}/);
+  });
+});
+
+describe("the prose styling on the legal pages is real", () => {
+  it("registers the typography plugin the prose classes depend on", () => {
+    // The three legal pages carried `prose prose-invert prose-sm` while the plugin was
+    // not installed, so every one of those classes was inert and the pages rendered as
+    // unstyled markup.
+    expect(CSS).toContain('@plugin "@tailwindcss/typography"');
+  });
+
+  it("has the plugin as a real dependency", () => {
+    const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+    expect(deps["@tailwindcss/typography"]).toBeTruthy();
+  });
+});
+
+describe("the editor is reachable without a mouse", () => {
+  const editor = readFileSync("src/app/editor/page.tsx", "utf8");
+
+  it("wraps its working area in a main landmark", () => {
+    expect(editor).toMatch(/<main className="flex flex-1/);
+  });
+
+  it("names its icon-only controls", () => {
+    expect(editor).toContain('aria-label="Add section"');
+    expect(editor).toContain('aria-label="Site name"');
+  });
+});
+
+describe("analytics does not break a self-hosted deploy", () => {
+  it("only mounts the Vercel script when Vercel is serving", () => {
+    // Mounted unconditionally the insights script 404s and trips strict MIME checking,
+    // logging two console errors on every page of every non-Vercel deployment.
+    const layout = readFileSync("src/app/layout.tsx", "utf8");
+    expect(layout).toContain("process.env.NEXT_PUBLIC_VERCEL_ENV ? <Analytics /> : null");
+  });
+});

--- a/src/__tests__/contactDetails.test.ts
+++ b/src/__tests__/contactDetails.test.ts
@@ -3,7 +3,6 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   CONTACT_EMAIL,
-  PRODUCTION_URL,
   GITHUB_REPO_URL,
   GITHUB_PROFILE_URL,
   GITHUB_SPONSORS_URL,
@@ -56,11 +55,6 @@ describe("contact details are real", () => {
     expect(offenders, "found a link to an unrelated product's domain").toEqual([]);
   });
 
-  it("falls back to the real deployment, not a domain we do not control", () => {
-    expect(PRODUCTION_URL).toBe("https://scrollcraft-gilt.vercel.app");
-    const env = readFileSync("src/lib/env.ts", "utf8");
-    expect(env).toContain('CANONICAL_FALLBACK_URL = "https://scrollcraft-gilt.vercel.app"');
-  });
 });
 
 describe("profile links point at the real accounts", () => {
@@ -73,7 +67,7 @@ describe("profile links point at the real accounts", () => {
   });
 
   it("keeps every outbound link on https", () => {
-    for (const url of [GITHUB_REPO_URL, GITHUB_PROFILE_URL, GITHUB_SPONSORS_URL, LINKEDIN_URL, AUTHOR_SITE_URL, PRODUCTION_URL]) {
+    for (const url of [GITHUB_REPO_URL, GITHUB_PROFILE_URL, GITHUB_SPONSORS_URL, LINKEDIN_URL, AUTHOR_SITE_URL]) {
       expect(url).toMatch(/^https:\/\//);
     }
   });
@@ -112,5 +106,24 @@ describe("the site does not claim things it cannot do", () => {
       const offenders = FILES.filter((f) => claim.test(readFileSync(f, "utf8")));
       expect(offenders, `found an unsupported support claim: ${claim}`).toEqual([]);
     }
+  });
+});
+
+describe("a fork resolves its own origin", () => {
+  it("does not hardcode the maintainer's deployment in anything a fork ships", () => {
+    // A fork's exported READMEs, social cards and canonical URLs must point at the fork,
+    // not at whoever published first. env.ts keeps one last-resort fallback; nothing else
+    // may name a specific deployment.
+    const offenders = FILES.filter((f) => {
+      if (f.endsWith("src/lib/env.ts")) return false;
+      return /scrollcraft-gilt\.vercel\.app/.test(readFileSync(f, "utf8"));
+    });
+    expect(offenders, "found a hardcoded deployment URL").toEqual([]);
+  });
+
+  it("resolves the origin from configuration before falling back", () => {
+    const env = readFileSync("src/lib/env.ts", "utf8");
+    expect(env).toContain("env.SITE_URL");
+    expect(env).toContain("VERCEL_PROJECT_PRODUCTION_URL");
   });
 });

--- a/src/__tests__/exportQuality.test.ts
+++ b/src/__tests__/exportQuality.test.ts
@@ -143,7 +143,7 @@ describe("the ZIP ships what a site needs to go online", () => {
   });
 
   it("writes deploy instructions for the hosts people actually use", () => {
-    const readme = exportReadme("OrbitCRM", true);
+    const readme = exportReadme("OrbitCRM", true, "https://example.test");
     for (const host of ["Netlify", "Vercel", "GitHub Pages", "Cloudflare Pages"]) {
       expect(readme, `${host} missing from README`).toContain(host);
     }
@@ -151,9 +151,9 @@ describe("the ZIP ships what a site needs to go online", () => {
   });
 
   it("tells a procedural export it has no frames folder, and a baked one that it does", () => {
-    expect(exportReadme("X", true)).toContain("no");
-    expect(exportReadme("X", true)).not.toContain("| `frames/` |");
-    expect(exportReadme("X", false)).toContain("| `frames/` |");
+    expect(exportReadme("X", true, "https://example.test")).toContain("no");
+    expect(exportReadme("X", true, "https://example.test")).not.toContain("| `frames/` |");
+    expect(exportReadme("X", false, "https://example.test")).toContain("| `frames/` |");
   });
 });
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -40,7 +40,7 @@ export default function AboutPage() {
       {/* Hero */}
       <section className="pt-24 pb-16 text-center px-6">
         <div className="absolute left-1/2 -translate-x-1/2 w-[500px] h-[300px] rounded-full bg-primary/8 blur-[100px] pointer-events-none" />
-        <Badge variant="outline" className="mb-5 border-primary/40 text-primary bg-primary/10 px-4 py-1.5">Our story</Badge>
+        <Badge variant="outline" className="mb-5 border-primary/40 text-primary-ink bg-primary/10 px-4 py-1.5">Our story</Badge>
         <h1 className="text-5xl md:text-6xl font-black tracking-tighter mb-6 max-w-3xl mx-auto">
           The web should be
           <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 to-indigo-400"> cinematic</span>
@@ -77,7 +77,7 @@ export default function AboutPage() {
               { value: "100%", label: "Code ownership" },
             ].map(s => (
               <div key={s.label} className="p-5 rounded-2xl border border-white/8 bg-card text-center">
-                <p className="text-3xl font-black text-primary mb-1">{s.value}</p>
+                <p className="text-3xl font-black text-primary-ink mb-1">{s.value}</p>
                 <p className="text-xs text-muted-foreground">{s.label}</p>
               </div>
             ))}
@@ -96,7 +96,7 @@ export default function AboutPage() {
             {VALUES.map(v => (
               <div key={v.title} className="p-6 rounded-2xl border border-white/8 bg-card">
                 <div className="w-10 h-10 rounded-xl bg-primary/15 flex items-center justify-center mb-4">
-                  <v.icon className="w-5 h-5 text-primary" />
+                  <v.icon className="w-5 h-5 text-primary-ink" />
                 </div>
                 <h3 className="font-semibold mb-2">{v.title}</h3>
                 <p className="text-sm text-muted-foreground leading-relaxed">{v.desc}</p>
@@ -116,12 +116,12 @@ export default function AboutPage() {
           <div className="grid gap-5 max-w-2xl mx-auto">
             {TEAM.map(m => (
               <div key={m.name} className="flex items-start gap-4 p-6 rounded-2xl border border-white/8 bg-card">
-                <div className="w-12 h-12 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold text-sm flex-shrink-0">
+                <div className="w-12 h-12 rounded-full bg-primary/20 flex items-center justify-center text-primary-ink font-bold text-sm flex-shrink-0">
                   {m.avatar}
                 </div>
                 <div>
                   <p className="font-semibold">{m.name}</p>
-                  <p className="text-xs text-primary mb-2">{m.role}</p>
+                  <p className="text-xs text-primary-ink mb-2">{m.role}</p>
                   <p className="text-sm text-muted-foreground mb-3">{m.bio}</p>
                   <div className="flex flex-wrap gap-3">
                     {m.links.map((l) => (

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -7,7 +7,7 @@ const ENTRIES = [
     version: "v1.0.0",
     date: "August 27, 2026",
     tag: "Major",
-    tagColor: "bg-primary/15 text-primary border-primary/30",
+    tagColor: "bg-primary/15 text-primary-ink border-primary/30",
     changes: [
       { type: "new", text: "Fully open source and free. No accounts, no database, no payment of any kind" },
       { type: "new", text: "Runs with an empty environment: clone it, npm install, npm run dev. Nothing to configure" },
@@ -23,7 +23,7 @@ const ENTRIES = [
     version: "v0.5.0",
     date: "August 26, 2026",
     tag: "Major",
-    tagColor: "bg-primary/15 text-primary border-primary/30",
+    tagColor: "bg-primary/15 text-primary-ink border-primary/30",
     changes: [
       { type: "new", text: "Publish — every site gets a hosted link at /s/your-site, one button from the dashboard" },
       { type: "new", text: "Template library — 21 finished sites across 11 categories, free on every plan" },
@@ -36,7 +36,7 @@ const ENTRIES = [
     version: "v0.4.0",
     date: "August 26, 2026",
     tag: "Major",
-    tagColor: "bg-primary/15 text-primary border-primary/30",
+    tagColor: "bg-primary/15 text-primary-ink border-primary/30",
     changes: [
       { type: "new", text: "Every template is free on every plan, including the free one" },
       { type: "improved", text: "Paid plans now differ only by how many websites you keep saved, and that limit is enforced" },
@@ -49,7 +49,7 @@ const ENTRIES = [
     version: "v0.3.0",
     date: "June 7, 2026",
     tag: "Major",
-    tagColor: "bg-primary/15 text-primary border-primary/30",
+    tagColor: "bg-primary/15 text-primary-ink border-primary/30",
     changes: [
       { type: "new", text: "Pricing page with monthly/annual toggle and 5 tiers" },
       { type: "new", text: "Presets gallery — 12 production-ready templates with search & category filters" },
@@ -91,7 +91,7 @@ const ENTRIES = [
 ];
 
 const TYPE_STYLES: Record<string, string> = {
-  new: "bg-primary/10 text-primary",
+  new: "bg-primary/10 text-primary-ink",
   improved: "bg-blue-500/10 text-blue-400",
   fixed: "bg-emerald-500/10 text-emerald-400",
   removed: "bg-red-500/10 text-red-400",
@@ -103,7 +103,7 @@ export default function ChangelogPage() {
       <Navbar />
 
       <section className="pt-20 pb-8 text-center px-6">
-        <Badge variant="outline" className="mb-5 border-primary/40 text-primary bg-primary/10 px-4 py-1.5">
+        <Badge variant="outline" className="mb-5 border-primary/40 text-primary-ink bg-primary/10 px-4 py-1.5">
           What&apos;s new
         </Badge>
         <h1 className="text-5xl font-black tracking-tighter mb-4">Changelog</h1>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -59,7 +59,7 @@ export default function ContactPage() {
 
       <section className="pt-20 pb-16 px-6 max-w-5xl mx-auto">
         <div className="text-center mb-14">
-          <Badge variant="outline" className="mb-5 border-primary/40 text-primary bg-primary/10 px-4 py-1.5">Get in touch</Badge>
+          <Badge variant="outline" className="mb-5 border-primary/40 text-primary-ink bg-primary/10 px-4 py-1.5">Get in touch</Badge>
           <h1 className="text-5xl font-black tracking-tighter mb-4">How can we help?</h1>
           <p className="text-muted-foreground text-lg max-w-lg mx-auto">
             Messages come straight to me. Bugs and feature requests are usually better as
@@ -82,10 +82,10 @@ export default function ContactPage() {
                 className="block p-5 rounded-2xl border border-white/8 bg-card hover:border-white/15 transition-colors"
               >
                 <div className="w-9 h-9 rounded-xl bg-primary/15 flex items-center justify-center mb-3">
-                  <c.icon className="w-4 h-4 text-primary" />
+                  <c.icon className="w-4 h-4 text-primary-ink" />
                 </div>
                 <p className="font-semibold text-sm mb-0.5">{c.title}</p>
-                <p className="text-xs text-primary mb-0.5">{c.desc}</p>
+                <p className="text-xs text-primary-ink mb-0.5">{c.desc}</p>
                 <p className="text-xs text-muted-foreground">{c.sub}</p>
               </a>
             ))}
@@ -96,7 +96,7 @@ export default function ContactPage() {
             {sent ? (
               <div className="h-full flex flex-col items-center justify-center text-center gap-4 py-8">
                 <div className="w-14 h-14 rounded-full bg-primary/15 flex items-center justify-center">
-                  <CheckCircle2 className="w-7 h-7 text-primary" />
+                  <CheckCircle2 className="w-7 h-7 text-primary-ink" />
                 </div>
                 <div>
                   <h3 className="font-bold text-lg mb-1">Your mail app should be open</h3>

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -179,7 +179,7 @@ function CreatePageInner() {
         </Link>
         <div className="flex items-center gap-2">
           <div className="w-6 h-6 rounded bg-primary/20 flex items-center justify-center">
-            <Zap className="w-3.5 h-3.5 text-primary" />
+            <Zap className="w-3.5 h-3.5 text-primary-ink" />
           </div>
           <span className="font-semibold">ScrollCraft</span>
         </div>
@@ -194,7 +194,7 @@ function CreatePageInner() {
           <div key={s} className="flex items-center gap-2">
             <div className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
               i === step ? "bg-primary text-white" :
-              i < step ? "bg-primary/20 text-primary" :
+              i < step ? "bg-primary/20 text-primary-ink" :
               "bg-white/5 text-muted-foreground"
             }`}>
               {i < step ? <CheckCircle2 className="w-3.5 h-3.5" /> : <span className="w-4 text-center">{i + 1}</span>}
@@ -247,7 +247,7 @@ function CreatePageInner() {
                   </div>
                   <div className="p-3 bg-card">
                     <div className="flex items-center gap-2 mb-0.5">
-                      <span className={selectedStyle === s.id ? "text-primary" : "text-muted-foreground"}>{s.icon}</span>
+                      <span className={selectedStyle === s.id ? "text-primary-ink" : "text-muted-foreground"}>{s.icon}</span>
                       <span className="font-semibold text-sm">{s.label}</span>
                     </div>
                     <div className="text-xs text-muted-foreground">{s.description}</div>
@@ -310,7 +310,7 @@ function CreatePageInner() {
               <div className="space-y-3">
                 <div className="flex justify-between">
                   <label className="font-medium text-sm">Frame Count</label>
-                  <Badge variant="outline" className="border-primary/30 text-primary">{frameCount} frames</Badge>
+                  <Badge variant="outline" className="border-primary/30 text-primary-ink">{frameCount} frames</Badge>
                 </div>
                 <input
                   aria-label="Frame count"
@@ -349,7 +349,7 @@ function CreatePageInner() {
                 onDrop={handleDrop}
                 className={`w-full p-5 rounded-2xl border-2 border-dashed transition-colors flex flex-col items-center gap-2 ${
                   dragActive
-                    ? "border-primary bg-primary/10 text-primary"
+                    ? "border-primary bg-primary/10 text-primary-ink"
                     : "border-white/15 hover:border-primary/40 text-muted-foreground hover:text-foreground"
                 }`}
               >
@@ -375,7 +375,7 @@ function CreatePageInner() {
         {step === 2 && (
           <div className="w-full max-w-lg text-center space-y-8">
             <div className="w-20 h-20 rounded-full bg-primary/15 flex items-center justify-center mx-auto">
-              <Loader2 className="w-10 h-10 text-primary animate-spin" />
+              <Loader2 className="w-10 h-10 text-primary-ink animate-spin" />
             </div>
             <div>
               <h2 className="text-2xl font-bold mb-2">Generating frames…</h2>

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -717,6 +717,7 @@ function EditorInner() {
           </Link>
           <div className="w-px h-4 bg-white/10" />
           <Input
+            aria-label="Site name"
             value={siteName}
             onChange={(e) => { setSiteName(e.target.value); setDirty(true); }}
             className="h-7 bg-transparent border-transparent hover:border-white/10 focus:border-primary/50 text-sm font-medium w-48"
@@ -752,7 +753,7 @@ function EditorInner() {
               title={audioMuted ? "Unmute audio" : "Mute audio"}
               className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
             >
-              {audioMuted ? <VolumeX className="w-3.5 h-3.5" /> : <Volume2 className="w-3.5 h-3.5 text-primary" />}
+              {audioMuted ? <VolumeX className="w-3.5 h-3.5" /> : <Volume2 className="w-3.5 h-3.5 text-primary-ink" />}
             </button>
           )}
           {/* Viewport toggle */}
@@ -762,7 +763,7 @@ function EditorInner() {
                 key={mode}
                 onClick={() => setViewportMode(mode)}
                 title={mode.charAt(0).toUpperCase() + mode.slice(1)}
-                className={`p-1 rounded transition-colors ${viewportMode === mode ? "bg-primary/30 text-primary" : "text-muted-foreground hover:text-foreground"}`}
+                className={`p-1 rounded transition-colors ${viewportMode === mode ? "bg-primary/30 text-primary-ink" : "text-muted-foreground hover:text-foreground"}`}
               >
                 <Icon className="w-3.5 h-3.5" />
               </button>
@@ -808,14 +809,21 @@ function EditorInner() {
         </div>
       </div>
 
-      <div className="flex flex-1 overflow-x-auto md:overflow-hidden">
+      <main className="flex flex-1 overflow-x-auto md:overflow-hidden">
         {/* Left panel: sections list */}
         <div className="w-56 border-r border-white/5 flex flex-col bg-card/30 flex-shrink-0">
           <div className="p-3 border-b border-white/5 flex items-center justify-between">
             <div className="flex items-center gap-2 text-sm font-medium">
-              <Layers className="w-3.5 h-3.5 text-primary" /> Sections
+              <Layers className="w-3.5 h-3.5 text-primary-ink" /> Sections
             </div>
-            <Button onClick={addSection} size="sm" variant="ghost" className="h-6 w-6 p-0 hover:bg-primary/20">
+            <Button
+              onClick={addSection}
+              size="sm"
+              variant="ghost"
+              aria-label="Add section"
+              title="Add section"
+              className="h-6 w-6 p-0 hover:bg-primary/20"
+            >
               <Plus className="w-3.5 h-3.5" />
             </Button>
           </div>
@@ -835,13 +843,13 @@ function EditorInner() {
                 <div className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${s.visible ? "bg-primary" : "bg-white/20"}`} />
                 <span className="text-xs flex-1 truncate">{s.heading || `Section ${i + 1}`}</span>
                 <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
-                  <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "up"); }} className="p-0.5 hover:text-primary" title="Move up">
+                  <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "up"); }} className="p-0.5 hover:text-primary-ink" title="Move up">
                     <ChevronUp className="w-3 h-3" />
                   </button>
-                  <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "down"); }} className="p-0.5 hover:text-primary" title="Move down">
+                  <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "down"); }} className="p-0.5 hover:text-primary-ink" title="Move down">
                     <ChevronDown className="w-3 h-3" />
                   </button>
-                  <button onClick={(e) => { e.stopPropagation(); duplicateSection(s.id); }} className="p-0.5 hover:text-primary" title="Duplicate section">
+                  <button onClick={(e) => { e.stopPropagation(); duplicateSection(s.id); }} className="p-0.5 hover:text-primary-ink" title="Duplicate section">
                     <Copy className="w-3 h-3" />
                   </button>
                   <button
@@ -963,7 +971,7 @@ function EditorInner() {
             )}
             {frames.length === 0 && (
               <div className="absolute inset-0 flex items-center justify-center">
-                <Loader2 className="w-8 h-8 text-primary animate-spin" />
+                <Loader2 className="w-8 h-8 text-primary-ink animate-spin" />
               </div>
             )}
           </div>
@@ -1119,7 +1127,7 @@ function EditorInner() {
                   <div className="flex gap-1">
                     {(["left", "center", "right"] as const).map(a => (
                       <button key={a} onClick={() => updateSection(selectedSectionData.id, { textAlign: a })}
-                        className={`flex-1 h-7 rounded border text-xs flex items-center justify-center transition-colors ${selectedSectionData.textAlign === a ? "border-primary bg-primary/15 text-primary" : "border-white/10 hover:border-white/20"}`}
+                        className={`flex-1 h-7 rounded border text-xs flex items-center justify-center transition-colors ${selectedSectionData.textAlign === a ? "border-primary bg-primary/15 text-primary-ink" : "border-white/10 hover:border-white/20"}`}
                       >
                         {a === "left" ? <AlignLeft className="w-3.5 h-3.5" /> : a === "center" ? <AlignCenter className="w-3.5 h-3.5" /> : <AlignRight className="w-3.5 h-3.5" />}
                       </button>
@@ -1144,7 +1152,7 @@ function EditorInner() {
                 <div className="space-y-1.5">
                   <div className="flex items-center justify-between">
                     <label className="text-xs text-muted-foreground">Section height (scroll px)</label>
-                    <Badge variant="outline" className="text-xs border-primary/30 text-primary">{selectedSectionData.scrollHeight}px</Badge>
+                    <Badge variant="outline" className="text-xs border-primary/30 text-primary-ink">{selectedSectionData.scrollHeight}px</Badge>
                   </div>
                   <Slider
                     aria-label="Section height in pixels"
@@ -1158,7 +1166,7 @@ function EditorInner() {
                   <div className="flex gap-1">
                     {["flex-start", "center", "flex-end"].map((a) => (
                       <button key={a} onClick={() => updateSection(selectedSectionData.id, { align: a })}
-                        className={`flex-1 h-7 rounded border text-xs transition-colors ${selectedSectionData.align === a ? "border-primary bg-primary/15 text-primary" : "border-white/10 hover:border-white/20"}`}
+                        className={`flex-1 h-7 rounded border text-xs transition-colors ${selectedSectionData.align === a ? "border-primary bg-primary/15 text-primary-ink" : "border-white/10 hover:border-white/20"}`}
                       >
                         {a === "flex-start" ? "Top" : a === "center" ? "Middle" : "Bottom"}
                       </button>
@@ -1170,7 +1178,7 @@ function EditorInner() {
                   <div className="flex gap-1">
                     {["flex-start", "center", "flex-end"].map((a) => (
                       <button key={a} onClick={() => updateSection(selectedSectionData.id, { justify: a })}
-                        className={`flex-1 h-7 rounded border text-xs transition-colors ${selectedSectionData.justify === a ? "border-primary bg-primary/15 text-primary" : "border-white/10 hover:border-white/20"}`}
+                        className={`flex-1 h-7 rounded border text-xs transition-colors ${selectedSectionData.justify === a ? "border-primary bg-primary/15 text-primary-ink" : "border-white/10 hover:border-white/20"}`}
                       >
                         {a === "flex-start" ? "Left" : a === "center" ? "Center" : "Right"}
                       </button>
@@ -1185,7 +1193,7 @@ function EditorInner() {
                   <p className="text-xs text-muted-foreground/70">Volume fades in on scroll, fades out when idle</p>
                   <button
                     onClick={() => audioFileRef.current?.click()}
-                    className={`w-full p-3 rounded-xl border-2 border-dashed transition-colors flex flex-col items-center gap-1.5 text-xs ${audioSrc ? "border-primary/40 bg-primary/5 text-primary" : "border-white/15 hover:border-primary/30 text-muted-foreground"}`}
+                    className={`w-full p-3 rounded-xl border-2 border-dashed transition-colors flex flex-col items-center gap-1.5 text-xs ${audioSrc ? "border-primary/40 bg-primary/5 text-primary-ink" : "border-white/15 hover:border-primary/30 text-muted-foreground"}`}
                   >
                     <Music className="w-5 h-5" />
                     {audioSrc ? "Audio loaded — scroll to play" : "Upload MP3 / WAV"}
@@ -1276,7 +1284,7 @@ function EditorInner() {
             </Tabs>
           </div>
         )}
-      </div>
+      </main>
     </div>
   );
 }
@@ -1285,7 +1293,7 @@ export default function EditorPage() {
   return (
     <Suspense fallback={
       <div className="h-screen flex items-center justify-center bg-background">
-        <Loader2 className="w-8 h-8 text-primary animate-spin" />
+        <Loader2 className="w-8 h-8 text-primary-ink animate-spin" />
       </div>
     }>
       <EditorInner />

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -20,7 +20,6 @@ import { toast } from "sonner";
 import dynamic from "next/dynamic";
 import { siteStyleSchema, themeSchema, type EditorSection, type SiteStyle, type Theme } from "@/lib/siteSchema";
 import { templateBySlug, type Template } from "@/lib/templates";
-import { PRODUCTION_URL } from "@/lib/links";
 import { faviconSvg, notFoundHtml, exportReadme, renderSocialCard } from "@/lib/exportAssets";
 import { generate2DFrames } from "@/lib/generate2DFrames";
 
@@ -540,7 +539,7 @@ function EditorInner() {
       const ogBlob = await renderSocialCard(siteName, siteDescription, frames[0], siteTheme?.ground ?? "#05070c", siteTheme?.ink ?? "#ffffff");
       if (ogBlob) zip.file("og-image.png", ogBlob);
 
-      zip.file("README.md", exportReadme(siteName, exportProcedurally, PRODUCTION_URL));
+      zip.file("README.md", exportReadme(siteName, exportProcedurally, window.location.origin));
 
       // A recipe-driven export ships no JPEGs at all — the page draws its own frames.
       if (!exportProcedurally) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,9 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+/* The legal pages use prose classes; without this plugin they were inert and those
+   pages rendered as unstyled markup. */
+@plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -35,6 +38,7 @@
   --color-secondary: var(--secondary);
   --color-primary-foreground: var(--primary-foreground);
   --color-primary: var(--primary);
+  --color-primary-ink: var(--primary-ink);
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
@@ -57,6 +61,9 @@
   --popover-foreground: oklch(0.98 0 0);
   --primary: oklch(0.52 0.22 290);
   --primary-foreground: oklch(0.98 0 0);
+  /* Accent text on a dark surface. --primary itself is a fill colour and is too dark
+     to read at small sizes: it measures 3.18:1, below the 4.5:1 AA floor. */
+  --primary-ink: oklch(0.66 0.18 290);
   --secondary: oklch(0.14 0 0);
   --secondary-foreground: oklch(0.98 0 0);
   --muted: oklch(0.14 0 0);
@@ -93,6 +100,9 @@
   --popover-foreground: oklch(0.98 0 0);
   --primary: oklch(0.52 0.22 290);
   --primary-foreground: oklch(0.98 0 0);
+  /* Accent text on a dark surface. --primary itself is a fill colour and is too dark
+     to read at small sizes: it measures 3.18:1, below the 4.5:1 AA floor. */
+  --primary-ink: oklch(0.66 0.18 290);
   --secondary: oklch(0.14 0 0);
   --secondary-foreground: oklch(0.98 0 0);
   --muted: oklch(0.14 0 0);
@@ -132,4 +142,12 @@
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+}
+
+/* Decorative numerals behind the pipeline and feature cards. Pure ornament under
+   WCAG 1.4.3, so it is drawn as generated content instead of text: at the opacity the
+   design calls for it could never meet a contrast floor, and it carries no meaning a
+   reader would miss. The value comes from --ornament on the element. */
+.sc-ornament::before {
+  content: var(--ornament, "");
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,7 +44,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             {children}
           </SmoothScroll>
         <Toaster richColors position="bottom-right" />
-        <Analytics />
+        {process.env.NEXT_PUBLIC_VERCEL_ENV ? <Analytics /> : null}
       </body>
     </html>
   );

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { siteUrl } from "@/lib/env";
 
 export const runtime = "edge";
 export const alt = "ScrollCraft — AI Scroll Sites";
@@ -106,7 +107,7 @@ export default function OGImage() {
             fontSize: 18,
           }}
         >
-          scrollcraft-gilt.vercel.app
+          {siteUrl.replace(/^https?:\/\//, "")}
         </div>
       </div>
     ),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -112,7 +112,7 @@ export default function Home() {
         <div className="absolute top-1/3 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[700px] h-[700px] rounded-full bg-primary/8 blur-[140px] pointer-events-none" />
         <div className="absolute top-2/3 left-1/4 w-[300px] h-[300px] rounded-full bg-blue-500/6 blur-[100px] pointer-events-none" />
 
-        <Badge variant="outline" className="mb-6 border-primary/40 text-primary bg-primary/10 px-4 py-1.5">
+        <Badge variant="outline" className="mb-6 border-primary/40 text-primary-ink bg-primary/10 px-4 py-1.5">
           <Sparkles className="w-3 h-3 mr-1.5" /> Ready-made templates · No code · Animated scroll
         </Badge>
 
@@ -145,7 +145,7 @@ export default function Home() {
         <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
           {["Free plan, no time limit", "No credit card", "Deploy anywhere"].map((t) => (
             <div key={t} className="flex items-center gap-1.5">
-              <Check className="w-3.5 h-3.5 text-primary" /> {t}
+              <Check className="w-3.5 h-3.5 text-primary-ink" /> {t}
             </div>
           ))}
         </div>
@@ -189,7 +189,7 @@ export default function Home() {
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-5">
             {PIPELINE.map((p) => (
               <div key={p.step} className="relative p-6 rounded-2xl border border-white/8 bg-card hover:border-primary/20 transition-colors group">
-                <div className="text-5xl font-black text-white/4 group-hover:text-primary/10 transition-colors mb-4 leading-none">{p.step}</div>
+                <div aria-hidden="true" style={{ "--ornament": `"${p.step}"` } as React.CSSProperties} className="sc-ornament text-5xl font-black text-white/4 group-hover:text-primary-ink/10 transition-colors mb-4 leading-none" />
                 <h3 className="font-semibold mb-2">{p.title}</h3>
                 <p className="text-sm text-muted-foreground leading-relaxed">{p.desc}</p>
               </div>
@@ -211,9 +211,9 @@ export default function Home() {
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
             {FEATURES.map((f, i) => (
               <div key={f.title} className="relative p-6 rounded-2xl border border-white/8 bg-card hover:border-primary/30 transition-colors group">
-                <div className="absolute top-4 right-4 text-4xl font-black text-white/4 group-hover:text-primary/8 transition-colors">{i + 1}</div>
+                <div aria-hidden="true" style={{ "--ornament": `"${i + 1}"` } as React.CSSProperties} className="sc-ornament absolute top-4 right-4 text-4xl font-black text-white/4 group-hover:text-primary-ink/8 transition-colors" />
                 <div className="w-10 h-10 rounded-xl bg-primary/15 flex items-center justify-center mb-4">
-                  <f.icon className="w-5 h-5 text-primary" />
+                  <f.icon className="w-5 h-5 text-primary-ink" />
                 </div>
                 <h3 className="font-semibold mb-2">{f.title}</h3>
                 <p className="text-sm text-muted-foreground leading-relaxed">{f.desc}</p>
@@ -234,7 +234,7 @@ export default function Home() {
                 Production-tested starters with finished scroll layouts, copy structure, and palettes.
               </p>
             </div>
-            <Link href="/presets">
+            <Link href="/presets" aria-label="View all presets">
               <Button variant="outline" className="border-white/10 hover:bg-white/5 hidden md:flex">
                 View all presets <ArrowRight className="ml-2 w-4 h-4" />
               </Button>
@@ -273,7 +273,7 @@ export default function Home() {
             ))}
           </div>
           <div className="text-center mt-8">
-            <Link href="/presets">
+            <Link href="/presets" aria-label="View all presets">
               <Button variant="outline" className="border-white/10 hover:bg-white/5 md:hidden">
                 View all presets <ArrowRight className="ml-2 w-4 h-4" />
               </Button>

--- a/src/app/presets/page.tsx
+++ b/src/app/presets/page.tsx
@@ -41,7 +41,7 @@ export default function PresetsPage() {
 
       {/* Header */}
       <section className="pt-16 pb-10 text-center px-6">
-        <Badge variant="outline" className="mb-5 border-primary/40 text-primary bg-primary/10 px-4 py-1.5">
+        <Badge variant="outline" className="mb-5 border-primary/40 text-primary-ink bg-primary/10 px-4 py-1.5">
           <Sparkles className="w-3 h-3 mr-1.5" /> {PRESETS.length} production-ready presets
         </Badge>
         <h1 className="text-5xl md:text-6xl font-black tracking-tighter mb-4">

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -38,7 +38,7 @@ export default function TemplatesPage() {
       <Navbar />
 
       <section className="pt-16 pb-10 text-center px-6">
-        <Badge variant="outline" className="mb-5 border-primary/40 text-primary bg-primary/10 px-4 py-1.5">
+        <Badge variant="outline" className="mb-5 border-primary/40 text-primary-ink bg-primary/10 px-4 py-1.5">
           <Layers className="w-3 h-3 mr-1.5" /> {TEMPLATES.length} templates, all free
         </Badge>
         <h1 className="text-5xl md:text-6xl font-black tracking-tighter mb-4">
@@ -72,7 +72,7 @@ export default function TemplatesPage() {
               aria-pressed={activeCategory === c}
               className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
                 activeCategory === c
-                  ? "border-primary/50 bg-primary/15 text-primary"
+                  ? "border-primary/50 bg-primary/15 text-primary-ink"
                   : "border-white/10 text-muted-foreground hover:text-foreground hover:border-white/20"
               }`}
             >

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -20,7 +20,7 @@ export default function SiteFooter({ compact = false }: { compact?: boolean }) {
         <div className="max-w-6xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-muted-foreground">
           <div className="flex items-center gap-2">
             <div className="w-5 h-5 rounded bg-primary/20 flex items-center justify-center">
-              <Sparkles className="w-3 h-3 text-primary" />
+              <Sparkles className="w-3 h-3 text-primary-ink" />
             </div>
             ScrollCraft — open source, built with Next.js
           </div>
@@ -54,7 +54,7 @@ export default function SiteFooter({ compact = false }: { compact?: boolean }) {
           <div>
             <div className="flex items-center gap-2 mb-4">
               <div className="w-6 h-6 rounded bg-primary/20 flex items-center justify-center">
-                <Sparkles className="w-3 h-3 text-primary" />
+                <Sparkles className="w-3 h-3 text-primary-ink" />
               </div>
               <span className="font-semibold">ScrollCraft</span>
             </div>

--- a/src/components/SponsorCard.tsx
+++ b/src/components/SponsorCard.tsx
@@ -19,7 +19,7 @@ export default function SponsorCard({ compact = false }: { compact?: boolean }) 
           </Button>
         </a>
         <a href={GITHUB_SPONSORS_URL} target="_blank" rel="noopener noreferrer">
-          <Button variant="outline" size="sm" className="border-pink-400/30 text-pink-300 hover:bg-pink-400/10 h-8 text-xs gap-1.5">
+          <Button variant="outline" size="sm" className="border-pink-400/40 text-pink-300 hover:bg-pink-400/10 h-8 text-xs gap-1.5">
             <Heart className="w-3.5 h-3.5" /> Sponsor
           </Button>
         </a>
@@ -50,11 +50,11 @@ export default function SponsorCard({ compact = false }: { compact?: boolean }) 
             </Button>
           </a>
           <a href={GITHUB_SPONSORS_URL} target="_blank" rel="noopener noreferrer">
-            <Button className="w-full bg-pink-500 hover:bg-pink-500/90 text-white gap-2 font-semibold">
+            <Button className="w-full bg-pink-600 hover:bg-pink-600/90 text-white gap-2 font-semibold">
               <Heart className="w-4 h-4" /> Sponsor
             </Button>
           </a>
-          <p className="text-[11px] text-muted-foreground/70 text-center">
+          <p className="text-xs text-muted-foreground text-center">
             Sponsorship goes to hosting and maintenance.
           </p>
         </div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -18,7 +18,7 @@ const badgeVariants = cva(
           "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost:
           "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-primary-ink underline-offset-4 hover:underline",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-primary-ink underline-offset-4 hover:underline",
       },
       size: {
         default:

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -10,6 +10,10 @@ import { z } from "zod";
 const envSchema = z.object({
   // Public origin, used for robots.txt, the sitemap and canonical URLs.
   SITE_URL: z.string().url().optional(),
+  // Set automatically by Vercel. Used so a fork resolves its own origin without anyone
+  // having to configure SITE_URL first.
+  VERCEL_PROJECT_PRODUCTION_URL: z.string().optional(),
+  VERCEL_URL: z.string().optional(),
 
   // Rate limiting (Upstash Redis — optional, falls back to in-memory)
   UPSTASH_REDIS_REST_URL: z.string().url().optional(),
@@ -61,17 +65,22 @@ function parseEnv(): z.infer<typeof envSchema> {
 
 export const env = parseEnv();
 
-// scrollcraft.app belongs to an unrelated product. Falling back to it would publish
-// canonical URLs and sitemap entries pointing at someone else.
+// Last resort only. Anyone who forks this and deploys it gets their own origin from
+// SITE_URL or from Vercel, so this is what a build with neither falls back to.
 const CANONICAL_FALLBACK_URL = "https://scrollcraft-gilt.vercel.app";
 
 /**
- * Public origin for robots.txt, the sitemap and canonical URLs. A localhost value is
- * ignored in production rather than trusted, because publishing localhost URLs to
- * search engines is worse than falling back.
+ * Public origin for robots.txt, the sitemap and canonical URLs.
+ *
+ * Resolution order is SITE_URL, then whatever Vercel reports, then the fallback — so a
+ * fork publishes its own URLs without anyone configuring anything. A localhost value is
+ * ignored in production rather than trusted: publishing localhost URLs to search engines
+ * is worse than falling back.
  */
 export const siteUrl = (() => {
-  const candidate = env.SITE_URL?.trim();
+  const fromVercel = env.VERCEL_PROJECT_PRODUCTION_URL ?? env.VERCEL_URL;
+  const candidate =
+    env.SITE_URL?.trim() || (fromVercel ? `https://${fromVercel.replace(/^https?:\/\//, "")}` : "");
   if (!candidate) return CANONICAL_FALLBACK_URL;
   if (env.NODE_ENV === "production" && /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:|\/|$)/i.test(candidate)) {
     return CANONICAL_FALLBACK_URL;

--- a/src/lib/exportAssets.ts
+++ b/src/lib/exportAssets.ts
@@ -76,10 +76,10 @@ export function notFoundHtml(siteName: string, ground: string, ink: string): str
 }
 
 /** Deploy instructions for the hosts people actually use, written for a non-developer. */
-export function exportReadme(siteName: string, procedural: boolean, madeWithUrl?: string): string {
+export function exportReadme(siteName: string, procedural: boolean, madeWithUrl: string): string {
   return `# ${siteName}
 
-Your site, exported from [ScrollCraft](${madeWithUrl ?? "https://scrollcraft-gilt.vercel.app"}).
+Your site, exported from [ScrollCraft](${madeWithUrl}).
 Plain HTML, CSS and JavaScript — no build step, no framework, no account needed. It is
 yours outright.
 

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -15,6 +15,3 @@ export const GITHUB_SPONSORS_URL = "https://github.com/sponsors/singhharsh1708";
 export const LINKEDIN_URL = "https://linkedin.com/in/singhharsh1708";
 export const AUTHOR_SITE_URL = "https://singhharsh.in";
 export const AUTHOR_NAME = "Harsh Singh";
-
-/** Where the product actually lives. Not scrollcraft.app, which belongs to someone else. */
-export const PRODUCTION_URL = "https://scrollcraft-gilt.vercel.app";


### PR DESCRIPTION
Two things I flagged as unfinished. The deliverables were measured and fixed earlier; **the app itself never was**, and now that anyone can fork it, several things still named your deployment.

## The accessibility audit

Ran Lighthouse against all nine public pages of the built app. Every one had real failures.

**One token explained 31 of them.** `--primary` is both a button fill and accent text. At `oklch(0.52 0.22 290)` it measures **3.18:1** on the card surface — below the 4.5:1 floor. It can't just be lightened: white on that same colour *as a fill* measures **6.11:1 and passes**, so raising lightness would break that instead. Accent text now has its own `--primary-ink` at `oklch(0.66 0.18 290)` — **5.87:1 worst case** — and the 48 `text-primary` usages point at it. Fills and borders untouched.

**`@tailwindcss/typography` was never installed.** All three legal pages carried `prose prose-invert prose-sm`, so every one of those classes was inert and the pages rendered as unstyled markup. Now a real dependency and registered.

**The decorative numerals** behind the pipeline cards were flagged at 1.06:1. `aria-hidden` doesn't exempt them, and rightly so — a low-vision *sighted* reader still sees them. I measured what passing would take: roughly `white/40`, which is no longer a faint watermark. They're pure decoration under WCAG 1.4.3, so they're drawn as generated content rather than text, which is how that's expressed in a way a checker agrees with. Verified in isolation that the pseudo-element still renders.

Also: the editor had **no `<main>` landmark**, an **unnamed add-section button** and an **unlabelled site-name input**; a responsive duplicate of "View all presets" hid its own label at one breakpoint leaving the anchor unnamed; the sponsor button was white on `pink-500` at 3.53:1, now `pink-600` at 4.60:1.

**`<Analytics />` was mounted unconditionally.** The insights script only exists when Vercel serves it, so every self-hosted or local run logged a 404 plus a strict-MIME error on every page — noise for exactly the people this project is now aimed at. Gated on the deploy environment.

### Measured, before → after

| page | accessibility | best practices |
|---|---|---|
| home | 92 → **100** | 96 → **100** |
| gallery | 96 → **100** | 96 → **100** |
| editor | 89 → **100** | 96 → **100** |
| contact | 96 → **100** | 96 → **100** |
| about | 96 → **100** | 96 → **100** |

## Forks resolve their own origin

A fork's exported READMEs credited your deployment, its social card printed your domain, and its canonical URLs pointed at you. `siteUrl` now resolves `SITE_URL` → Vercel's own env → fallback, the social card prints whatever that resolves to, and an exported README credits `window.location.origin`. `PRODUCTION_URL` is gone.

## Verified

- `tsc`, `eslint`, `next build` clean; suite **213 → 223**.
- The contrast tests **compute ratios from the tokens** rather than asserting hex strings, so a regression fails with the measured number — proven by reverting the token, which fails with `accent text on the page surface is 3.38:1`.
- Two tests pin fork-safety: nothing a fork ships may contain your deployment URL, and the origin must be read from config before any fallback.

**Not changed:** `/create` and `/editor` are `disallow`ed in robots.txt, which caps their SEO score at 63. That's deliberate — they're the tool, not marketing pages — so I left it.