### PR TITLE
Stop one site's mobile frames becoming the next site's

### DIFF
--- a/src/__tests__/editorAutosave.test.ts
+++ b/src/__tests__/editorAutosave.test.ts
@@ -95,6 +95,19 @@ describe("editor autosave", () => {
     expect(body).toContain("generate2DFrames(");
   });
 
+  it("clears the mobile-frames slot when this document has none", () => {
+    // There is one slot and it is shared. The write only ever put to it, and the restore
+    // loads it unconditionally, so a site with no mobile variant inherited whatever the
+    // last site that had one left behind - and exported it as its own.
+    // Verified in Chrome: seed the slot, edit a site with no mobile frames, let autosave
+    // run. Previous build left ["SITE-A-MOBILE-FRAME"] in place; this one clears it.
+    const write = EDITOR.slice(EDITOR.indexOf("const writeDocument"), EDITOR.indexOf("const handleSave"));
+    expect(write).toContain("storeFrames(SAVED_MOBILE_FRAMES_KEY, mobileFrames)");
+    expect(write).toContain("deleteFrames(SAVED_MOBILE_FRAMES_KEY)");
+    // Both branches of the same condition, so the slot always matches the document.
+    expect(write).toMatch(/if \(mobileFrames\.length\) \{[\s\S]*?\} else \{[\s\S]*?deleteFrames/);
+  });
+
   it("keeps the unload warning as the backstop for the debounce window", () => {
     expect(EDITOR).toContain('window.addEventListener("beforeunload", onBeforeUnload);');
     expect(EDITOR).toMatch(/if \(!dirty\) return;/);

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useEffect, useRef, useCallback, useSyncExternalStore, Suspense } from "react";
-import { loadFrames, storeFrames, storeDocument, loadDocument } from "@/lib/frameStorage";
+import { loadFrames, storeFrames, deleteFrames, storeDocument, loadDocument } from "@/lib/frameStorage";
 import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -707,8 +707,13 @@ function EditorInner() {
       framesCached = await storeFrames(SAVED_FRAMES_KEY, frames).then(() => true, () => false);
       if (framesCached) {
         savedFramesSigRef.current = framesSignature;
+        // Clear the slot when this document has none, or it keeps whatever the last
+        // document that did put there - restore loads this key unconditionally, so a
+        // site with no mobile variant inherited the previous site's and exported it.
         if (mobileFrames.length) {
           await storeFrames(SAVED_MOBILE_FRAMES_KEY, mobileFrames).catch(() => {});
+        } else {
+          await deleteFrames(SAVED_MOBILE_FRAMES_KEY).catch(() => {});
         }
       }
     }


### PR DESCRIPTION
There is **one** slot for mobile frames (`scrollcraft_saved_mframes`) and it is shared by every saved document.

`writeDocument` only ever *put* to it:

```ts
if (mobileFrames.length) {
  await storeFrames(SAVED_MOBILE_FRAMES_KEY, mobileFrames).catch(() => {});
}
```

…never cleared it. And the restore path loads it **unconditionally**, independent of whether the restored document ever had a mobile variant:

```ts
const storedMobile = await loadFrames(SAVED_MOBILE_FRAMES_KEY).catch(() => null);
…
if (storedMobile?.length) setMobileFrames(storedMobile);
```

So: save site A with a mobile variant → later save site B without one → reopen B → B comes back carrying A's portrait frames, and exports them as its own.

The write now clears the slot when the document has no mobile frames, so the slot always matches the document.

## Verified in Chrome

Production builds of this branch and a `main` worktree (`b7b1aee`), served side by side. Bootstrap the database with one edit, seed the slot with `["SITE-A-MOBILE-FRAME"]` **from `/api/health`** so nothing contends for the connection, then edit a template with no mobile variant and let autosave run:

| | after site B's autosave |
| --- | --- |
| `main` | `STILL THERE -> ["SITE-A-MOBILE-FRAME"]` |
| this branch | `cleared` |

Both runs reached `Saved`, so the save itself is unaffected.

One test in `editorAutosave.test.ts`, asserting both branches of the same condition so the slot cannot drift from the document again. It fails on `main`. Suite 297 passed.