### PR TITLE
Stop the toasts from following the OS instead of the app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "jszip": "^3.10.1",
         "lucide-react": "^1.17.0",
         "next": "^16.2.12",
-        "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "server-only": "^0.0.1",
@@ -9564,16 +9563,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-themes": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
-      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "jszip": "^3.10.1",
     "lucide-react": "^1.17.0",
     "next": "^16.2.12",
-    "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "server-only": "^0.0.1",

--- a/src/__tests__/appAccessibility.test.ts
+++ b/src/__tests__/appAccessibility.test.ts
@@ -144,6 +144,28 @@ describe("the editor is reachable without a mouse", () => {
   });
 });
 
+describe("the app has one theme and every component agrees on it", () => {
+  it("fixes the theme on the document, with no provider and no switch", () => {
+    expect(readFileSync("src/app/layout.tsx", "utf8")).toMatch(/<html lang="en" className={`dark /);
+    // Nothing resolves the theme at runtime, so nothing may ask the OS what it is.
+    const askers = sourceFiles().filter((f) => readFileSync(f, "utf8").includes("next-themes"));
+    expect(askers, "a component reads the theme from next-themes, which has no provider").toEqual([]);
+  });
+
+  it("tells the toaster the theme instead of letting it read the OS", () => {
+    // useTheme() with no provider returns "system", so sonner followed
+    // prefers-color-scheme. Measured in Chrome with the media feature emulated: on a
+    // machine set to light the toaster rendered data-sonner-theme="light" and a
+    // rgb(240,248,255) card over the black app.
+    expect(readFileSync("src/components/ui/sonner.tsx", "utf8")).toContain('theme="dark"');
+  });
+
+  it("has dropped the dependency that was only there to answer that question", () => {
+    const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+    expect({ ...pkg.dependencies, ...pkg.devDependencies }["next-themes"]).toBeUndefined();
+  });
+});
+
 describe("analytics does not break a self-hosted deploy", () => {
   it("only mounts the Vercel script when Vercel is serving", () => {
     // Mounted unconditionally the insights script 404s and trips strict MIME checking,

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,15 +1,17 @@
 "use client"
 
-import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
 
+/**
+ * The app is dark everywhere: `<html className="dark">` in the root layout, with no
+ * theme provider and no switch. Sonner has to be told that, or it resolves its own
+ * theme from the OS and renders a white toast over a black page.
+ */
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
-
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme="dark"
       className="toaster group"
       icons={{
         success: (


### PR DESCRIPTION
## The bug

The site is dark unconditionally: `<html className="dark">` in the root layout, no theme provider, no switch. The `Toaster` asked `next-themes` for the theme anyway, and with no provider mounted `useTheme()` answers `"system"` — so sonner resolved `prefers-color-scheme` itself and followed the machine, not the app.

Measured in Chrome with `Emulation.setEmulatedMedia` on a production build, reading the live toaster DOM on `/editor`:

| OS setting | before | after |
| --- | --- | --- |
| light | `data-sonner-theme="light"`, toast `rgb(240, 248, 255)` | `data-sonner-theme="dark"`, toast `rgb(0, 13, 31)` |
| dark | `data-sonner-theme="dark"`, toast `rgb(0, 13, 31)` | `data-sonner-theme="dark"`, toast `rgb(0, 13, 31)` |

So roughly every visitor whose machine is set to light saw a white card appear over the black app, on every toast in the editor, the create flow and the contact form.

## The fix

Tell sonner the theme instead of letting it ask. `next-themes` was in the dependency list only to answer that question, so it goes with it.

Three tests in `appAccessibility.test.ts`, next to the other checks that pin decisions found by auditing the running app: the document fixes the theme, nothing imports `next-themes`, and the toaster is given a literal. All three fail on `main`.

Suite 236 passed.