### PR TITLE
Validate the shape of what the export route is handed

### DIFF
--- a/src/__tests__/exportQuality.test.ts
+++ b/src/__tests__/exportQuality.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { NextRequest } from "next/server";
 import { TEMPLATES } from "@/lib/templates";
+import { MAX_SECTIONS } from "@/lib/siteSchema";
 import { faviconSvg, notFoundHtml, exportReadme } from "@/lib/exportAssets";
 
 /**
@@ -41,6 +42,67 @@ beforeEach(async () => {
   vi.clearAllMocks();
   rateLimitMock.mockResolvedValue({ allowed: true });
   ({ POST } = await import("../app/api/export-site/route"));
+});
+
+/**
+ * The route reads the request body and nothing else - no accounts, no stored record to
+ * prefer over it - so the body's shape is the only thing between a caller and the page
+ * that gets generated. It was checked for being a non-empty array and for size, never
+ * for shape, so a null element threw inside the generator and surfaced as a 500 "Export
+ * failed", and a heading of the wrong type was interpolated as-is: {"heading":{"a":1}}
+ * shipped a page whose <h1> read "[object Object]". Verified against a running
+ * production build before and after.
+ */
+async function exportStatus(sections: unknown): Promise<{ status: number; error?: string }> {
+  const res = await POST(new Request("https://scrollcraft.app/api/export-site", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ sections, siteName: "S", frameCount: 10 }),
+  }) as unknown as NextRequest);
+  const json = await res.json();
+  return { status: res.status, error: json.error };
+}
+
+describe("the export route validates the shape of what it is given", () => {
+  it("still exports a well-formed document, so the guard is not just rejecting everything", async () => {
+    const ok = await exportStatus([{ heading: "Hi", scrollHeight: 1000 }]);
+    expect(ok.status).toBe(200);
+  });
+
+  it("rejects a malformed section with a 400 that names the field", async () => {
+    for (const [label, sections] of [
+      ["null element", [null]],
+      ["string element", ["oops"]],
+      ["heading of the wrong type", [{ heading: 12345 }]],
+      ["nested object as heading", [{ heading: { a: 1 } }]],
+      ["scrollHeight as a string", [{ heading: "Hi", scrollHeight: "tall" }]],
+    ] as const) {
+      const res = await exportStatus(sections);
+      expect(res.status, `${label} was not rejected`).toBe(400);
+      expect(res.error, `${label} produced no message`).toBeTruthy();
+    }
+  });
+
+  it("never lets a non-string heading reach the page", async () => {
+    // The 500 was the loud failure; this was the quiet one.
+    const res = await exportStatus([{ heading: { a: 1 } }]);
+    expect(res.status).toBe(400);
+  });
+
+  it("clamps an out-of-range number rather than failing the whole export", async () => {
+    // The route's existing contract for imageWidth, scrim and reveal, which is why the
+    // shape check above is types-only. scrollHeight was the one field with neither a
+    // bound nor a clamp, so -99999 was emitted straight into the page's inline style.
+    const html = await exportHtml({ sections: [{ heading: "A", scrollHeight: -99999 }] });
+    expect(html).not.toContain("-99999");
+    expect(html).toContain("height:1000px");
+  });
+
+  it("holds the section count to the limit the editor itself enforces", async () => {
+    const one = { heading: "Hi", scrollHeight: 1000 };
+    expect((await exportStatus(Array.from({ length: MAX_SECTIONS }, () => one))).status).toBe(200);
+    expect((await exportStatus(Array.from({ length: MAX_SECTIONS + 1 }, () => one))).status).toBe(400);
+  });
 });
 
 describe("the exported page has a real document outline", () => {

--- a/src/__tests__/siteSchema.test.ts
+++ b/src/__tests__/siteSchema.test.ts
@@ -5,7 +5,10 @@ import {
   REVEALS,
   MAX_SECTIONS,
   parseSectionsJson,
+  exportSectionSchema,
+  exportSectionsSchema,
   sectionSchema,
+  sectionsSchema,
   visibleSections,
   type Section,
 } from "@/lib/siteSchema";
@@ -139,5 +142,32 @@ describe("visibleSections", () => {
   it("drops only sections explicitly hidden", () => {
     const s: Section[] = [{ heading: "A" }, { heading: "B", visible: false }, { heading: "C", visible: true }];
     expect(visibleSections(s).map((x) => x.heading)).toEqual(["A", "C"]);
+  });
+});
+
+describe("the export route's lenient schema stays in step with the strict one", () => {
+  it("covers exactly the same fields", () => {
+    // Two schemas exist on purpose: the route clamps ranges rather than rejecting them,
+    // so its input schema checks types only. They must still describe the same section,
+    // or a field added to one is silently stripped by the other.
+    const strict = Object.keys(sectionSchema.shape).sort();
+    const lenient = Object.keys(exportSectionSchema.shape).sort();
+    expect(strict.length).toBeGreaterThan(10);
+    expect(lenient).toEqual(strict);
+  });
+
+  it("still rejects the shapes that broke the generator", () => {
+    expect(exportSectionsSchema.safeParse([null]).success).toBe(false);
+    expect(exportSectionsSchema.safeParse(["oops"]).success).toBe(false);
+    expect(exportSectionsSchema.safeParse([{ heading: { a: 1 } }]).success).toBe(false);
+    expect(exportSectionsSchema.safeParse([{ heading: 12345 }]).success).toBe(false);
+  });
+
+  it("leaves out-of-range values for the route to clamp", () => {
+    // Rejecting these would break the export over something the route already fixes.
+    for (const section of [{ scrim: 5 }, { imageWidth: 99999 }, { reveal: "explode" }, { scrollHeight: -99999 }]) {
+      expect(exportSectionsSchema.safeParse([section]).success, JSON.stringify(section)).toBe(true);
+      expect(sectionsSchema.safeParse([section]).success, `${JSON.stringify(section)} should fail the strict schema`).toBe(false);
+    }
   });
 });

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { rateLimit, getClientIp } from "@/lib/rateLimit";
-import { REVEALS, type Section, visibleSections as onlyVisible } from "@/lib/siteSchema";
+import { REVEALS, exportSectionsSchema, type Section, visibleSections as onlyVisible } from "@/lib/siteSchema";
 import { layoutStyle } from "@/lib/layoutStyles";
 import { parseThemeJson, parseStyleJson } from "@/lib/siteSchema";
 import { proceduralRuntimeSource } from "@/lib/generate2DFrames";
@@ -13,6 +13,19 @@ function esc(s: unknown): string {
           .replace(/"/g, "&quot;").replace(/'/g, "&#x27;");
 }
 
+
+/**
+ * The scroll track a section occupies.
+ *
+ * Clamped the way imageWidth and scrim already are. `Number(x) || 1000` accepted a
+ * negative, so a scrollHeight of -99999 was emitted straight into the exported page's
+ * inline style; the bounds are sectionSchema's own.
+ */
+function trackHeight(s: Section): number {
+  const raw = Number(s.scrollHeight);
+  if (!Number.isFinite(raw) || raw <= 0) return 1000;
+  return Math.min(Math.max(Math.round(raw), 100), 20_000);
+}
 
 function layoutFor(s: Section) {
   return layoutStyle(s.layout);
@@ -88,9 +101,26 @@ export async function POST(req: NextRequest) {
     }
     // Cap the section payload: with no stored record to fall back on, the body is the
     // only input and an uncapped `sections` amplifies a small request into a huge page.
-    if (sections.length > 200 || JSON.stringify(sections).length > 1_000_000) {
+    if (JSON.stringify(sections).length > 1_000_000) {
       return NextResponse.json({ error: "sections payload is too large" }, { status: 400 });
     }
+    // Shape, not just size. Without this the route read whatever arrived: a null element
+    // threw inside the generator and surfaced as a 500 "Export failed", and a heading of
+    // the wrong type was interpolated as-is, so `{"heading":{"a":1}}` shipped a page
+    // whose <h1> read "[object Object]". Types only - out-of-range numbers stay the
+    // clamps' job below, and MAX_SECTIONS is the limit the editor itself enforces.
+    const parsedSections = exportSectionsSchema.safeParse(sections);
+    if (!parsedSections.success) {
+      const issue = parsedSections.error.issues[0];
+      const where = issue?.path?.length ? issue.path.join(".") : "sections";
+      return NextResponse.json(
+        { error: `${where}: ${issue?.message ?? "invalid section"}` },
+        { status: 400 }
+      );
+    }
+    // Cast because this schema checks types, not the enums: an unrecognised layout or
+    // reveal is clamped a few lines down rather than rejected.
+    const validSections = parsedSections.data as Section[];
     // A background recipe lets the exported page draw its own frames, so the ZIP carries
     // no JPEGs at all. Frames are only required when there is no recipe to draw from.
     const parsedStyle = styleJson ? parseStyleJson(styleJson) : null;
@@ -174,7 +204,9 @@ export async function POST(req: NextRequest) {
       siteName ||
       "A cinematic scroll website";
 
-    const visibleSections = onlyVisible(sections as Section[]);
+    // The validated copy, not the raw body: unknown keys are stripped and every field
+    // is the type the generator below assumes.
+    const visibleSections = onlyVisible(validSections);
     if (visibleSections.length === 0) {
       return NextResponse.json({ error: "At least one section must be visible to export" }, { status: 400 });
     }
@@ -191,13 +223,13 @@ export async function POST(req: NextRequest) {
       const imgWidth = Math.min(Number(s.imageWidth) || 480, 1600);
       if (s.kind === "spacer") {
         return `
-    <section class="scroll-section" aria-hidden="true" style="height:${Number(s.scrollHeight) || 1000}px; position:relative; z-index:10;"></section>`;
+    <section class="scroll-section" aria-hidden="true" style="height:${trackHeight(s)}px; position:relative; z-index:10;"></section>`;
       }
       const reveal = (REVEALS as readonly string[]).includes(s.reveal ?? "") ? s.reveal : "rise";
       const hTag = sectionIndex === firstHeadingIndex ? "h1" : "h2";
       const scrim = Math.min(Math.max(Number(s.scrim ?? 0) || 0, 0), 1);
       return `
-    <section class="scroll-section" style="height:${Number(s.scrollHeight) || 1000}px; position:relative; z-index:10;">
+    <section class="scroll-section" style="height:${trackHeight(s)}px; position:relative; z-index:10;">
       <div class="section-sticky" style="position:sticky; top:0; height:100vh; display:flex; align-items:${safeCss(s.align || L.align)}; justify-content:${safeCss(s.justify || L.justify)}; overflow:hidden;">
         <div class="section-content" data-reveal="${reveal}" style="${scrim > 0 ? `background:radial-gradient(ellipse 120% 100% at 50% 50%, rgba(0,0,0,${scrim}) 0%, rgba(0,0,0,${(scrim * 0.72).toFixed(3)}) 45%, rgba(0,0,0,0) 78%); ` : ""}text-align:${safeCss(s.textAlign || L.textAlign)}; padding:${L.pad}; max-width:${L.maxWidth}px; transition:opacity 0.6s cubic-bezier(0.25,0.46,0.45,0.94),transform 0.6s cubic-bezier(0.25,0.46,0.45,0.94),clip-path 0.7s cubic-bezier(0.25,0.46,0.45,0.94);">
           ${imgSrc ? `<img src="${esc(imgSrc)}" alt="${esc(s.imageAlt || "")}" style="display:block; max-width:min(100%, ${imgWidth}px); height:auto; margin:${stack};" />` : ""}
@@ -212,7 +244,7 @@ export async function POST(req: NextRequest) {
     </section>`;
     }).join("\n");
 
-    const totalScrollHeight = visibleSections.reduce((acc: number, s: Section) => acc + (Number(s.scrollHeight) || 1000), 0) + 1000;
+    const totalScrollHeight = visibleSections.reduce((acc: number, s: Section) => acc + trackHeight(s), 0) + 1000;
 
     const html = `<!DOCTYPE html>
 <html lang="en">

--- a/src/lib/siteSchema.ts
+++ b/src/lib/siteSchema.ts
@@ -117,6 +117,45 @@ export const sectionSchema = object({
 
 export const sectionsSchema = array(sectionSchema).max(MAX_SECTIONS);
 
+/**
+ * What the export route requires of a section it is handed directly.
+ *
+ * Stricter than "an array of anything": the route interpolates these into a page, so a
+ * null element threw inside the generator and a heading of the wrong type rendered as
+ * "[object Object]".
+ *
+ * Deliberately looser than sectionSchema on ranges and enums. The route already clamps
+ * an oversized imageWidth, a scrim outside 0-1 and an unrecognised reveal, and failing a
+ * whole export over a scrim of 1.05 would be worse for the user than fixing it. Types
+ * here, ranges there. exportSectionsCoverSameFields in the schema tests keeps the two in
+ * step.
+ */
+export const exportSectionSchema = object({
+  id: string().optional(),
+  layout: string().optional(),
+  kind: string().optional(),
+  reveal: string().optional(),
+  scrim: number().optional(),
+  eyebrow: string().optional(),
+  heading: string().optional(),
+  body: string().optional(),
+  ctaLabel: string().optional(),
+  ctaHref: string().optional(),
+  image: string().optional(),
+  imageAlt: string().optional(),
+  imageWidth: number().optional(),
+  accentColor: string().optional(),
+  headingColor: string().optional(),
+  bodyColor: string().optional(),
+  textAlign: string().optional(),
+  align: string().optional(),
+  justify: string().optional(),
+  scrollHeight: number().optional(),
+  visible: boolean().optional(),
+}).strip();
+
+export const exportSectionsSchema = array(exportSectionSchema).max(MAX_SECTIONS);
+
 export type Section = zInfer<typeof sectionSchema>;
 
 export type EditorSection = Section & {


### PR DESCRIPTION
No accounts and no database, so the request body is the whole input and there is no stored record to prefer over it. The route checked that `sections` was a non-empty array and that it was not too large — never that it held sections.

Measured against a running production build:

| body | `main` | this branch |
| --- | --- | --- |
| `sections: [null]` | **500** `"Export failed"` from inside the generator | `400 0: expected object, received null` |
| `sections: ["oops"]` | 200, a section rendered from a string | `400 0: expected object, received string` |
| `sections: [{heading:{a:1}}]` | 200, and the page's `<h1>` read **`[object Object]`** | `400 0.heading: expected string, received object` |
| `sections: [{heading:12345}]` | 200 | `400 0.heading: expected string, received number` |
| `sections: [{scrollHeight:"tall"}]` | 200 | `400 0.scrollHeight: expected number, received string` |

## Why a second schema and not `sectionsSchema`

That is what I tried first, and it broke three existing tests. The route deliberately **clamps** rather than rejects: an oversized `imageWidth` caps at 1600, a `scrim` of 5 clamps to 1, an unrecognised `reveal` falls back to `rise`. Failing a whole export over a `scrim` of 1.05 would be worse for the user than fixing it.

So `exportSectionsSchema` checks **types only**; ranges and enums stay the clamps' job. A test asserts the two schemas cover exactly the same field set, so a field added to one cannot be silently stripped by the other.

## One field had neither

`scrollHeight` used `Number(s.scrollHeight) || 1000`, which accepts a negative — so `-99999` went straight into the exported page's inline style. It is now clamped like its neighbours, to `sectionSchema`'s own bounds:

| | `main` | this branch |
| --- | --- | --- |
| emitted `height:` for `scrollHeight: -99999` | `-99999px` | `1000px` |

## Nothing valid changed

Built and served this branch and a `main` worktree side by side. For a realistic template export — 5 full sections with theme and style JSON — the emitted **markup is byte-identical** (15,218 bytes both), so the validated copy drops nothing the generator used. A 100-section export still succeeds on both.

The one intentional tightening: 101+ sections now returns 400. `MAX_SECTIONS` is 100, which is the limit the editor itself enforces; the route had been allowing 200.

Four new tests plus three schema tests. Suite 300 passed.