### PR TITLE
Advertise shortcuts in the key the visitor actually has

### DIFF
--- a/src/__tests__/appAccessibility.test.ts
+++ b/src/__tests__/appAccessibility.test.ts
@@ -144,6 +144,24 @@ describe("the editor is reachable without a mouse", () => {
     expect(editor).toContain('aria-label="Site name"');
   });
 
+  it("advertises its shortcuts in the key the visitor actually has", () => {
+    // The handler accepts metaKey and ctrlKey alike, but the titles promised ⌘ to
+    // everyone. Verified in Chrome: a Mac sees ⌘+Z, a spoofed Win32 platform sees
+    // Ctrl+Z, with no hydration mismatch (useSyncExternalStore with a "Ctrl" server
+    // snapshot). Save and Export carry titles too — they had shortcuts nobody could
+    // discover.
+    expect(editor).not.toMatch(/title="[^"]*⌘/);
+    for (const title of [
+      "title={`Undo (${modKey}+Z)`}",
+      "title={`Redo (${modKey}+Shift+Z)`}",
+      "title={`Save (${modKey}+S)`}",
+      "title={exportStage ?? `Export (${modKey}+E)`}",
+    ]) {
+      expect(editor).toContain(title);
+    }
+    expect(editor).toContain('() => "Ctrl"');
+  });
+
   it("gives every icon-only control a target WCAG 2.5.8 accepts", () => {
     // A 14px icon needs p-1.5 to clear 24px; p-1 gives 22 and p-0.5 gives 18. Measured
     // in Chrome at 390x844 against a production build: twelve controls under 24px

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect, useRef, useCallback, Suspense } from "react";
+import { useState, useEffect, useRef, useCallback, useSyncExternalStore, Suspense } from "react";
 import { loadFrames, storeFrames, storeDocument, loadDocument } from "@/lib/frameStorage";
 import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
@@ -356,6 +356,14 @@ function EditorInner() {
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
   const [dirty, setDirty] = useState(false);
+  // The handler accepts metaKey and ctrlKey alike, but the labels promised ⌘ to
+  // everyone. useSyncExternalStore keeps this hydration-safe: the server snapshot
+  // matches the first client render, then the real platform takes over.
+  const modKey = useSyncExternalStore(
+    () => () => {}, // the platform never changes; nothing to subscribe to
+    () => (/Mac|iPhone|iPad/.test(navigator.platform) ? "⌘" : "Ctrl"),
+    () => "Ctrl"
+  );
   const [saveState, setSaveState] = useState<SaveState>("idle");
   // Bumped on every content edit. A save captures this at its start and only clears the
   // dirty flag if it is unchanged when the request resolves — otherwise edits the user
@@ -748,7 +756,7 @@ function EditorInner() {
     shortcutsRef.current = { undo, redo, handleSave, handleExport, isSaving, isExporting };
   });
 
-  // Keyboard shortcuts: ⌘Z undo, ⌘⇧Z / ⌘Y redo, ⌘S save, ⌘E export
+  // Keyboard shortcuts: mod+Z undo, mod+Shift+Z / mod+Y redo, mod+S save, mod+E export
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
@@ -818,7 +826,7 @@ function EditorInner() {
             <button
               onClick={undo}
               disabled={!canUndo}
-              title="Undo (⌘Z)"
+              title={`Undo (${modKey}+Z)`}
               className="p-1.5 rounded transition-colors text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
             >
               <Undo2 className="w-3.5 h-3.5" />
@@ -826,7 +834,7 @@ function EditorInner() {
             <button
               onClick={redo}
               disabled={!canRedo}
-              title="Redo (⌘⇧Z)"
+              title={`Redo (${modKey}+Shift+Z)`}
               className="p-1.5 rounded transition-colors text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
             >
               <Redo2 className="w-3.5 h-3.5" />
@@ -872,6 +880,7 @@ function EditorInner() {
             size="sm"
             onClick={() => handleSave()}
             disabled={isSaving}
+            title={`Save (${modKey}+S)`}
             className="border-white/10 h-7 px-3 text-xs gap-1"
           >
             {isSaving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Save className="w-3.5 h-3.5" />}
@@ -881,7 +890,7 @@ function EditorInner() {
             size="sm"
             onClick={handleExport}
             disabled={isExporting}
-            title={exportStage ?? undefined}
+            title={exportStage ?? `Export (${modKey}+E)`}
             className="bg-primary hover:bg-primary/90 text-white h-7 px-3 text-xs font-semibold"
           >
             {isExporting ? <Loader2 className="w-3.5 h-3.5 animate-spin mr-1" /> : <Download className="w-3.5 h-3.5 mr-1" />}


### PR DESCRIPTION
The keydown handler accepts `metaKey` and `ctrlKey` alike, but every title promised ⌘ to everyone — a Windows or Linux visitor hovering Undo was told a key they don't have. And Save and Export had working shortcuts (`mod+S`, `mod+E`) with no title at all, so nothing anywhere disclosed they exist.

The modifier label comes from `useSyncExternalStore` with a `"Ctrl"` server snapshot: the server render and the first client render agree, then the real platform takes over — no hydration mismatch, and it is the pattern the React Compiler accepts where a `setState`-in-effect is rejected (tried first; the build refused it).

Verified in Chrome against a production build:

| platform | titles |
| --- | --- |
| macOS | `Undo (⌘+Z) \| Redo (⌘+Shift+Z) \| Save (⌘+S) \| Export (⌘+E)` |
| spoofed Win32 | `Undo (Ctrl+Z) \| Redo (Ctrl+Shift+Z) \| Save (Ctrl+S) \| Export (Ctrl+E)` |

No hydration errors either way. Suite 282 passed; the new assertion fails against `main`'s editor.