### PR TITLE
Give every form control a name, and let Enter belong to the focused control

### DIFF
--- a/src/__tests__/appAccessibility.test.ts
+++ b/src/__tests__/appAccessibility.test.ts
@@ -229,6 +229,51 @@ describe("the app has one theme and every component agrees on it", () => {
   });
 });
 
+describe("every form control has a name a screen reader can read", () => {
+  /**
+   * Measured in Chrome against production builds by walking every rendered input,
+   * textarea, select and role=switch and checking for a label, aria-label,
+   * aria-labelledby or title. Before: 3 on /contact, 1 on /presets, 1 on the /create
+   * configure step. After: 0 on all of them.
+   */
+  it("associates every contact field with its label", () => {
+    const contact = readFileSync("src/app/contact/page.tsx", "utf8");
+    for (const id of ["contact-name", "contact-email", "contact-message"]) {
+      expect(contact, `${id} has no label association`).toContain(`htmlFor="${id}"`);
+      expect(contact, `${id} is not on a control`).toContain(`id="${id}"`);
+    }
+    // The topic pills are a group, not a field: a bare <label> named nothing.
+    expect(contact).toContain('role="group" aria-labelledby="contact-topic-label"');
+    expect(contact).toContain("aria-pressed={form.topic === t}");
+  });
+
+  it("names the presets search box", () => {
+    const presets = readFileSync("src/app/presets/page.tsx", "utf8");
+    expect(presets).toContain('<label htmlFor="preset-search" className="sr-only">Search presets</label>');
+    expect(presets).toContain('id="preset-search"');
+  });
+
+  it("names the mobile-variant switch", () => {
+    // role="switch" with aria-checked and no name announces only its state.
+    const create = readFileSync("src/app/create/page.tsx", "utf8");
+    const sw = create.slice(create.indexOf('role="switch"') - 400, create.indexOf('role="switch"') + 200);
+    expect(sw).toContain('aria-label="Generate mobile variant"');
+  });
+});
+
+describe("Enter belongs to the control that has focus", () => {
+  it("does not also run the create wizard's own Enter handler", () => {
+    // The browser already turns Enter on a focused button into a click. Handling it at
+    // the window too meant one keypress both chose a palette and started generation.
+    // Verified in Chrome: on the previous build, focusing a palette swatch and pressing
+    // Enter started generation; now it does not, while Enter on a non-interactive
+    // target still advances the wizard.
+    const create = readFileSync("src/app/create/page.tsx", "utf8");
+    expect(create).not.toMatch(/if \(tag === "INPUT" \|\| tag === "TEXTAREA"\) return;/);
+    expect(create).toContain(`el.closest("input, textarea, select, button, a[href], [contenteditable], [role='switch'], [role='button']")`);
+  });
+});
+
 describe("analytics does not break a self-hosted deploy", () => {
   it("only mounts the Vercel script when Vercel is serving", () => {
     // Mounted unconditionally the insights script 404s and trips strict MIME checking,

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -111,27 +111,30 @@ export default function ContactPage() {
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-1.5">
-                    <label className="text-xs text-muted-foreground">Name</label>
-                    <Input value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} placeholder="Your name" className="bg-white/5 border-white/10" />
+                    <label htmlFor="contact-name" className="text-xs text-muted-foreground">Name</label>
+                    <Input id="contact-name" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} placeholder="Your name" className="bg-white/5 border-white/10" />
                   </div>
                   <div className="space-y-1.5">
-                    <label className="text-xs text-muted-foreground">Email</label>
-                    <Input value={form.email} onChange={e => setForm(f => ({ ...f, email: e.target.value }))} placeholder="you@example.com" type="email" className="bg-white/5 border-white/10" />
+                    <label htmlFor="contact-email" className="text-xs text-muted-foreground">Email</label>
+                    <Input id="contact-email" value={form.email} onChange={e => setForm(f => ({ ...f, email: e.target.value }))} placeholder="you@example.com" type="email" className="bg-white/5 border-white/10" />
                   </div>
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs text-muted-foreground">Topic</label>
-                  <div className="flex flex-wrap gap-2">
+                  {/* A pill group, not a text field: named as a group so a screen reader
+                      announces what the pressed state belongs to. */}
+                  <span id="contact-topic-label" className="block text-xs text-muted-foreground">Topic</span>
+                  <div role="group" aria-labelledby="contact-topic-label" className="flex flex-wrap gap-2">
                     {TOPICS.map(t => (
                       <button key={t} type="button" onClick={() => setForm(f => ({ ...f, topic: t }))}
+                        aria-pressed={form.topic === t}
                         className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-all ${form.topic === t ? "bg-primary text-white border-primary" : "border-white/10 text-muted-foreground hover:border-white/20"}`}
                       >{t}</button>
                     ))}
                   </div>
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs text-muted-foreground">Message</label>
-                  <Textarea value={form.message} onChange={e => setForm(f => ({ ...f, message: e.target.value }))} placeholder="Tell us what's on your mind..." className="bg-white/5 border-white/10 min-h-[140px] resize-none" />
+                  <label htmlFor="contact-message" className="text-xs text-muted-foreground">Message</label>
+                  <Textarea id="contact-message" value={form.message} onChange={e => setForm(f => ({ ...f, message: e.target.value }))} placeholder="Tell us what's on your mind..." className="bg-white/5 border-white/10 min-h-[140px] resize-none" />
                 </div>
                 <Button type="submit" disabled={loading} className="w-full bg-primary hover:bg-primary/90 text-white font-semibold py-5">
                   {loading ? "Opening…" : "Compose message"}

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -148,8 +148,12 @@ function CreatePageInner() {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Enter" || isGenerating) return;
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      // Enter on a focused control belongs to that control - the browser turns it into a
+      // click. Handling it here too fired the button and advanced the wizard from the
+      // same keypress, so tabbing to a palette swatch and pressing Enter chose the
+      // palette and started generation together.
+      const el = e.target as HTMLElement | null;
+      if (!el || el.closest("input, textarea, select, button, a[href], [contenteditable], [role='switch'], [role='button']")) return;
       if (step === 0) { e.preventDefault(); setStep(1); }
       // Through a ref: the listener is only rebound when step/isGenerating change, so
       // calling handleGenerate directly ran the closure captured back then — generating
@@ -333,6 +337,7 @@ function CreatePageInner() {
                   className={`relative w-10 h-6 rounded-full transition-colors ${generateMobile ? "bg-primary" : "bg-white/10"}`}
                   role="switch"
                   aria-checked={generateMobile}
+                  aria-label="Generate mobile variant"
                 >
                   <span className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${generateMobile ? "translate-x-5" : "translate-x-1"}`} />
                 </button>

--- a/src/app/presets/page.tsx
+++ b/src/app/presets/page.tsx
@@ -55,8 +55,10 @@ export default function PresetsPage() {
       {/* Search + filters */}
       <div className="px-6 pb-8 max-w-7xl mx-auto space-y-4">
         <div className="relative max-w-md mx-auto">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" aria-hidden="true" />
+          <label htmlFor="preset-search" className="sr-only">Search presets</label>
           <Input
+            id="preset-search"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search presets…"


### PR DESCRIPTION
## Unnamed controls

Five controls announced nothing useful to a screen reader:

- The contact form's **Name**, **Email** and **Message** labels were bare `<label>` elements with no `htmlFor` and no wrapping, so all three read as unlabelled edit fields.
- The **presets search box** had neither a label nor an `aria-label` — the templates page already does this correctly, so this was just a miss.
- The **"Generate mobile variant" switch** carried `role="switch"` and `aria-checked` with no name at all, so it announced only its state.

The contact form's **Topic** row is a pill group, not a field, so it becomes a `role="group"` with `aria-labelledby` and `aria-pressed` on each pill, rather than a `<label>` pointing at nothing.

Measured in Chrome against production builds, walking every *rendered* input, textarea, select and `role=switch` and checking for a label, `aria-label`, `aria-labelledby` or `title`:

| page | before | after |
| --- | --- | --- |
| `/contact` | 3 | **0** |
| `/presets` | 1 | **0** |
| `/create` (configure step) | 1 | **0** |

(The hidden `<input type="file">` is `display:none` and driven by the labelled button above it, so it is out of the accessibility tree — my first probe counted it and I tightened the probe rather than "fixing" a non-issue.)

## Enter belonged to the wizard, not to the control

`/create` listened for Enter on the window and bailed only for `INPUT` and `TEXTAREA`. The browser already turns Enter on a focused button into a click, so one keypress on a palette swatch both **chose the palette and started generation** — a keyboard user could not select a palette without immediately committing to it.

It now bails for any focused control, while Enter on a non-interactive target still advances the wizard as intended. Both halves verified, because a guard that also broke the feature would be worse:

| on the configure step | `main` | this branch |
| --- | --- | --- |
| Enter on a focused palette button | **starts generating** | does nothing |
| Enter on a non-interactive target (control) | starts generating | starts generating |

Measured against a `main` worktree built and served side by side, rather than by swapping files in place.

Four tests in `appAccessibility.test.ts`, all failing on `main`. Suite 292 passed.