### PR TITLE
Stop shipping 53 zod locales to the browser

### DIFF
--- a/src/__tests__/zodBundle.test.ts
+++ b/src/__tests__/zodBundle.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Zod reaches the browser through siteSchema, which the editor and the gallery both use
+ * to validate URL parameters and stored JSON.
+ *
+ * `import { z } from "zod"` binds a namespace object, so the bundler keeps it whole —
+ * including `z.locales`, all 53 of them. Measured over the wire against production
+ * builds: importing the schema constructors by name instead took /templates from 466.1
+ * to 424.5 KiB of JS and /editor from 452.9 to 411.3 KiB, and left no chunk in the build
+ * containing a translated validation message.
+ */
+
+function sourceFiles(): string[] {
+  const out: string[] = [];
+  (function walk(dir: string) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "__tests__") continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (/\.tsx?$/.test(entry.name)) out.push(full);
+    }
+  })("src");
+  return out;
+}
+
+/** Server-only by declaration: nothing here is bundled for a browser. */
+const SERVER_ONLY = new Set(["src/lib/env.ts"]);
+
+// Anchored to the start of a line so prose about the old form does not match.
+const NAMESPACE_IMPORT = /^import\s+(\{\s*z\s*\}|\*\s+as\s+z)\s+from\s+["']zod["']/m;
+
+describe("zod does not drag its locales into the browser", () => {
+  it("has at least one module importing zod, so this is not vacuous", () => {
+    const users = sourceFiles().filter((f) => /from\s+["']zod["']/.test(readFileSync(f, "utf8")));
+    expect(users.length).toBeGreaterThan(0);
+  });
+
+  it("binds no zod namespace in anything that reaches the browser", () => {
+    const offenders = sourceFiles().filter(
+      (f) => !SERVER_ONLY.has(f) && NAMESPACE_IMPORT.test(readFileSync(f, "utf8"))
+    );
+    expect(offenders, "a namespace import keeps z.locales in the bundle").toEqual([]);
+  });
+
+  it("keeps the module that does bind one out of the browser by declaration", () => {
+    for (const f of SERVER_ONLY) {
+      // Not a convention: `import "server-only"` is a hard build error if a client
+      // component reaches it, which is the only thing making the exemption above safe.
+      expect(readFileSync(f, "utf8"), `${f} is exempt but not server-only`)
+        .toMatch(/^import "server-only";/m);
+    }
+  });
+
+  it("still validates the shapes it always did", async () => {
+    const { themeSchema, siteStyleSchema } = await import("@/lib/siteSchema");
+    expect(themeSchema.safeParse({ scale: "poster", displayWeight: 700 }).success).toBe(true);
+    expect(themeSchema.safeParse({ scale: "enormous" }).success).toBe(false);
+    expect(themeSchema.safeParse({ displayWeight: 1200 }).success).toBe(false);
+    expect(siteStyleSchema.safeParse({ style: "gradient", colors: ["#fff", "#000", "#123456"] }).success).toBe(true);
+    expect(siteStyleSchema.safeParse({ style: "gradient", colors: ["#fff", "#000"] }).success).toBe(false);
+    expect(siteStyleSchema.safeParse({ style: "not-a-style", colors: ["#fff", "#000", "#111"] }).success).toBe(false);
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,3 +1,4 @@
+import "server-only"; // a client import would pull zod's whole namespace back in
 import { z } from "zod";
 
 /**

--- a/src/lib/siteSchema.ts
+++ b/src/lib/siteSchema.ts
@@ -1,4 +1,12 @@
-import { z } from "zod";
+/**
+ * Imported by name rather than as the `z` namespace.
+ *
+ * `import { z } from "zod"` binds a namespace object, which the bundler has to keep
+ * whole — including `z.locales`, all 53 of them. This module is reachable from the
+ * editor and the gallery, so that was 41.6 KiB of translated validation messages, in
+ * languages this app does not speak, on the two heaviest routes.
+ */
+import { string, number, boolean, object, array, tuple, enum as zEnum, type infer as zInfer, type ZodType } from "zod";
 
 export const SECTION_LAYOUTS = ["center", "left", "right", "lower-third", "upper-third"] as const;
 export type SectionLayout = (typeof SECTION_LAYOUTS)[number];
@@ -11,15 +19,15 @@ export type Reveal = (typeof REVEALS)[number];
 
 export const MAX_SECTIONS = 100;
 
-export const sectionIdSchema = z.string().min(1).max(100);
+export const sectionIdSchema = string().min(1).max(100);
 
-export const colorSchema = z.string().max(50)
+export const colorSchema = string().max(50)
   .regex(/^(?:#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\([\d\s.,%/]+\)|[a-zA-Z]{3,20})$/);
 
-export const ctaHrefSchema = z.string().max(2000)
+export const ctaHrefSchema = string().max(2000)
   .refine((v) => v === "" || /^(?:#|\/|\.{1,2}\/|https?:\/\/|mailto:|tel:)/i.test(v));
 
-export const imageSrcSchema = z.string().max(2000)
+export const imageSrcSchema = string().max(2000)
   .refine((v) => v === "" || /^(?:https?:\/\/|\/|\.{1,2}\/|assets\/)/i.test(v), {
     message: "image must be an http(s) URL or a relative path",
   });
@@ -30,35 +38,35 @@ export const BACKGROUND_STYLES = ["gradient", "geometric", "particles", "wave"] 
 
 // The family name is interpolated into a Google Fonts stylesheet URL, so the charset is
 // constrained rather than escaped.
-export const fontFamilySchema = z.string().min(1).max(60).regex(/^[A-Za-z0-9][A-Za-z0-9 ]*$/);
+export const fontFamilySchema = string().min(1).max(60).regex(/^[A-Za-z0-9][A-Za-z0-9 ]*$/);
 
-export const themeSchema = z.object({
+export const themeSchema = object({
   fontDisplay: fontFamilySchema.optional(),
   fontBody: fontFamilySchema.optional(),
-  scale: z.enum(TYPE_SCALE_KEYS).optional(),
-  displayWeight: z.number().int().min(100).max(900).optional(),
-  displayCase: z.enum(["none", "upper"]).optional(),
-  displayTracking: z.number().min(-0.08).max(0.4).optional(),
+  scale: zEnum(TYPE_SCALE_KEYS).optional(),
+  displayWeight: number().int().min(100).max(900).optional(),
+  displayCase: zEnum(["none", "upper"]).optional(),
+  displayTracking: number().min(-0.08).max(0.4).optional(),
   ink: colorSchema.optional(),
   muted: colorSchema.optional(),
   accent: colorSchema.optional(),
   accentText: colorSchema.optional(),
   ground: colorSchema.optional(),
-  radius: z.number().min(0).max(64).optional(),
+  radius: number().min(0).max(64).optional(),
 }).strip();
 
-export type Theme = z.infer<typeof themeSchema>;
+export type Theme = zInfer<typeof themeSchema>;
 
-export const siteStyleSchema = z.object({
-  style: z.enum(BACKGROUND_STYLES),
-  colors: z.tuple([colorSchema, colorSchema, colorSchema]),
+export const siteStyleSchema = object({
+  style: zEnum(BACKGROUND_STYLES),
+  colors: tuple([colorSchema, colorSchema, colorSchema]),
 }).strip();
 
-export type SiteStyle = z.infer<typeof siteStyleSchema>;
+export type SiteStyle = zInfer<typeof siteStyleSchema>;
 
 export type JsonParse<T> = { ok: true; value: T } | { ok: false; error: string };
 
-function parseJsonField<T>(raw: unknown, name: string, schema: z.ZodType<T>): JsonParse<T> {
+function parseJsonField<T>(raw: unknown, name: string, schema: ZodType<T>): JsonParse<T> {
   if (typeof raw !== "string") return { ok: false, error: `${name} must be a string` };
   let decoded: unknown;
   try {
@@ -83,33 +91,33 @@ export function parseStyleJson(raw: unknown): JsonParse<SiteStyle> {
   return parseJsonField(raw, "styleJson", siteStyleSchema);
 }
 
-export const sectionSchema = z.object({
+export const sectionSchema = object({
   id: sectionIdSchema.optional(),
-  layout: z.enum(SECTION_LAYOUTS).optional(),
-  kind: z.enum(SECTION_KINDS).optional(),
-  reveal: z.enum(REVEALS).optional(),
-  scrim: z.number().min(0).max(1).optional(),
-  eyebrow: z.string().max(200).optional(),
-  heading: z.string().max(500).optional(),
-  body: z.string().max(5000).optional(),
-  ctaLabel: z.string().max(200).optional(),
+  layout: zEnum(SECTION_LAYOUTS).optional(),
+  kind: zEnum(SECTION_KINDS).optional(),
+  reveal: zEnum(REVEALS).optional(),
+  scrim: number().min(0).max(1).optional(),
+  eyebrow: string().max(200).optional(),
+  heading: string().max(500).optional(),
+  body: string().max(5000).optional(),
+  ctaLabel: string().max(200).optional(),
   ctaHref: ctaHrefSchema.optional(),
   image: imageSrcSchema.optional(),
-  imageAlt: z.string().max(500).optional(),
-  imageWidth: z.number().int().min(16).max(1600).optional(),
+  imageAlt: string().max(500).optional(),
+  imageWidth: number().int().min(16).max(1600).optional(),
   accentColor: colorSchema.optional(),
   headingColor: colorSchema.optional(),
   bodyColor: colorSchema.optional(),
-  textAlign: z.enum(["left", "center", "right"]).optional(),
-  align: z.string().max(30).optional(),
-  justify: z.string().max(30).optional(),
-  scrollHeight: z.number().int().min(100).max(20_000).optional(),
-  visible: z.boolean().optional(),
+  textAlign: zEnum(["left", "center", "right"]).optional(),
+  align: string().max(30).optional(),
+  justify: string().max(30).optional(),
+  scrollHeight: number().int().min(100).max(20_000).optional(),
+  visible: boolean().optional(),
 }).strip();
 
-export const sectionsSchema = z.array(sectionSchema).max(MAX_SECTIONS);
+export const sectionsSchema = array(sectionSchema).max(MAX_SECTIONS);
 
-export type Section = z.infer<typeof sectionSchema>;
+export type Section = zInfer<typeof sectionSchema>;
 
 export type EditorSection = Section & {
   id: string;


### PR DESCRIPTION
## The problem

[src/lib/siteSchema.ts](src/lib/siteSchema.ts) is reachable from the editor and the gallery, where it validates URL parameters and stored JSON. It bound zod as a namespace:

```ts
import { z } from "zod";
```

That is `import * as z from "zod/v4/classic/external.js"` underneath, and line 14 of that file is `export * as locales from "../locales/index.js"` — all 53 of them. A namespace object has to be kept whole, so both routes downloaded translated validation messages, in languages this app does not speak, for schemas whose messages are never shown to anyone.

## The change

Import the constructors by name. Turbopack then shakes the locales out.

| | before | after |
| --- | --- | --- |
| chunks in the build containing a translated validation message | 1, at 65.1 KiB over the wire, pure zod | 0 |
| `/templates` JS | 466.1 KiB | 424.5 KiB |
| `/editor` JS | 452.9 KiB | 411.3 KiB |

Measured over the wire against production builds with the cache cleared, and the byte counts are identical run to run.

`zEnum` and `zInfer` are aliased because `enum` and `infer` are reserved words. Everything else reads as `string().min(1)`, `object({ … })`.

## The guard

[src/lib/env.ts](src/lib/env.ts) still binds the namespace. That is fine — it is server-side — but only by accident of who happens to import it. It now declares `import "server-only"`, following the idiom already in `rateLimit.ts`, so a client component reaching for `siteUrl` is a build error rather than a silent 41.6 KiB regression. The test exempts it *only* on that basis and checks the declaration is really there.

Four tests, two failing on `main`. One of them round-trips the schemas so the rewrite is not just a bundle change that passed a grep.

Suite 259 passed. `/templates`, `/templates/orbitcrm`, `/editor?template=orbitcrm` and `/create` all report zero policy violations, page errors and console errors.