### PR TITLE
Recover from a database that lost its object store

### DIFF
--- a/src/__tests__/frameStorageRecovery.test.ts
+++ b/src/__tests__/frameStorageRecovery.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * A database can exist at the current version without its object store — an interrupted
+ * upgrade leaves exactly that — and onupgradeneeded never fires again for the same
+ * version. Without recovery, every read and write in frameStorage fails forever: the
+ * editor shows "Not saved" on each autosave with no way out.
+ *
+ * Reproduced in Chrome against a production build: create "scrollcraft" at v1 with no
+ * store, open /editor?template=orbitcrm, type, never touch Save. On the previous build
+ * the indicator settled on "Not saved" and the database still had no store; with
+ * recovery it settles on "Saved" and the document is there.
+ */
+const STORAGE = readFileSync("src/lib/frameStorage.ts", "utf8");
+
+describe("a store-less database is recovered, not fatal", () => {
+  it("checks for the store after every open, not only during upgrade", () => {
+    expect(STORAGE).toContain("if (db.objectStoreNames.contains(STORE_NAME)) return db;");
+  });
+
+  it("deletes and recreates rather than failing forever", () => {
+    // Safe by construction: a database without the store cannot hold any data.
+    expect(STORAGE).toContain("indexedDB.deleteDatabase(DB_NAME)");
+    const recovery = STORAGE.slice(STORAGE.indexOf("async function openDB"));
+    expect(recovery).toMatch(/const recreated = await requestDB\(\);/);
+  });
+
+  it("still refuses to hang when another tab blocks the delete", () => {
+    expect(STORAGE).toContain('del.onblocked = () => reject(new Error("IndexedDB delete blocked by another tab"));');
+  });
+
+  it("guards createObjectStore so a partial upgrade cannot throw on retry", () => {
+    expect(STORAGE).toContain("if (!req.result.objectStoreNames.contains(STORE_NAME)) req.result.createObjectStore(STORE_NAME);");
+  });
+});

--- a/src/lib/frameStorage.ts
+++ b/src/lib/frameStorage.ts
@@ -4,15 +4,41 @@ const DB_NAME = "scrollcraft";
 const STORE_NAME = "frames";
 const DB_VERSION = 1;
 
-function openDB(): Promise<IDBDatabase> {
+function requestDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const req = indexedDB.open(DB_NAME, DB_VERSION);
-    req.onupgradeneeded = () => req.result.createObjectStore(STORE_NAME);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE_NAME)) req.result.createObjectStore(STORE_NAME);
+    };
     req.onsuccess = () => resolve(req.result);
     req.onerror = () => reject(req.error);
     // Without this a version bump held open by another tab hangs here forever.
     req.onblocked = () => reject(new Error("IndexedDB upgrade blocked by another tab"));
   });
+}
+
+/**
+ * A database can exist at the current version without its store — an upgrade that was
+ * interrupted partway leaves exactly that. onupgradeneeded never fires again for the
+ * same version, so without recovery every read and write in this module fails forever.
+ * A store-less database holds nothing, so deleting and recreating it loses nothing.
+ */
+async function openDB(): Promise<IDBDatabase> {
+  const db = await requestDB();
+  if (db.objectStoreNames.contains(STORE_NAME)) return db;
+  db.close();
+  await new Promise<void>((resolve, reject) => {
+    const del = indexedDB.deleteDatabase(DB_NAME);
+    del.onsuccess = () => resolve();
+    del.onerror = () => reject(del.error);
+    del.onblocked = () => reject(new Error("IndexedDB delete blocked by another tab"));
+  });
+  const recreated = await requestDB();
+  if (!recreated.objectStoreNames.contains(STORE_NAME)) {
+    recreated.close();
+    throw new Error("IndexedDB store could not be created");
+  }
+  return recreated;
 }
 
 // A transaction can abort without any request error — storage eviction, the connection


### PR DESCRIPTION
## The failure

An interrupted upgrade can leave the `scrollcraft` database existing at the current version with **no object store** — and `onupgradeneeded` never fires again for a version that already committed. From that point every read and write in [src/lib/frameStorage.ts](src/lib/frameStorage.ts) fails forever: each autosave shows "Not saved", manual save errors, restore finds nothing, and no action in the UI can clear it. With no accounts, this browser *is* the persistence layer, so a bricked database is permanent data loss going forward.

Found by hitting it for real: an `indexedDB.open("scrollcraft")` with no version and no upgrade handler (what a devtools probe or any same-origin script does) creates exactly this state.

## The fix

`openDB` checks for the store after every open. Missing store → delete the database and recreate it. This is safe by construction: a database without the store cannot hold any data, so there is nothing to lose. The delete rejects on `onblocked` the way the open already did, so another tab cannot hang it, and `createObjectStore` is guarded so a retried upgrade cannot throw on a store that half-exists.

## Reproduced both ways in Chrome

Production builds, fresh profile each run: create `scrollcraft` at v1 with no store, open `/editor?template=orbitcrm`, type into the site name, never touch Save.

| | indicator | stores | document |
| --- | --- | --- | --- |
| `main` | `Not saved` | `[]` | absent |
| this branch | `Saved` | `[frames]` | present, with the typed name |

Suite 281 passed. The four new tests in `frameStorageRecovery.test.ts` all fail against `main`'s `frameStorage.ts`.