### PR TITLE
Stop the editor claiming a background it no longer has

### DIFF
--- a/src/__tests__/editorAutosave.test.ts
+++ b/src/__tests__/editorAutosave.test.ts
@@ -31,6 +31,21 @@ describe("save status label", () => {
   it("reports a write in flight over a pending edit", () => {
     expect(saveStatusLabel(true, "saving")).toBe("Saving…");
   });
+
+  it("does not call it saved when only the background was dropped", () => {
+    // The document write can succeed while the frames write fails: the frames are
+    // megabytes and are what a quota rejects. Verified in Chrome with the frames put
+    // rejected as QuotaExceededError - the previous build showed "Saved" while storing
+    // the document with framesKey undefined, so the background was already gone.
+    expect(saveStatusLabel(false, "partial")).toBe("Background not saved");
+  });
+
+  it("keeps that warning up once a new edit lands", () => {
+    // Unlike "Saved", it reports something already lost, so it must not flicker away on
+    // the next keystroke.
+    expect(saveStatusLabel(true, "partial")).toBe("Background not saved");
+    expect(saveStatusLabel(true, "failed")).toBe("Not saved");
+  });
 });
 
 describe("editor autosave", () => {
@@ -59,6 +74,25 @@ describe("editor autosave", () => {
   it("leaves edits made during a write marked unsaved", () => {
     const autosave = EDITOR.slice(EDITOR.indexOf("AUTOSAVE_DEBOUNCE_MS);") - 1200);
     expect(autosave).toMatch(/editGenRef\.current !== genAtSave/);
+  });
+
+  it("tells the user when the write kept the text but not the background", () => {
+    expect(EDITOR).toContain('setSaveState(framesCached ? "saved" : "partial");');
+    // Both paths must agree: the manual save already warned via a toast.
+    expect([...EDITOR.matchAll(/framesCached \? "saved" : "partial"/g)]).toHaveLength(2);
+  });
+
+  it("never passes the placeholder background off as the user's own", () => {
+    // A framesKey is a handoff, not the data. When the entry is gone - evicted storage,
+    // another browser, an old bookmark - the editor kept the demo frames with isDemo
+    // false, so they were saved and exported as a real background.
+    const loader = EDITOR.slice(EDITOR.indexOf("Load desktop frames from IndexedDB"));
+    const body = loader.slice(0, loader.indexOf("const audioFileRef"));
+    expect(body).toContain("setIsDemo(true);");
+    expect(body).toMatch(/toast\.warning\(/);
+    // Preferring a redraw over a warning, where the URL still carries the recipe.
+    expect(body).toContain("siteStyleSchema.safeParse({ style: styleParam, colors: colorParams })");
+    expect(body).toContain("generate2DFrames(");
   });
 
   it("keeps the unload warning as the backstop for the debounce window", () => {

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -43,12 +43,16 @@ function SaveIndicator({ dirty, state }: { dirty: boolean; state: SaveState }) {
       </span>
     );
   }
-  if (label === "Not saved") {
+  if (label === "Not saved" || label === "Background not saved") {
     return (
       <span
         role="status"
         className="flex-shrink-0 text-xs text-amber-400"
-        title="Autosave failed. Your browser may be out of storage or in private mode - export to keep your work."
+        title={
+          label === "Not saved"
+            ? "Autosave failed. Your browser may be out of storage or in private mode - export to keep your work."
+            : "Your text is saved but the background was too large to keep. Export now to keep it."
+        }
       >
         {label}
       </span>
@@ -209,16 +213,53 @@ function EditorInner() {
     return () => observer.disconnect();
   }, [showPreview, viewportMode]);
 
-  // Load desktop frames from IndexedDB (primary store; sessionStorage was too small at 5 MB)
+  /**
+   * Load desktop frames from IndexedDB, where /create left them.
+   *
+   * The handoff is a key, not the data, so the entry can be gone: storage evicted, a
+   * different browser, a bookmarked link opened days later. Silently keeping the
+   * placeholder then passed it off as the user's own background, and it would have been
+   * saved and exported as one. Redraw from the recipe in the URL where there is one, and
+   * say so where there is not.
+   */
   useEffect(() => {
     if (!framesKey || parsedFrames) return;
-    loadFrames(framesKey).then((f) => {
-      if (f && f.length) {
-        setFrames(f);
-        setFrameCount(f.length);
+    let cancelled = false;
+    (async () => {
+      const stored = await loadFrames(framesKey).catch(() => null);
+      if (cancelled) return;
+      if (stored?.length) {
+        setFrames(stored);
+        setFrameCount(stored.length);
         setIsDemo(false);
+        return;
       }
-    }).catch(() => {});
+      // The recipe the URL carried. Re-derived here rather than read from state: this
+      // effect runs once on mount, and state may have moved on by the time it resolves.
+      const parsed = siteStyleSchema.safeParse({ style: styleParam, colors: colorParams });
+      if (parsed.success) {
+        const recipe = parsed.data;
+        const mob = window.innerWidth < 768;
+        const regen = await generate2DFrames({
+          style: recipe.style,
+          color1: recipe.colors[0],
+          color2: recipe.colors[1],
+          color3: recipe.colors[2],
+          frameCount: mob ? 60 : 90, width: mob ? 640 : 1280, height: mob ? 360 : 720,
+        }, () => {}).catch(() => null);
+        if (cancelled) return;
+        if (regen?.length) {
+          setFrames(regen);
+          setFrameCount(regen.length);
+          setIsDemo(false);
+          toast.info("Redrew the background from its style - this browser no longer had the frames");
+          return;
+        }
+      }
+      setIsDemo(true);
+      toast.warning("That background is no longer in this browser. Pick a template or a style to make a new one.");
+    })();
+    return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const audioFileRef = useRef<HTMLInputElement>(null);
@@ -700,7 +741,7 @@ function EditorInner() {
       // Only clear dirty if nothing changed while the write was in flight, so those
       // edits are not silently marked as saved.
       if (editGenRef.current === genAtSave) setDirty(false);
-      setSaveState("saved");
+      setSaveState(framesCached ? "saved" : "partial");
       if (!opts?.silent) {
         if (framesCached) toast.success("Saved in this browser");
         else toast.warning("Saved, but the background could not be cached - export to keep it.");
@@ -733,11 +774,14 @@ function EditorInner() {
       const genAtSave = editGenRef.current;
       setSaveState("saving");
       writeDocumentRef.current({ withFrames: false }).then(
-        () => {
+        (framesCached) => {
           // Edits made while the write was in flight are still unsaved.
           if (editGenRef.current !== genAtSave) { setSaveState("idle"); return; }
           setDirty(false);
-          setSaveState("saved");
+          // The document write can succeed while the frames write fails — the frames are
+          // orders of magnitude larger, so they are what a quota rejects. Saying "Saved"
+          // there sends the user off to close the tab on a background that is gone.
+          setSaveState(framesCached ? "saved" : "partial");
         },
         () => setSaveState("failed"),
       );

--- a/src/lib/saveStatus.ts
+++ b/src/lib/saveStatus.ts
@@ -6,21 +6,27 @@
  * lost afternoon. This label is the whole signal, which is why the precedence below is
  * pinned by tests rather than left to the component.
  */
-export type SaveState = "idle" | "saving" | "saved" | "failed";
+export type SaveState = "idle" | "saving" | "saved" | "failed" | "partial";
 
 /** How long the editor waits for typing to stop before writing to IndexedDB. */
 export const AUTOSAVE_DEBOUNCE_MS = 1500;
 
-export type SaveStatusLabel = "Saving…" | "Not saved" | "Unsaved changes" | "Saved";
+export type SaveStatusLabel = "Saving…" | "Not saved" | "Background not saved" | "Unsaved changes" | "Saved";
 
 /**
  * `dirty` outranks a past success on purpose: the moment a new edit lands, "Saved" is a
  * lie until the next write completes. A failure outranks everything, because a user who
  * is not told the write failed will close the tab.
+ *
+ * "partial" is the frames write failing while the document write succeeded — the text is
+ * safe but the background is not. It outranks `dirty` because it reports something
+ * already lost rather than something still pending, so it must not flicker away on the
+ * next keystroke.
  */
 export function saveStatusLabel(dirty: boolean, state: SaveState): SaveStatusLabel | null {
   if (state === "saving") return "Saving…";
   if (state === "failed") return "Not saved";
+  if (state === "partial") return "Background not saved";
   if (dirty) return "Unsaved changes";
   if (state === "saved") return "Saved";
   return null;


### PR DESCRIPTION
Two paths where the background is gone and the editor says otherwise. Both found by auditing the storage layer against every caller.

## 1. Autosave said "Saved" when only the text was saved

`writeDocument` returns whether the frames write succeeded. The **manual** save inspects it and warns ("Saved, but the background could not be cached"). The **autosave** effect discarded the return value and set `"saved"` unconditionally.

Frames are megabytes against a document of kilobytes, so the frames write is exactly what a quota rejects. The document then stores `framesKey: undefined` — the background is already unrecoverable — while the indicator says "Saved" and the `beforeunload` guard lets the tab close without a word. For a video upload there is no style recipe, so nothing can redraw it.

New `"partial"` state → **"Background not saved"**, with a title telling the user to export now. It outranks `dirty` because it reports something already lost rather than something still pending, so it does not flicker away on the next keystroke.

## 2. A missing `framesKey` became the user's background

`/editor?framesKey=…` hands over a *key*, not the data, and the entry can be gone: storage evicted, a different browser, a bookmark opened days later. The loader silently kept the demo placeholder with `isDemo` still `false` — so the placeholder was treated as the user's own background and would have been saved and exported as one.

It now redraws from the style recipe when the URL still carries one, and says so plainly when it cannot.

## Verified in Chrome

Production builds, fresh profile per run, with `IDBObjectStore.put` rejecting the frames entry as `QuotaExceededError` (deterministic — the first injection I wrote raced the transaction and I replaced it):

| scenario | `main` | this branch |
| --- | --- | --- |
| frames write fails, document write succeeds | **"Saved"**, `framesKey: undefined` | **"Background not saved"** + explanatory title |
| `framesKey` missing, recipe in the URL | silent placeholder, no demo badge, no toast | redrawn from the recipe, "Redrew the background from its style" |
| `framesKey` missing, no recipe | silent placeholder, **no demo badge**, no toast | demo badge + "That background is no longer in this browser" |

## Tests

Four in `editorAutosave.test.ts`, all failing on `main`. One asserts both save paths agree on the `framesCached` branch by counting occurrences, so the manual path cannot silently diverge again.

Suite 286 passed.