### PR TITLE
Tell the user when a second editor tab is open

### DIFF
--- a/src/__tests__/editorAutosave.test.ts
+++ b/src/__tests__/editorAutosave.test.ts
@@ -108,6 +108,21 @@ describe("editor autosave", () => {
     expect(write).toMatch(/if \(mobileFrames\.length\) \{[\s\S]*?\} else \{[\s\S]*?deleteFrames/);
   });
 
+  it("tells the user when a second editor tab is open", () => {
+    // One document slot by design, so two tabs autosave over each other and the loser's
+    // work is gone with no sign it happened. Nothing to merge, so the fix is to say so
+    // while both tabs are still open. Verified in Chrome: one tab warns about nothing,
+    // and opening a second makes both warn.
+    expect(EDITOR).toContain('const EDITOR_CHANNEL = "scrollcraft-editor-tabs";');
+    expect(EDITOR).toContain("new BroadcastChannel(EDITOR_CHANNEL)");
+    expect(EDITOR).toContain("Another editor tab is open");
+    // A per-tab id, or a channel would answer itself and a dev double-mount would warn.
+    expect(EDITOR).toContain("if (!msg || msg.from === TAB_ID) return;");
+    // Absent in some environments, and losing the warning must not lose the editor.
+    expect(EDITOR).toContain('if (typeof BroadcastChannel === "undefined") return;');
+    expect(EDITOR).toContain("return () => channel.close();");
+  });
+
   it("keeps the unload warning as the backstop for the debounce window", () => {
     expect(EDITOR).toContain('window.addEventListener("beforeunload", onBeforeUnload);');
     expect(EDITOR).toMatch(/if \(!dirty\) return;/);

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -29,6 +29,18 @@ const ScrollSection = dynamic(() => import("@/components/ScrollSection"), { ssr:
 
 type Section = EditorSection;
 
+/**
+ * One tab, one saved document.
+ *
+ * There is a single document slot by design - a tool with no account has nothing to hang
+ * a library off - so two editor tabs autosave over each other and the loser's work is
+ * gone with no sign it ever happened. There is nothing to merge, so the honest fix is to
+ * say so while both tabs are still open rather than report the loss afterwards.
+ */
+const EDITOR_CHANNEL = "scrollcraft-editor-tabs";
+/** Per tab, so a channel never answers itself and a double-mount in dev cannot warn. */
+const TAB_ID = typeof crypto !== "undefined" && crypto.randomUUID ? crypto.randomUUID() : String(Math.random());
+
 const SAVED_FRAMES_KEY = "scrollcraft_saved_frames";
 const SAVED_MOBILE_FRAMES_KEY = "scrollcraft_saved_mframes";
 
@@ -828,6 +840,38 @@ function EditorInner() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  useEffect(() => {
+    if (typeof BroadcastChannel === "undefined") return;
+    let channel: BroadcastChannel;
+    try {
+      channel = new BroadcastChannel(EDITOR_CHANNEL);
+    } catch {
+      return;
+    }
+    let warned = false;
+    const warnOnce = () => {
+      if (warned) return;
+      warned = true;
+      toast.warning("Another editor tab is open. Both save to the same document, so the last one to save wins.", {
+        duration: 10000,
+      });
+    };
+    channel.onmessage = (e: MessageEvent) => {
+      const msg = e.data as { type?: string; from?: string } | null;
+      if (!msg || msg.from === TAB_ID) return;
+      // A new tab asks; every existing tab answers. Both ends warn, so whichever tab the
+      // user is looking at tells them.
+      if (msg.type === "hello") {
+        channel.postMessage({ type: "here", from: TAB_ID });
+        warnOnce();
+      } else if (msg.type === "here") {
+        warnOnce();
+      }
+    };
+    channel.postMessage({ type: "hello", from: TAB_ID });
+    return () => channel.close();
   }, []);
 
   // Warn before leaving with unsaved changes


### PR DESCRIPTION
There is **one** document slot, by design — `frameStorage.ts` says so: *"a single working document is the honest shape for a tool with no account to hang a library off"*. The consequence was not handled: two editor tabs autosave over each other, and the loser's work is gone with no sign it ever happened.

There is nothing to merge here, so the honest fix is to say so **while both tabs are still open**, rather than report the loss afterwards.

## How

A `BroadcastChannel`: a new tab says `hello`, every existing tab answers `here`, and both ends warn — so whichever tab the user is actually looking at tells them.

- Each tab carries its own `TAB_ID`, or a channel would answer itself and a StrictMode double-mount in development would warn about a tab that does not exist.
- Guarded on `typeof BroadcastChannel === "undefined"` and wrapped in try/catch: losing the warning must never lose the editor.
- The channel is closed on unmount.

## Verified in Chrome

Production builds of this branch and a `main` worktree, with two **real** tabs on the same origin (opened via `/json/new`, not simulated):

| | `main` | this branch |
| --- | --- | --- |
| one tab open | no warning | no warning |
| second tab open — tab 2 | no warning | **warned** |
| second tab open — tab 1 | no warning | **warned** |

The single-tab row is the one that matters most: a warning that fires spuriously would be worse than the bug, so it is checked on both builds.

One test in `editorAutosave.test.ts`, failing on `main`. Suite 305 passed.