### PR TITLE
Make the editor usable on a phone

### DIFF
--- a/src/__tests__/appAccessibility.test.ts
+++ b/src/__tests__/appAccessibility.test.ts
@@ -135,12 +135,57 @@ describe("the editor is reachable without a mouse", () => {
   const editor = readFileSync("src/app/editor/page.tsx", "utf8");
 
   it("wraps its working area in a main landmark", () => {
-    expect(editor).toMatch(/<main className="flex flex-1/);
+    // Asserted on the element, not its classes, so a layout change cannot fail it.
+    expect(editor).toMatch(/<main className=/);
   });
 
   it("names its icon-only controls", () => {
     expect(editor).toContain('aria-label="Add section"');
     expect(editor).toContain('aria-label="Site name"');
+  });
+
+  it("gives every icon-only control a target WCAG 2.5.8 accepts", () => {
+    // A 14px icon needs p-1.5 to clear 24px; p-1 gives 22 and p-0.5 gives 18. Measured
+    // in Chrome at 390x844 against a production build: twelve controls under 24px
+    // before, none after. Each string below appears in the previous revision.
+    for (const tooTight of [
+      'className="p-1 rounded',
+      'className="p-0.5 ',
+      "className={`p-1 rounded",
+    ]) {
+      expect(editor, `${tooTight} is a target under 24px`).not.toContain(tooTight);
+    }
+  });
+});
+
+describe("the editor fits a phone", () => {
+  const editor = readFileSync("src/app/editor/page.tsx", "utf8");
+
+  /**
+   * Measured in Chrome at 390x844 against a production build, with the template loaded.
+   * Before: nine controls off the right edge, including Export, the Layout/Audio/Code
+   * tabs and every text input in the inspector, reachable only by scrolling the whole
+   * app sideways. After: none.
+   */
+  it("stacks its panels rather than scrolling the app sideways", () => {
+    expect(editor).toContain('<main className="flex flex-col md:flex-row flex-1');
+  });
+
+  it("gives every panel the full width before it stacks", () => {
+    expect(editor).toMatch(/className="w-full max-h-52 md:w-56/);
+    expect(editor).toMatch(/className="w-full md:w-72/);
+  });
+
+  it("lets the toolbar wrap, so Export does not fall off the edge", () => {
+    expect(editor).toContain('<div className="flex items-center gap-2 flex-wrap justify-end">');
+  });
+
+  it("fits the inspector tabs in the panel that holds them", () => {
+    // Five icon-and-label tabs overflowed a 288px panel at every width: Content was
+    // clipped on the left and Code ran off the right, where it could not be clicked.
+    const tabStrip = editor.slice(editor.indexOf("<TabsList"), editor.indexOf("</TabsList>"));
+    expect(tabStrip).toContain("grid grid-cols-5");
+    expect(tabStrip).not.toMatch(/<(Type|Sparkles|Settings|Music) /);
   });
 });
 

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -10,7 +10,7 @@ import { Slider } from "@/components/ui/slider";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   ArrowLeft, Download, Plus, Trash2, Eye, EyeOff, ChevronUp, ChevronDown,
-  Sparkles, Layers, Settings, Type, Loader2, AlignLeft, AlignCenter, AlignRight,
+  Layers, Loader2, AlignLeft, AlignCenter, AlignRight,
   Monitor, Tablet, Smartphone, Music, Volume2, VolumeX, Save,
   Undo2, Redo2, Copy
 } from "lucide-react";
@@ -797,7 +797,7 @@ function EditorInner() {
           <Link
             href="/create"
             onClick={(e) => { if (dirty && !window.confirm("Discard unsaved changes and leave?")) e.preventDefault(); }}
-            className="flex items-center gap-1 text-muted-foreground hover:text-foreground text-sm transition-colors"
+            className="flex items-center gap-1 py-1 text-muted-foreground hover:text-foreground text-sm transition-colors"
           >
             <ArrowLeft className="w-3.5 h-3.5" /> Back
           </Link>
@@ -812,14 +812,14 @@ function EditorInner() {
           {isDemo && <Badge variant="outline" className="border-amber-500/40 text-amber-400 text-xs">Demo mode</Badge>}
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap justify-end">
           {/* Undo / redo */}
           <div className="flex items-center bg-white/5 rounded-md p-0.5 gap-0.5">
             <button
               onClick={undo}
               disabled={!canUndo}
               title="Undo (⌘Z)"
-              className="p-1 rounded transition-colors text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+              className="p-1.5 rounded transition-colors text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
             >
               <Undo2 className="w-3.5 h-3.5" />
             </button>
@@ -827,7 +827,7 @@ function EditorInner() {
               onClick={redo}
               disabled={!canRedo}
               title="Redo (⌘⇧Z)"
-              className="p-1 rounded transition-colors text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+              className="p-1.5 rounded transition-colors text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
             >
               <Redo2 className="w-3.5 h-3.5" />
             </button>
@@ -837,7 +837,7 @@ function EditorInner() {
             <button
               onClick={() => setAudioMuted(m => !m)}
               title={audioMuted ? "Unmute audio" : "Mute audio"}
-              className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
+              className="p-1.5 rounded text-muted-foreground hover:text-foreground transition-colors"
             >
               {audioMuted ? <VolumeX className="w-3.5 h-3.5" /> : <Volume2 className="w-3.5 h-3.5 text-primary-ink" />}
             </button>
@@ -849,7 +849,7 @@ function EditorInner() {
                 key={mode}
                 onClick={() => setViewportMode(mode)}
                 title={mode.charAt(0).toUpperCase() + mode.slice(1)}
-                className={`p-1 rounded transition-colors ${viewportMode === mode ? "bg-primary/30 text-primary-ink" : "text-muted-foreground hover:text-foreground"}`}
+                className={`p-1.5 rounded transition-colors ${viewportMode === mode ? "bg-primary/30 text-primary-ink" : "text-muted-foreground hover:text-foreground"}`}
               >
                 <Icon className="w-3.5 h-3.5" />
               </button>
@@ -895,9 +895,9 @@ function EditorInner() {
         </div>
       </div>
 
-      <main className="flex flex-1 overflow-x-auto md:overflow-hidden">
+      <main className="flex flex-col md:flex-row flex-1 overflow-y-auto md:overflow-x-auto md:overflow-y-hidden">
         {/* Left panel: sections list */}
-        <div className="w-56 border-r border-white/5 flex flex-col bg-card/30 flex-shrink-0">
+        <div className="w-full max-h-52 md:w-56 md:max-h-none border-b md:border-b-0 md:border-r border-white/5 flex flex-col bg-card/30 flex-shrink-0">
           <div className="p-3 border-b border-white/5 flex items-center justify-between">
             <div className="flex items-center gap-2 text-sm font-medium">
               <Layers className="w-3.5 h-3.5 text-primary-ink" /> Sections
@@ -929,19 +929,19 @@ function EditorInner() {
                 <div className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${s.visible ? "bg-primary" : "bg-white/20"}`} />
                 <span className="text-xs flex-1 truncate">{s.heading || `Section ${i + 1}`}</span>
                 <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
-                  <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "up"); }} className="p-0.5 hover:text-primary-ink" title="Move up">
+                  <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "up"); }} className="p-1.5 hover:text-primary-ink" title="Move up">
                     <ChevronUp className="w-3 h-3" />
                   </button>
-                  <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "down"); }} className="p-0.5 hover:text-primary-ink" title="Move down">
+                  <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "down"); }} className="p-1.5 hover:text-primary-ink" title="Move down">
                     <ChevronDown className="w-3 h-3" />
                   </button>
-                  <button onClick={(e) => { e.stopPropagation(); duplicateSection(s.id); }} className="p-0.5 hover:text-primary-ink" title="Duplicate section">
+                  <button onClick={(e) => { e.stopPropagation(); duplicateSection(s.id); }} className="p-1.5 hover:text-primary-ink" title="Duplicate section">
                     <Copy className="w-3 h-3" />
                   </button>
                   <button
                     onClick={(e) => { e.stopPropagation(); removeSection(s.id); }}
                     onBlur={() => setPendingDeleteId(null)}
-                    className={`p-0.5 rounded transition-colors ${pendingDeleteId === s.id ? "bg-destructive text-white ring-1 ring-destructive" : "hover:text-destructive"}`}
+                    className={`p-1.5 rounded transition-colors ${pendingDeleteId === s.id ? "bg-destructive text-white ring-1 ring-destructive" : "hover:text-destructive"}`}
                     title={pendingDeleteId === s.id ? "Click again to confirm delete" : "Delete section"}
                   >
                     <Trash2 className="w-3 h-3" />
@@ -954,7 +954,7 @@ function EditorInner() {
 
         {/* Center: preview canvas */}
         {showPreview && (
-          <div className="flex-1 relative overflow-hidden bg-black/20 flex items-center justify-center">
+          <div className="h-[45vh] flex-shrink-0 md:h-auto md:flex-1 md:flex-shrink relative overflow-hidden bg-black/20 flex items-center justify-center">
             {frames.length > 0 && (
               <div
                 ref={previewScrollRef}
@@ -1065,25 +1065,18 @@ function EditorInner() {
 
         {/* Right panel: section editor */}
         {selectedSectionData && (
-          <div className="w-72 border-l border-white/5 flex flex-col bg-card/30 flex-shrink-0 overflow-y-auto" data-lenis-prevent>
+          <div className="w-full md:w-72 border-t md:border-t-0 md:border-l border-white/5 flex flex-col bg-card/30 flex-shrink-0 md:overflow-y-auto" data-lenis-prevent>
             <Tabs defaultValue="content">
               <div className="p-3 border-b border-white/5">
-                <TabsList className="w-full h-8 bg-white/5">
-                  <TabsTrigger value="content" className="flex-1 text-xs h-6">
-                    <Type className="w-3 h-3 mr-1" /> Content
-                  </TabsTrigger>
-                  <TabsTrigger value="style" className="flex-1 text-xs h-6">
-                    <Sparkles className="w-3 h-3 mr-1" /> Style
-                  </TabsTrigger>
-                  <TabsTrigger value="layout" className="flex-1 text-xs h-6">
-                    <Settings className="w-3 h-3 mr-1" /> Layout
-                  </TabsTrigger>
-                  <TabsTrigger value="audio" className="flex-1 text-xs h-6">
-                    <Music className="w-3 h-3 mr-1" /> Audio
-                  </TabsTrigger>
-                  <TabsTrigger value="code" className="flex-1 text-xs h-6">
-                    &lt;/&gt; Code
-                  </TabsTrigger>
+                {/* Five icon-and-label tabs did not fit the panel at any width: Content
+                    was clipped on the left and Code ran off the right, unreachable. The
+                    label is what names a tab, so the icons go. */}
+                <TabsList className="grid grid-cols-5 w-full h-8 bg-white/5">
+                  <TabsTrigger value="content" className="text-xs h-6 px-1">Content</TabsTrigger>
+                  <TabsTrigger value="style" className="text-xs h-6 px-1">Style</TabsTrigger>
+                  <TabsTrigger value="layout" className="text-xs h-6 px-1">Layout</TabsTrigger>
+                  <TabsTrigger value="audio" className="text-xs h-6 px-1">Audio</TabsTrigger>
+                  <TabsTrigger value="code" className="text-xs h-6 px-1">Code</TabsTrigger>
                 </TabsList>
               </div>
 


### PR DESCRIPTION
## What was wrong

At 390×844 the three panels sat side by side in a container wider than the viewport, and below `md` the editor scrolled sideways by design (`overflow-x-auto`). Driving Chrome at that size against a production build, with a template loaded:

**Nine controls were off the right edge** — Export, the Layout / Audio / Code tabs, and every text input in the inspector including the heading field. **Twelve controls were under the 24px target** WCAG 2.5.8 asks for.

Reaching the heading field meant scrolling the whole application sideways, and Export was simply not there.

## What changed

- Panels stack below `md`, each full width. The sections list is capped at `max-h-52` and the preview takes `45vh`, so all three are reachable by scrolling down rather than across.
- The right-hand toolbar group wraps, so Export stays on screen instead of running past the edge.
- **The inspector tab strip was broken at every width, not just on a phone.** Five icon-and-label tabs did not fit a 288px panel: `Content` was clipped on the left and `Code` ran off the right where it could not be clicked. The label is what names a tab, so the icons go and the strip becomes a five-column grid.
- Icon-only controls move from `p-1` and `p-0.5` to `p-1.5`, taking a 14px icon from 22 and 18px to 26.

## Measured

Chrome, production build, `/editor?template=orbitcrm`:

| viewport | off-screen controls | targets under 24px |
| --- | --- | --- |
| 390×844 | 9 → **0** | 12 → **0** |
| 768×1024 | 1 → **0** | 0 → 0 |
| 1440×900 | 1 → **0** | 0 → 0 |

Document overflow stays at 0 at all three widths, and screenshots at each confirm the layout reads correctly rather than merely fitting.

Autosave re-verified on the new layout: typing in the site name and never touching Save still leaves the document in IndexedDB with all five sections. `/editor` and `/editor?template=orbitcrm` report zero policy violations, page errors and console errors.

## Tests

Five in `appAccessibility.test.ts`, beside the existing editor keyboard checks. All five fail on `main`, and the tap-target one asserts on strings that are present in the previous revision rather than on a regex that could pass vacuously.

Suite 277 passed.