### PR TITLE
Stop allowing a payment processor the app no longer uses

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -14,15 +14,22 @@ const securityHeaders = [
     key: "Content-Security-Policy",
     value: [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://checkout.razorpay.com",
+      // 'unsafe-eval' stays: JSZip's bundled shims call it behind a try/catch, and the
+      // export path has not been verified without it.
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "img-src 'self' data: blob: https:",
       // data: is required — the editor reads an uploaded track with readAsDataURL, so
       // without it every upload is blocked by CSP and scroll audio silently never plays.
       "media-src 'self' blob: data:",
-      "connect-src 'self' https://checkout.razorpay.com https://*.sentry.io",
-      "frame-src https://api.razorpay.com https://checkout.razorpay.com",
+      "connect-src 'self' https://*.sentry.io",
       "font-src 'self' https://fonts.gstatic.com",
+      // Nothing here frames anything, and nothing may frame it.
+      "frame-src 'none'",
+      "frame-ancestors 'none'",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
     ].join("; "),
   },
 ];

--- a/src/__tests__/securityHeaders.test.ts
+++ b/src/__tests__/securityHeaders.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The Content-Security-Policy, read from next.config.ts.
+ *
+ * It is the one piece of the payment integration that survived its removal: the policy
+ * still let a payment processor run scripts, be framed, and be talked to, on every page
+ * of an app that no longer takes money. A policy is only as good as its narrowest
+ * directive, so the checks below are about what it does *not* allow.
+ */
+const CONFIG = readFileSync("next.config.ts", "utf8");
+
+const directives: Record<string, string> = Object.fromEntries(
+  [...CONFIG.matchAll(/^\s*"([a-z-]+) ([^"]*)",\s*$/gm)]
+    .filter(([, name]) => name.includes("-src") || name.startsWith("frame-") || name.startsWith("base-") || name.startsWith("form-"))
+    .map(([, name, value]) => [name, value])
+);
+
+describe("the content security policy", () => {
+  it("was parsed out of the config at all", () => {
+    // If the shape of the config changes, every assertion below would pass vacuously.
+    expect(Object.keys(directives)).toContain("default-src");
+    expect(Object.keys(directives).length).toBeGreaterThan(6);
+  });
+
+  it("names no payment processor", () => {
+    // Razorpay held script-src, connect-src and frame-src grants. Payments were removed;
+    // the grants were not, so a third party kept permission to execute on every page.
+    const offenders = Object.entries(directives).filter(([, value]) =>
+      /razorpay|stripe|lemonsqueezy|paypal|checkout\./i.test(value)
+    );
+    expect(offenders, "a payment host is still allowed").toEqual([]);
+  });
+
+  it("allows scripts only from this origin", () => {
+    const hosts = directives["script-src"].split(/\s+/).filter((t) => !t.startsWith("'"));
+    expect(hosts, "script-src names a third-party host").toEqual([]);
+  });
+
+  it("frames nothing and may not be framed", () => {
+    expect(directives["frame-src"]).toBe("'none'");
+    expect(directives["frame-ancestors"]).toBe("'none'");
+  });
+
+  it("closes the directives that do not fall back to default-src", () => {
+    // base-uri and form-action are not covered by default-src: without them a single
+    // injected tag can retarget every relative URL or every form post on the page.
+    expect(directives["base-uri"]).toBe("'self'");
+    expect(directives["form-action"]).toBe("'self'");
+    expect(directives["object-src"]).toBe("'none'");
+  });
+});
+
+describe("the transport and framing headers", () => {
+  it("keeps the ones a scanner checks for", () => {
+    for (const header of [
+      "X-Frame-Options",
+      "X-Content-Type-Options",
+      "Referrer-Policy",
+      "Permissions-Policy",
+      "Strict-Transport-Security",
+    ]) {
+      expect(CONFIG, `${header} is no longer sent`).toContain(header);
+    }
+  });
+
+  it("applies them to every route, not just the pages", () => {
+    expect(CONFIG).toContain('source: "/(.*)", headers: securityHeaders');
+  });
+});
+
+describe("nothing in the app still talks to a payment processor", () => {
+  it("has no client that would need the grants back", () => {
+    const out: string[] = [];
+    (function walk(dir: string) {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (/\.(ts|tsx)$/.test(entry.name)) out.push(full);
+      }
+    })("src");
+    const offenders = out.filter((f) => {
+      const t = readFileSync(f, "utf8");
+      // The changelog records the removal by name, which is not a caller.
+      return /razorpay|lemonsqueezy/i.test(t) && !f.includes("changelog") && !f.includes("__tests__");
+    });
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The leftover

Payments were removed in #345. Their Content-Security-Policy grants were not. Every page still shipped:

```
script-src  … https://checkout.razorpay.com
connect-src … https://checkout.razorpay.com
frame-src   https://api.razorpay.com https://checkout.razorpay.com
```

So a third party kept permission to execute scripts on, be framed by, and be connected to from every page of an app that takes no money and loads nothing from either host. `razorpay` appears nowhere else in `src/` except a changelog line recording its removal.

## What changed

Those grants go. The directives that were never there go in:

| directive | value | why |
| --- | --- | --- |
| `frame-src` | `'none'` | nothing here frames anything |
| `frame-ancestors` | `'none'` | the CSP equivalent of the `X-Frame-Options: DENY` already sent |
| `object-src` | `'none'` | no plugins, ever |
| `base-uri` | `'self'` | **not** covered by `default-src`: one injected `<base>` retargets every relative URL |
| `form-action` | `'self'` | **not** covered by `default-src`: one injected tag retargets every form post |

`'unsafe-eval'` stays. JSZip's bundled shims call it behind a `try/catch`, and dropping it reports a `script-src blocked eval` violation on `/templates`, `/templates/[slug]` and `/editor`. Nothing visibly broke, but the export path has not been verified without it, so that belongs in its own change.

## Verified

Driven in Chrome against a production build, listening for `securitypolicyviolation`, `error`, `unhandledrejection` and console errors on each route:

```
/ /templates /templates/orbitcrm /presets /create /about
/privacy /terms /cookies /changelog /contact /editor?template=orbitcrm
```

Twelve routes, all `csp=0 pageErrors=0 consoleErrors=0`.

## Tests

`src/__tests__/securityHeaders.test.ts` parses the policy back out of the config and asserts on what it refuses, with a guard test so the assertions cannot pass vacuously if the config's shape changes. Four of the eight fail on `main`.

Suite 241 passed.