### PR TITLE
Correct five things the site says about itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 **Ready-made cinematic scroll websites — no code, pure HTML.**
 
 Pick a template, change the words, and export a production‑ready HTML/CSS/JS ZIP you can
-deploy anywhere. The editor, publishing and ZIP export are free, along with 13 of the 21
-templates. The other 8 are bought once, outright.
+deploy anywhere. All of it is free and open source: every template, the editor, and the
+export. No account, nothing to buy.
 
 [Live demo](https://scrollcraft-gilt.vercel.app) · [Report a bug](https://github.com/singhharsh1708/scrollcraft/issues) · [Request a feature](https://github.com/singhharsh1708/scrollcraft/issues)
 
@@ -31,7 +31,7 @@ ScrollCraft removes all of that. You:
 
 - 🎨 **Generated scroll frames** — pick a style (gradient, geometric, particles, wave) and a palette; the frame sequence is rendered in-browser on canvas, no API key required.
 - 🎬 **Scroll‑linked animation engine** — smooth canvas scrubbing, desktop + mobile frame sets.
-- 🧩 **Template library** — 21 finished scroll sites across 11 categories, all free, each with its own Google Fonts pairing and palette.
+- 🧩 **Template library** — 21 finished scroll sites across 16 categories, all free, each with its own Google Fonts pairing and palette.
 - 📦 **Pure HTML export** — zero dependencies, zero lock‑in, deploy anywhere. The ZIP ships a 404 page, favicon, social card, `robots.txt` and host configs, and scores 100 across Lighthouse.
 - 🎞️ **Bring your own video** — frames are extracted in your browser; the file never leaves your device.
 - 🔊 **Scroll‑synced audio** — attach a soundtrack that responds to scroll position.

--- a/src/__tests__/contactDetails.test.ts
+++ b/src/__tests__/contactDetails.test.ts
@@ -127,3 +127,70 @@ describe("a fork resolves its own origin", () => {
     expect(env).toContain("VERCEL_PROJECT_PRODUCTION_URL");
   });
 });
