### PR TITLE
Fix contributor setup, which still asked for a database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,9 @@
 # Only worth setting on a real deployment.
 SITE_URL=""
 
-# Rate limiting for the two API routes. Without these the limiter falls back to
-# an in-memory store, which is correct for a single instance and fine locally.
+# Rate limiting for the export route, the only one that takes a request body.
+# Without these the limiter falls back to an in-memory store, which is correct
+# for a single instance and fine locally.
 UPSTASH_REDIS_REST_URL=""
 UPSTASH_REDIS_REST_TOKEN=""
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,5 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# temporary frame extraction files
+# scratch directory, in case a script wants one
 /tmp
-
-# Prisma generated client is regenerated via postinstall/build — do not commit
-# /src/generated/prisma

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,21 +18,20 @@ isn't tolerated.
 
 ## Development setup
 
-> Requires Node.js 20+ and a PostgreSQL database.
+> Requires Node.js 20+. That is the whole list.
 
 ```bash
 # Fork the repo, then:
 git clone https://github.com/<your-username>/scrollcraft.git
 cd scrollcraft
 npm install
-
-cp .env.example .env          # fill in DATABASE_URL + NEXTAUTH_SECRET at minimum
-npx prisma migrate deploy     # apply the schema
 npm run dev
 ```
 
-You can develop most features in **demo mode** (no AI/payment keys needed) — the editor
-falls back to placeholder frames.
+There is no database to provision, no account to create and no key to obtain. Every
+environment variable is optional, so the app runs with no `.env` at all. If you want
+error reporting or shared rate limiting while developing, `.env.example` lists what
+those need.
 
 ## Workflow
 
@@ -68,9 +67,9 @@ falls back to placeholder frames.
 Follow [Conventional Commits](https://www.conventionalcommits.org):
 
 ```
-feat: add Lemon Squeezy one-time export checkout
-fix: read LS custom_data from meta in webhook
-docs: rewrite README for ScrollCraft
+feat: autosave the editor instead of relying on the Save button
+fix: stop the toasts from following the OS instead of the app
+docs: fix contributor setup, which still asked for a database
 ```
 
 ## Coding standards
@@ -83,21 +82,19 @@ docs: rewrite README for ScrollCraft
 - **Log, don't `console.log`** — use the structured `logger` from `src/lib/logger.ts` in API/server code.
 - **Lint clean** — don't introduce new ESLint errors. Run `npm run lint` before pushing.
 
-## Database changes
+## Where state lives
 
-When you change `prisma/schema.prisma`:
+There is no server-side state to change. A visitor's work is held in their own browser
+(IndexedDB, via `src/lib/frameStorage.ts`) until they export it, and the two API routes
+hold nothing between requests.
 
-1. Create a migration:
-   ```bash
-   npx prisma migrate dev --name short_description
-   ```
-2. Commit **both** the schema change and the generated SQL in `prisma/migrations/`.
-3. The generated client lives in `src/generated/prisma` and is regenerated on `npm run build` / `postinstall`.
+If a change would need somewhere to persist data, say so in the issue before building
+it — adding a database back is a product decision, not an implementation detail.
 
 ## Tests
 
 - Tests live in `src/__tests__/` and run with [Vitest](https://vitest.dev).
-- Add tests for new logic, especially anything security- or payment-related
+- Add tests for new logic, especially anything that touches the exporter, the scroll engine, or what the site claims about itself
   (signature verification, rate limiting, idempotency).
 - Run the suite with `npm test`.
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ unexported work is gone.** Export early.
 ```
 src/
 ├── app/
-│   ├── api/              # Route handlers (sites, payments, webhooks, export, …)
+│   ├── api/              # Route handlers (export-site, demo-frame, health)
 │   ├── templates/        # Template gallery + preview (/templates, /templates/[slug])
 │   ├── editor/           # The visual scroll-site editor
 │   └── create/           # Style + upload → editor flow

--- a/docs/WATCHDOG.md
+++ b/docs/WATCHDOG.md
@@ -15,7 +15,7 @@ when something breaks — under strict rules so it stays useful instead of noisy
 | `prod-template-preview` | a template page does not return 200. |
 | `prod-sitemap` | `/sitemap.xml` is missing or has no template URLs. |
 
-**Code** (daily, and on every push to `main` that touches `src/`, `prisma/`, or the watchdog):
+**Code** (daily, and on every push to `main` that touches `src/` or the watchdog):
 
 | Check | Fails when |
 | --- | --- |


### PR DESCRIPTION
## The blocker

`CONTRIBUTING.md` told a new contributor to provision PostgreSQL, copy `.env`, fill in `DATABASE_URL` and `NEXTAUTH_SECRET`, and run `npx prisma migrate deploy`. None of that has existed since #345, so anyone following the guide would stall before the app ran at all — the worst place to lose someone who wanted to help.

Setup is now clone, install, dev. **Verified from a clean `git clone` with no `.env`:** install and build both succeed.

The database-migration section becomes a short note on where state actually lives, and the point that adding persistence back is a product decision to raise in an issue rather than something to slip into a PR.

## The rest of the sweep

Same class of leftover, found by grepping the docs for the removed stack:

| | was | now |
| --- | --- | --- |
| `CONTRIBUTING.md` commit examples | two of three described Lemon Squeezy checkout and an LS webhook | three real commits from this repo |
| `.gitignore` | a Prisma generated-client note; `/tmp` described as frame extraction files | the note goes; extraction moved into the browser, nothing writes there |
| `.env.example` | Upstash keys cover "the two API routes" | there are three routes and one is rate limited |
| `README.md` | route tree out of date | corrected |
| `docs/WATCHDOG.md` | triggers on pushes touching `prisma/` | that path is gone |

Grepping the docs for `prisma`, `postgres`, `nextauth`, `DATABASE_URL`, `lemon` and `razorpay` now returns nothing.

Docs and ignore rules only — no source changes.