### PR TITLE
Autosave the editor instead of relying on the Save button

### DIFF
--- a/src/__tests__/editorAutosave.test.ts
+++ b/src/__tests__/editorAutosave.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { AUTOSAVE_DEBOUNCE_MS, saveStatusLabel } from "@/lib/saveStatus";
+
+/**
+ * A document lives in this browser and nowhere else, so the editor writes it without
+ * being asked. Verified in Chrome before landing: opening /editor?template=orbitcrm,
+ * typing in the site name and never touching Save leaves the document in IndexedDB
+ * within the debounce window; on the previous build the database was never created.
+ */
+
+const EDITOR = readFileSync("src/app/editor/page.tsx", "utf8");
+
+describe("save status label", () => {
+  it("says nothing when there is nothing to say", () => {
+    expect(saveStatusLabel(false, "idle")).toBeNull();
+  });
+
+  it("prefers a new edit over an earlier success", () => {
+    // The window between a keystroke and the next write is exactly when "Saved" would
+    // convince someone it is safe to close the tab.
+    expect(saveStatusLabel(true, "saved")).toBe("Unsaved changes");
+    expect(saveStatusLabel(false, "saved")).toBe("Saved");
+  });
+
+  it("reports a failure over anything else", () => {
+    expect(saveStatusLabel(false, "failed")).toBe("Not saved");
+    expect(saveStatusLabel(true, "failed")).toBe("Not saved");
+  });
+
+  it("reports a write in flight over a pending edit", () => {
+    expect(saveStatusLabel(true, "saving")).toBe("Saving…");
+  });
+});
+
+describe("editor autosave", () => {
+  it("debounces long enough to not write mid-word, short enough to survive a closed tab", () => {
+    expect(AUTOSAVE_DEBOUNCE_MS).toBeGreaterThanOrEqual(500);
+    expect(AUTOSAVE_DEBOUNCE_MS).toBeLessThanOrEqual(5000);
+  });
+
+  it("writes the document on a timer, not only from the Save button", () => {
+    expect(EDITOR).toMatch(/setTimeout\(\s*\(\)\s*=>\s*\{[\s\S]*?writeDocumentRef\.current\(/);
+    expect(EDITOR).toContain("}, AUTOSAVE_DEBOUNCE_MS);");
+  });
+
+  it("does not force a frame write on the autosave path", () => {
+    // Frames are megabytes. Rewriting them per keystroke would push IndexedDB into
+    // eviction and stall the editor; the signature check inside writeDocument still
+    // persists them the first time and whenever the background actually changes.
+    expect(EDITOR).toContain("writeDocumentRef.current({ withFrames: false })");
+    expect(EDITOR).toContain("await writeDocument({ withFrames: true })");
+  });
+
+  it("holds off while the editor is still restoring or has nothing real to save", () => {
+    expect(EDITOR).toContain("if (!dirty || isDemo || hydrating) return;");
+  });
+
+  it("leaves edits made during a write marked unsaved", () => {
+    const autosave = EDITOR.slice(EDITOR.indexOf("AUTOSAVE_DEBOUNCE_MS);") - 1200);
+    expect(autosave).toMatch(/editGenRef\.current !== genAtSave/);
+  });
+
+  it("keeps the unload warning as the backstop for the debounce window", () => {
+    expect(EDITOR).toContain('window.addEventListener("beforeunload", onBeforeUnload);');
+    expect(EDITOR).toMatch(/if \(!dirty\) return;/);
+  });
+});

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -22,11 +22,48 @@ import { siteStyleSchema, themeSchema, type EditorSection, type SiteStyle, type 
 import { templateBySlug, type Template } from "@/lib/templates";
 import { faviconSvg, notFoundHtml, exportReadme, renderSocialCard } from "@/lib/exportAssets";
 import { generate2DFrames } from "@/lib/generate2DFrames";
+import { AUTOSAVE_DEBOUNCE_MS, saveStatusLabel, type SaveState } from "@/lib/saveStatus";
 
 const ScrollEngine = dynamic(() => import("@/components/ScrollEngine"), { ssr: false });
 const ScrollSection = dynamic(() => import("@/components/ScrollSection"), { ssr: false });
 
 type Section = EditorSection;
+
+const SAVED_FRAMES_KEY = "scrollcraft_saved_frames";
+const SAVED_MOBILE_FRAMES_KEY = "scrollcraft_saved_mframes";
+
+/** Autosave is silent, so this is the only place the user can see whether work is safe. */
+function SaveIndicator({ dirty, state }: { dirty: boolean; state: SaveState }) {
+  const label = saveStatusLabel(dirty, state);
+  if (!label) return null;
+  if (label === "Saving…") {
+    return (
+      <span role="status" className="flex items-center gap-1 flex-shrink-0 text-xs text-muted-foreground">
+        <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />{label}
+      </span>
+    );
+  }
+  if (label === "Not saved") {
+    return (
+      <span
+        role="status"
+        className="flex-shrink-0 text-xs text-amber-400"
+        title="Autosave failed. Your browser may be out of storage or in private mode - export to keep your work."
+      >
+        {label}
+      </span>
+    );
+  }
+  if (label === "Unsaved changes") {
+    return (
+      <span role="status" className="flex items-center flex-shrink-0" title={label}>
+        <span aria-hidden="true" className="w-1.5 h-1.5 rounded-full bg-amber-400" />
+        <span className="sr-only">{label}</span>
+      </span>
+    );
+  }
+  return <span role="status" className="flex-shrink-0 text-xs text-muted-foreground">{label}</span>;
+}
 
 const defaultSection = (i: number): Section => ({
   id: `section-${Date.now()}-${i}`,
@@ -264,7 +301,7 @@ function EditorInner() {
 
         // Frames first; if storage dropped them, the recipe can redraw the background.
         const storedFrames = doc.framesKey ? await loadFrames(doc.framesKey).catch(() => null) : null;
-        const storedMobile = await loadFrames("scrollcraft_saved_mframes").catch(() => null);
+        const storedMobile = await loadFrames(SAVED_MOBILE_FRAMES_KEY).catch(() => null);
         if (cancelled) return;
         if (storedFrames?.length) {
           setFrames(storedFrames);
@@ -319,6 +356,7 @@ function EditorInner() {
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const [saveState, setSaveState] = useState<SaveState>("idle");
   // Bumped on every content edit. A save captures this at its start and only clears the
   // dirty flag if it is unchanged when the request resolves — otherwise edits the user
   // made while the save was in flight would be silently marked as saved.
@@ -606,8 +644,41 @@ function EditorInner() {
    *
    * There is no account and no server, so this is the whole persistence story: the
    * document goes to IndexedDB and is restored the next time the editor opens. Frames
-   * are stored under their own key because they are far too large to sit alongside it.
+   * are stored under their own key because they are far too large to sit alongside it,
+   * and are rewritten only when their contents change so an autosave on every keystroke
+   * does not push megabytes through IndexedDB.
    */
+  const savedFramesSigRef = useRef<string>("");
+  const framesSignature = `${frames.length}:${frames[0]?.slice(0, 64) ?? ""}:${mobileFrames.length}`;
+
+  const writeDocument = async (opts: { withFrames: boolean }): Promise<boolean> => {
+    let framesCached = savedFramesSigRef.current === framesSignature;
+
+    if (opts.withFrames || !framesCached) {
+      framesCached = await storeFrames(SAVED_FRAMES_KEY, frames).then(() => true, () => false);
+      if (framesCached) {
+        savedFramesSigRef.current = framesSignature;
+        if (mobileFrames.length) {
+          await storeFrames(SAVED_MOBILE_FRAMES_KEY, mobileFrames).catch(() => {});
+        }
+      }
+    }
+
+    await storeDocument({
+      name: siteName,
+      description: siteDescription || undefined,
+      sections,
+      themeJson: siteTheme ? JSON.stringify(siteTheme) : null,
+      styleJson: styleSpec ? JSON.stringify(styleSpec) : null,
+      customHead,
+      customCss,
+      fps,
+      framesKey: framesCached ? SAVED_FRAMES_KEY : undefined,
+      savedAt: new Date().toISOString(),
+    });
+    return framesCached;
+  };
+
   const handleSave = async (opts?: { silent?: boolean }): Promise<string | null> => {
     if (isDemo) {
       if (!opts?.silent) toast.error("Nothing to save yet - pick a template or generate a background first");
@@ -615,41 +686,56 @@ function EditorInner() {
     }
     setIsSaving(true);
     const genAtSave = editGenRef.current;
-    const framesKeyForDoc = "scrollcraft_saved_frames";
     try {
-      const framesCached = await storeFrames(framesKeyForDoc, frames).then(() => true, () => false);
-      if (mobileFrames.length) {
-        await storeFrames("scrollcraft_saved_mframes", mobileFrames).catch(() => {});
-      }
-
-      await storeDocument({
-        name: siteName,
-        description: siteDescription || undefined,
-        sections,
-        themeJson: siteTheme ? JSON.stringify(siteTheme) : null,
-        styleJson: styleSpec ? JSON.stringify(styleSpec) : null,
-        customHead,
-        customCss,
-        fps,
-        framesKey: framesCached ? framesKeyForDoc : undefined,
-        savedAt: new Date().toISOString(),
-      });
+      const framesCached = await writeDocument({ withFrames: true });
 
       // Only clear dirty if nothing changed while the write was in flight, so those
       // edits are not silently marked as saved.
       if (editGenRef.current === genAtSave) setDirty(false);
+      setSaveState("saved");
       if (!opts?.silent) {
         if (framesCached) toast.success("Saved in this browser");
         else toast.warning("Saved, but the background could not be cached - export to keep it.");
       }
-      return framesKeyForDoc;
+      return SAVED_FRAMES_KEY;
     } catch {
+      setSaveState("failed");
       toast.error("Couldn't save. Your browser may be out of storage or in private mode.");
       return null;
     } finally {
       setIsSaving(false);
     }
   };
+
+  // The autosave timer below is scheduled by one render and fires during another, so it
+  // reaches the current writeDocument through a ref rather than a stale closure.
+  const writeDocumentRef = useRef(writeDocument);
+  useEffect(() => { writeDocumentRef.current = writeDocument; });
+
+  /**
+   * Autosave.
+   *
+   * Everything lives in this browser, so an unsaved editor is one closed tab away from
+   * being gone. Wait for a pause in typing, then write; the beforeunload warning stays as
+   * the backstop for a tab closed inside that window.
+   */
+  useEffect(() => {
+    if (!dirty || isDemo || hydrating) return;
+    const timer = setTimeout(() => {
+      const genAtSave = editGenRef.current;
+      setSaveState("saving");
+      writeDocumentRef.current({ withFrames: false }).then(
+        () => {
+          // Edits made while the write was in flight are still unsaved.
+          if (editGenRef.current !== genAtSave) { setSaveState("idle"); return; }
+          setDirty(false);
+          setSaveState("saved");
+        },
+        () => setSaveState("failed"),
+      );
+    }, AUTOSAVE_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [dirty, isDemo, hydrating, sections, siteName, siteDescription, customHead, customCss, fps, styleSpec, siteTheme, framesSignature]);
 
   const totalScrollHeight = sections.filter(s => s.visible).reduce((a, s) => a + s.scrollHeight, 0) + 1000;
 
@@ -722,7 +808,7 @@ function EditorInner() {
             onChange={(e) => { setSiteName(e.target.value); setDirty(true); }}
             className="h-7 bg-transparent border-transparent hover:border-white/10 focus:border-primary/50 text-sm font-medium w-48"
           />
-          {dirty && <span title="Unsaved changes" className="w-1.5 h-1.5 rounded-full bg-amber-400 flex-shrink-0" />}
+          <SaveIndicator dirty={dirty} state={saveState} />
           {isDemo && <Badge variant="outline" className="border-amber-500/40 text-amber-400 text-xs">Demo mode</Badge>}
         </div>
 

--- a/src/lib/saveStatus.ts
+++ b/src/lib/saveStatus.ts
@@ -1,0 +1,27 @@
+/**
+ * The editor's save state, and what to tell the user about it.
+ *
+ * There is no account and no server: a document lives in this browser and nowhere else,
+ * so whether the last write succeeded is the only thing standing between the user and a
+ * lost afternoon. This label is the whole signal, which is why the precedence below is
+ * pinned by tests rather than left to the component.
+ */
+export type SaveState = "idle" | "saving" | "saved" | "failed";
+
+/** How long the editor waits for typing to stop before writing to IndexedDB. */
+export const AUTOSAVE_DEBOUNCE_MS = 1500;
+
+export type SaveStatusLabel = "Saving…" | "Not saved" | "Unsaved changes" | "Saved";
+
+/**
+ * `dirty` outranks a past success on purpose: the moment a new edit lands, "Saved" is a
+ * lie until the next write completes. A failure outranks everything, because a user who
+ * is not told the write failed will close the tab.
+ */
+export function saveStatusLabel(dirty: boolean, state: SaveState): SaveStatusLabel | null {
+  if (state === "saving") return "Saving…";
+  if (state === "failed") return "Not saved";
+  if (dirty) return "Unsaved changes";
+  if (state === "saved") return "Saved";
+  return null;
+}


### PR DESCRIPTION
## Why

There is no account and no server, so a document lives in IndexedDB and nowhere else. Until now only the Save button wrote it, with a `beforeunload` prompt as the only thing between an afternoon of edits and a closed tab.

## What

- The editor writes after a 1.5s pause in typing, gated on `dirty && !isDemo && !hydrating` so a restore never overwrites itself and demo mode stays a no-op.
- Frames are the expensive part of that write, so `writeDocument` rewrites them only when their contents change. The first autosave of a session persists the background; later ones carry the document alone. Manual Save still forces a frame write.
- Edits that land while a write is in flight stay marked unsaved, matching what the Save button already did.
- The bare amber dot becomes a real status. `saveStatusLabel` puts a failure above everything and a new edit above an earlier success, so "Saved" is never on screen over work that is not saved. It lives in `src/lib/saveStatus.ts` because that precedence is the thing worth testing.
- The unload warning stays as the backstop for a tab closed inside the debounce window.

## Verification

Driven in headless Chrome against a production build, `/editor?template=orbitcrm`: no existing database, type in the site name, never touch Save.

| | this branch | previous build |
| --- | --- | --- |
| IndexedDB before the edit | does not exist | does not exist |
| status after typing | `Unsaved changes` | no status element |
| status 6s later | `Saved` | no status element |
| document in IndexedDB | name, 5 sections, frames key | database never created |

Suite 233 passed, up from 223. Stashing only `src/app/editor/page.tsx` fails 4 of the 5 new source assertions; the fifth pins the pre-existing unload backstop and passes both ways by design.