+
+/**
+ * Numbers and capabilities the site publishes about itself.
+ *
+ * Every one of these was wrong at some point after the open-source pivot: the README's
+ * opening paragraph still sold 8 of the 21 templates and advertised a publishing feature
+ * removed in v1.0.0, the presets page promised an AI that no longer exists, and the
+ * about page promised a weekly release cadence the changelog contradicts.
+ */
+describe("what the site claims about itself is true", () => {
+  const README = readFileSync("README.md", "utf8");
+  const TEMPLATES_SRC = readFileSync("src/lib/templates.ts", "utf8");
+
+  const templateCount = (TEMPLATES_SRC.match(/^ {4}slug: "/gm) ?? []).length;
+  const categoryCount = new Set(
+    [...TEMPLATES_SRC.matchAll(/^ {4}category: "([^"]+)"/gm)].map((m) => m[1])
+  ).size;
+
+  it("counted the catalogue at all, so the assertions below are not vacuous", () => {
+    expect(templateCount).toBeGreaterThan(10);
+    expect(categoryCount).toBeGreaterThan(3);
+  });
+
+  it("quotes the real template and category counts in the README", () => {
+    const line = README.split("\n").find((l) => l.includes("Template library"));
+    expect(line, "the README feature bullet is gone").toBeTruthy();
+    expect(line).toContain(`${templateCount} finished scroll sites`);
+    expect(line).toContain(`${categoryCount} categories`);
+  });
+
+  it("sells nothing, anywhere", () => {
+    for (const [label, text] of [
+      ["README", README],
+      ["terms", readFileSync("src/app/terms/page.tsx", "utf8")],
+      ["contact", readFileSync("src/app/contact/page.tsx", "utf8")],
+    ] as const) {
+      expect(text, `${label} still offers something for sale`).not.toMatch(
+        /bought once|are paid|paid templates|premium template|"Billing"/i
+      );
+    }
+  });
+
+  it("promises no AI, which the product does not have", () => {
+    // The changelog records its removal by name, so it is the one file allowed to say it.
+    for (const file of ["README.md", "src/app/presets/page.tsx", "src/app/HomeClient.tsx", "src/app/create/page.tsx", "src/app/about/page.tsx"]) {
+      expect(readFileSync(file, "utf8"), `${file} advertises AI`).not.toMatch(
+        /\bthe AI\b|AI generates|AI-generated|AI-powered/i
+      );
+    }
+  });
+
+  it("promises no release cadence it does not keep", () => {
+    expect(readFileSync("src/app/about/page.tsx", "utf8")).not.toMatch(
+      /release weekly|every single week|ship daily|weekly releases/i
+    );
+  });
+
+  it("keeps the legal pages dated to when they were last rewritten", () => {
+    // They described the August teardown while dated June, which reads as unmaintained.
+    for (const file of ["src/app/terms/page.tsx", "src/app/cookies/page.tsx", "src/app/privacy/page.tsx"]) {
+      const text = readFileSync(file, "utf8");
+      const stamp = /Last updated: ([A-Z][a-z]+ \d{4})/.exec(text);
+      expect(stamp, `${file} has no Last updated line`).toBeTruthy();
+      expect(stamp![1], `${file} predates the open-source rewrite`).not.toBe("June 2026");
+    }
+  });
+});

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -27,7 +27,7 @@ const TEAM = [
 
 const VALUES = [
   { icon: Sparkles, title: "Ready to ship", desc: "Every template is a finished site, not a blank canvas. Pick one and change the words." },
-  { icon: Zap, title: "Ship fast", desc: "We release weekly. Features, fixes, and improvements every single week." },
+  { icon: Zap, title: "Nothing to wait for", desc: "No signup, no build step, no keys. Open the editor and you are already working." },
   { icon: Globe, title: "Own your code", desc: "Everything you export belongs to you. No lock-in, ever." },
   { icon: Users, title: "Built for builders", desc: "Freelancers, founders, agencies — we build for people who make things." },
 ];

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -12,7 +12,7 @@ import GitHubMark from "@/components/GitHubMark";
 import LinkedInMark from "@/components/LinkedInMark";
 import SiteFooter from "@/components/SiteFooter";
 
-const TOPICS = ["General question", "Bug report", "Feature request", "Enterprise inquiry", "Billing", "Partnership"];
+const TOPICS = ["General question", "Bug report", "Feature request", "Enterprise inquiry", "Partnership"];
 
 export default function ContactPage() {
   const [sent, setSent] = useState(false);

--- a/src/app/cookies/page.tsx
+++ b/src/app/cookies/page.tsx
@@ -10,7 +10,7 @@ export default function CookiesPage() {
       <Navbar />
       <article className="max-w-3xl mx-auto px-6 py-16 prose prose-invert prose-sm">
         <h1>Cookie Policy</h1>
-        <p className="text-muted-foreground">Last updated: June 2026</p>
+        <p className="text-muted-foreground">Last updated: August 2026</p>
 
         <h2>We set none</h2>
         <p>

--- a/src/app/presets/page.tsx
+++ b/src/app/presets/page.tsx
@@ -164,7 +164,7 @@ export default function PresetsPage() {
       <section className="pb-24 px-6 text-center border-t border-white/5 pt-20">
         <h2 className="text-3xl font-black tracking-tighter mb-4">Don&apos;t see what you need?</h2>
         <p className="text-muted-foreground mb-8 max-w-md mx-auto">
-          Start from scratch — describe any atmosphere and the AI generates it instantly.
+          Start from scratch — pick a style and a palette, or bring your own video, and the frames render in your browser.
         </p>
         <Link href="/create">
           <Button size="lg" className="bg-primary hover:bg-primary/90 text-white px-10 py-6 text-base font-semibold shadow-xl shadow-primary/30">

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -9,7 +9,7 @@ export default function TermsPage() {
       <Navbar />
       <article className="max-w-3xl mx-auto px-6 py-16 prose prose-invert prose-sm">
         <h1>Terms of Service</h1>
-        <p className="text-muted-foreground">Last updated: June 2026</p>
+        <p className="text-muted-foreground">Last updated: August 2026</p>
 
         <h2>Acceptance</h2>
         <p>By using ScrollCraft you agree to these terms. If you do not agree, do not use the service.</p>


### PR DESCRIPTION
Found by auditing every user-facing page and the README against the code.

| where | claimed | actually |
| --- | --- | --- |
| `README.md:8` | "13 of the 21 templates" free, "The other 8 are bought once, outright", and a **publishing** feature | all 21 are free, nothing is for sale, publishing was removed in v1.0.0 |
| `src/app/presets/page.tsx:167` | "describe any atmosphere and **the AI** generates it instantly" | `/create` has four fixed styles and no text input; AI left the product two releases ago |
| `src/app/about/page.tsx:30` | "We release weekly. Features, fixes, and improvements every single week." | the changelog does not support a weekly cadence |
| `README.md:34` | 11 template categories | 16 |
| `terms`, `cookies` | "Last updated: June 2026" | both describe the August rewrite |
| `src/app/contact/page.tsx:15` | a **Billing** topic | no payments exist |

The README contradicted itself: its opening paragraph sold 8 templates while its feature list two sections down said "all free" and its tech-stack section said "no payment provider". A visitor reading the first paragraph would go looking for a purchase flow that does not exist.

## Tests

Six in `contactDetails.test.ts`, beside the existing checks on invented contact details. The counts are **derived from `src/lib/templates.ts`**, not restated, so the README cannot drift again — plus a guard test so they cannot pass vacuously if the catalogue moves. The others assert the site sells nothing, promises no AI (the changelog is the one file allowed to name it, since it records its removal), promises no release cadence, and keeps its legal pages dated to when they were rewritten.

Five of the six fail on `main`. Suite 288 passed.