### PR TITLE
Load the client Sentry SDK only when a DSN exists

### DIFF
--- a/src/__tests__/sentryClientLoading.test.ts
+++ b/src/__tests__/sentryClientLoading.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The client Sentry SDK must not be a static import.
+ *
+ * `enabled: !!dsn` stopped it reporting, not shipping. Measured over the wire against a
+ * production build with no DSN, which is how this project and every fork of it is
+ * configured: /privacy fell from 347.5 KiB of JS to 283.6 KiB once the SDK left the
+ * initial graph. NEXT_PUBLIC_ values are inlined at build time, so the branch guarding
+ * the dynamic import compiles away entirely.
+ */
+
+function clientFiles(): string[] {
+  const out: string[] = [];
+  (function walk(dir: string) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "__tests__") continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (/\.tsx?$/.test(entry.name)) out.push(full);
+    }
+  })("src");
+  // Server modules may import it however they like: none of it reaches a browser.
+  const serverOnly = ["src/lib/logger.ts", "src/instrumentation.ts"];
+  return out.filter((f) => !serverOnly.includes(f));
+}
+
+const STATIC_IMPORT = /^\s*import\s[^;]*from\s+["']@sentry\/nextjs["']/m;
+
+describe("the client Sentry SDK is loaded, not shipped", () => {
+  it("is never a static import in anything that reaches the browser", () => {
+    const offenders = clientFiles().filter((f) => STATIC_IMPORT.test(readFileSync(f, "utf8")));
+    expect(offenders, "a static import puts the whole SDK in the initial bundle").toEqual([]);
+  });
+
+  it("only imports it when a DSN exists at build time", () => {
+    const client = readFileSync("src/instrumentation-client.ts", "utf8");
+    expect(client).toContain("const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;");
+    expect(client).toMatch(/if \(dsn\) \{\s*\n\s*import\("@sentry\/nextjs"\)/);
+  });
+
+  it("still exports the router transition hook Next calls synchronously", () => {
+    // Without this export, client-side navigations are missing from traces. It cannot
+    // await the import, so it forwards once the SDK has arrived.
+    const client = readFileSync("src/instrumentation-client.ts", "utf8");
+    expect(client).toContain("export const onRouterTransitionStart");
+    expect(client).toContain("capture?.(href, navigationType)");
+  });
+
+  it("never lets a failed report replace the error the user is looking at", () => {
+    expect(readFileSync("src/lib/captureClientError.ts", "utf8")).toContain(".catch(");
+    expect(readFileSync("src/instrumentation-client.ts", "utf8")).toContain(".catch(");
+  });
+
+  it("does not tell the user they have been notified when nobody has", () => {
+    // With no DSN, and that is the default, nothing is reported anywhere.
+    const boundaries = ["src/app/global-error.tsx", "src/app/create/error.tsx", "src/app/editor/error.tsx"];
+    for (const f of boundaries) {
+      expect(readFileSync(f, "utf8"), `${f} promises a report that may never be sent`)
+        .not.toMatch(/been notified|looking into it/i);
+    }
+  });
+});

--- a/src/app/create/error.tsx
+++ b/src/app/create/error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
 import { useEffect } from "react";
+import { captureClientError } from "@/lib/captureClientError";
 import { Button } from "@/components/ui/button";
 
 export default function CreateError({
@@ -12,7 +12,7 @@ export default function CreateError({
   reset: () => void;
 }) {
   useEffect(() => {
-    Sentry.captureException(error);
+    captureClientError(error);
   }, [error]);
 
   return (

--- a/src/app/editor/error.tsx
+++ b/src/app/editor/error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
 import { useEffect } from "react";
+import { captureClientError } from "@/lib/captureClientError";
 import { Button } from "@/components/ui/button";
 
 export default function EditorError({
@@ -12,7 +12,7 @@ export default function EditorError({
   reset: () => void;
 }) {
   useEffect(() => {
-    Sentry.captureException(error);
+    captureClientError(error);
   }, [error]);
 
   return (

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,10 +1,10 @@
 "use client";
-import * as Sentry from "@sentry/nextjs";
 import { useEffect } from "react";
+import { captureClientError } from "@/lib/captureClientError";
 
 export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
-    Sentry.captureException(error);
+    captureClientError(error);
   }, [error]);
 
   return (
@@ -12,7 +12,7 @@ export default function GlobalError({ error, reset }: { error: Error & { digest?
       <body className="min-h-screen bg-black text-white flex items-center justify-center">
         <div className="text-center space-y-4">
           <h2 className="text-2xl font-bold">Something went wrong</h2>
-          <p className="text-white/60">We&apos;ve been notified and are looking into it.</p>
+          <p className="text-white/60">Reloading usually clears it.</p>
           <button
             onClick={reset}
             className="px-6 py-2 bg-violet-600 hover:bg-violet-700 rounded-lg font-medium transition-colors"

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,12 +1,38 @@
-import * as Sentry from "@sentry/nextjs";
+/**
+ * Sentry on the client, only when there is somewhere to send to.
+ *
+ * `enabled: !!dsn` stopped it reporting but not shipping: the SDK was a static import,
+ * so every page of every deployment downloaded it whether or not a DSN existed. No DSN
+ * is set on this project, and a fork has none by definition.
+ *
+ * NEXT_PUBLIC_ values are inlined at build time, so a build without a DSN compiles the
+ * branch below away and the SDK never enters the bundle.
+ */
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: parseFloat(process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE ?? "0.5"),
-  debug: false,
-  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
-});
+type CaptureRouterTransitionStart = (href: string, navigationType: string) => void;
+let capture: CaptureRouterTransitionStart | undefined;
 
-// Next 16 calls this on client-side navigations. Without it, router transitions are
-// missing from traces even once the SDK is loading.
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+if (dsn) {
+  import("@sentry/nextjs")
+    .then((Sentry) => {
+      Sentry.init({
+        dsn,
+        tracesSampleRate: parseFloat(process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE ?? "0.5"),
+        debug: false,
+      });
+      capture = Sentry.captureRouterTransitionStart;
+    })
+    .catch(() => {
+      // Losing error reporting must never take the app with it.
+    });
+}
+
+/**
+ * Next 16 calls this on client-side navigations, and needs it to exist synchronously, so
+ * it forwards to the SDK once the import above resolves. Navigations before that are not
+ * traced, which was already true while the SDK was loading.
+ */
+export const onRouterTransitionStart: CaptureRouterTransitionStart = (href, navigationType) => {
+  capture?.(href, navigationType);
+};

--- a/src/lib/captureClientError.ts
+++ b/src/lib/captureClientError.ts
@@ -1,0 +1,20 @@
+"use client";
+
+/**
+ * Report a client error, if there is anywhere to send it.
+ *
+ * The error boundaries imported the SDK statically, and global-error.tsx is in the root
+ * client graph, so that put Sentry in the chunk every page loads whether or not a DSN
+ * existed. NEXT_PUBLIC_ values are inlined at build time, so a build with no DSN compiles
+ * the import away.
+ */
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+export function captureClientError(error: unknown): void {
+  if (!dsn) return;
+  import("@sentry/nextjs")
+    .then((Sentry) => Sentry.captureException(error))
+    .catch(() => {
+      // Losing the report must never replace the error the user is already looking at.
+    });
+}


### PR DESCRIPTION
## The problem

`enabled: !!dsn` stopped Sentry reporting but not shipping. The SDK was a static import in [src/instrumentation-client.ts](src/instrumentation-client.ts), so every page of every deployment downloaded it whether or not there was anywhere to send to.

`vercel env ls` lists two variables on this project, both Upstash. **No Sentry DSN is set in production or preview**, and a fork has none by definition. So today this is pure weight on every page for every visitor.

## The change

`NEXT_PUBLIC_` values are inlined at build time, so guarding a dynamic import on the DSN compiles the branch away when there is none. `onRouterTransitionStart` still has to exist synchronously, so it forwards to the SDK once the import resolves.

The three client error boundaries move to the same shape through [src/lib/captureClientError.ts](src/lib/captureClientError.ts), and `global-error.tsx` stops saying "We've been notified and are looking into it", which with no DSN was not true.

## Measured

Over the wire against production builds, JS bytes with the cache cleared.

**No DSN, which is how this project is configured:**

| route | before | after | |
| --- | --- | --- | --- |
| `/privacy` | 347.5 KiB | 283.6 KiB | −63.9 |
| `/` | 342.5 KiB | 277.0 KiB | −65.5 |
| `/editor` | 452.9 KiB | 384.1 KiB | −68.8 |
| `/templates` | 466.4 KiB | 402.2 KiB | −64.2 |

**With a DSN:**

| route | before | after | |
| --- | --- | --- | --- |
| `/privacy` | 347.5 KiB | 464.4 KiB | **+116.9** |

## The tradeoff, stated plainly

That second table is the cost. A dynamic import is a chunk boundary Turbopack does not tree-shake across, so a deploy that opts into Sentry downloads the whole SDK (a 177 KiB chunk) rather than the shaken subset the static import produced. I tried narrowing it — named exports instead of the namespace, an explicit `integrations` list — and it stayed at 464.4 KiB exactly.

What that deploy gets in exchange: the SDK arrives after hydration instead of blocking it, and the cost falls only on deployments where somebody asked for error reporting.

If you would rather have the old numbers for a DSN-set deploy, say so and I will close this. The alternative worth considering is dropping the client SDK entirely, which would be −64 KiB with no downside for anyone, at the cost of client-side error reporting as an option.

## Verified

- With a DSN set at build time, the SDK loads and binds a client: `window.__SENTRY__` reports `version, 10.56.0`.
- Without one, the Sentry chunk is never requested by `/privacy` or `/editor` (checked against the full request list, not inferred).
- `/`, `/editor` and `/create` report zero policy violations, page errors and console errors.

Five tests in `src/__tests__/sentryClientLoading.test.ts`, all five failing on `main`. Suite 260 passed.