### PR TITLE
Make the exported site the site the user previewed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ isn't tolerated.
 
 ## Development setup
 
-> Requires Node.js 20+. That is the whole list.
+> Requires Node.js 22+. That is the whole list.
 
 ```bash
 # Fork the repo, then:

--- a/README.md
+++ b/README.md
@@ -77,28 +77,28 @@ Ask Claude for a scroll site, or drive it yourself:
 ```bash
 # Fastest path — no footage needed. Scaffolds the spec, generates a
 # background, and builds a working site in one command.
-node scripts/init.mjs --name "Orrery" --style aurora
+node plugins/scrollcraft/skills/scrollcraft/scripts/init.mjs --name "Orrery" --style aurora
 ```
 
 Or step by step:
 
 ```bash
 # 1a. your own video -> frame sequence, desktop + mobile
-node scripts/frames-from-video.mjs --input hero.mp4 --out frames \
+node plugins/scrollcraft/skills/scrollcraft/scripts/frames-from-video.mjs --input hero.mp4 --out frames \
   --fps 24 --width 1920 --mobile-width 828 --mobile-out frames-mobile
 
 # 1b. or generate one: six cinematic styles, ~1MB instead of ~36MB
-node scripts/frames-from-style.mjs --list
-node scripts/frames-from-style.mjs --style nebula --count 180 \
+node plugins/scrollcraft/skills/scrollcraft/scripts/frames-from-style.mjs --list
+node plugins/scrollcraft/skills/scrollcraft/scripts/frames-from-style.mjs --style nebula --count 180 \
   --width 1920 --mobile-width 828 --mobile-out frames-mobile
 
 # 2. write scrollcraft.json describing your sections, then build
-node scripts/build-site.mjs --spec scrollcraft.json --out dist
+node plugins/scrollcraft/skills/scrollcraft/scripts/build-site.mjs --spec scrollcraft.json --out dist
 
 # 3. check the files, then check what actually renders
-node scripts/doctor.mjs --spec scrollcraft.json
-node scripts/verify.mjs --dir dist --shots shots
-node scripts/serve.mjs --dir dist --port 4321
+node plugins/scrollcraft/skills/scrollcraft/scripts/doctor.mjs --spec scrollcraft.json
+node plugins/scrollcraft/skills/scrollcraft/scripts/verify.mjs --dir dist --shots shots
+node plugins/scrollcraft/skills/scrollcraft/scripts/serve.mjs --dir dist --port 4321
 ```
 
 `verify.mjs` drives headless Chrome over the DevTools Protocol with no npm dependencies,
@@ -135,7 +135,8 @@ to sign up for and nothing to configure.
 
 ### Prerequisites
 
-Node.js 20 or newer. That is the whole list.
+Node.js 22 or newer. That is the whole list — `verify.mjs` drives Chrome over the
+global `WebSocket`, which Node only exposes unflagged from 22.
 
 ```bash
 git clone https://github.com/singhharsh1708/scrollcraft.git

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "scrollcraft",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/plugins/scrollcraft/skills/scrollcraft/engine/scrollcraft.runtime.js
+++ b/plugins/scrollcraft/skills/scrollcraft/engine/scrollcraft.runtime.js
@@ -54,7 +54,7 @@
     return dir + '/frame_' + s + '.jpg';
   }
 
-  function preloadSet(count, dir, target, isPrimary) {
+  function preloadSet(count, dir, target) {
     if (!count) return;
     var STEP = 5;
     var keyframes = [];
@@ -83,7 +83,6 @@
       }
       img.onload = function () {
         target[i] = img;
-        if (i === 0 && isPrimary) drawFrame(0);
         if (i === currentFrame) drawFrame(i);
         advance();
       };
@@ -96,10 +95,10 @@
 
   function preload() {
     if (hasMobile && isMobile) {
-      preloadSet(mobileCount, framesMobileDir, mobileImages, true);
+      preloadSet(mobileCount, framesMobileDir, mobileImages);
       mobileLoaded = true;
     } else {
-      preloadSet(desktopCount, framesDir, desktopImages, true);
+      preloadSet(desktopCount, framesDir, desktopImages);
       desktopLoaded = true;
     }
   }
@@ -130,11 +129,11 @@
       isMobile = e.matches;
       frameCount = isMobile ? mobileCount : desktopCount;
       if (isMobile && !mobileLoaded) {
-        preloadSet(mobileCount, framesMobileDir, mobileImages, true);
+        preloadSet(mobileCount, framesMobileDir, mobileImages);
         mobileLoaded = true;
       }
       if (!isMobile && !desktopLoaded) {
-        preloadSet(desktopCount, framesDir, desktopImages, true);
+        preloadSet(desktopCount, framesDir, desktopImages);
         desktopLoaded = true;
       }
       currentFrame = -1;

--- a/plugins/scrollcraft/skills/scrollcraft/references/grammars.md
+++ b/plugins/scrollcraft/skills/scrollcraft/references/grammars.md
@@ -33,7 +33,6 @@ rhythm, so no section needs to shout.
 | text | left | rise | 1300 |
 | text | right | rise | 1300 |
 | text | left | rise | 1300 |
-| text | right | rise | 1300 |
 | text | center | scale | 1000 |
 
 ### `manifesto` — text pinned low, background doing the talking
@@ -53,7 +52,6 @@ For specifications, data, a technical story. `compact` type scale suits it.
 
 | kind | layout | reveal | track |
 | --- | --- | --- | --- |
-| text | upper-third | fade | 900 |
 | text | upper-third | fade | 900 |
 | text | upper-third | fade | 900 |
 | text | upper-third | fade | 900 |

--- a/plugins/scrollcraft/skills/scrollcraft/references/site-spec.md
+++ b/plugins/scrollcraft/skills/scrollcraft/references/site-spec.md
@@ -52,12 +52,13 @@ spec file, not the working directory.
 | `body` | string | none | One paragraph, capped at 600px measure. |
 | `eyebrow` | string | none | Small uppercase label above the heading. |
 | `ctaLabel` | string | none | Renders a button-styled link. Needs `ctaHref` to go anywhere. |
-| `ctaHref` | string | `"#"` | Only `http://`, `https://` and in-page `#anchors` survive; anything else becomes `#`. |
+| `ctaHref` | string | `"#"` | `http(s)://`, `mailto:`, `tel:`, an in-page `#anchor`, or a local `/`, `./`, `../` path. Anything else, including `javascript:` and protocol-relative `//host`, becomes `#`. |
 | `scrollHeight` | number | `1000` | Scroll track in px this section occupies. Drives pacing. |
+| `scrim` | number | `0` | 0-1. Darkens a radial patch behind the copy so text stays readable over a busy frame. `theme.scrim` sets it for every section; this overrides per section. |
 | `align` | string | from `layout` | Flex `align-items` on the sticky wrapper. Overrides the layout. |
 | `justify` | string | from `layout` | Flex `justify-content`. Overrides the layout. |
 | `textAlign` | string | from `layout` | Text alignment inside the content block. Overrides the layout. |
-| `accentColor` | string | `#ddd6fe` eyebrow / `#7c3aed` CTA | Used for both. Note the two roles pull in opposite directions: a colour readable as text on a dark frame is usually too light behind white CTA text. Run `verify.mjs` after overriding it. |
+| `accentColor` | string | `#ede9fe` eyebrow / `#7c3aed` CTA | Used for both. Note the two roles pull in opposite directions: a colour readable as text on a dark frame is usually too light behind white CTA text. Run `verify.mjs` after overriding it. |
 | `headingColor` | string | `#ffffff` | |
 | `bodyColor` | string | `rgba(255,255,255,0.7)` | |
 | `visible` | boolean | `true` | `false` excludes the section from both the output and the scroll-track total. |

--- a/plugins/scrollcraft/skills/scrollcraft/scripts/build-site.mjs
+++ b/plugins/scrollcraft/skills/scrollcraft/scripts/build-site.mjs
@@ -61,7 +61,12 @@ function themeHead(theme) {
     if (!fams.includes(f)) fams.push(f);
   }
   if (!fams.length) return "";
-  const q = fams.map((f) => `family=${f.replace(/ /g, "+")}:wght@400;600;800`).join("&");
+  // Ask for the weight the theme declares, not a fixed 400/600/800. displayWeight is
+  // free between 100 and 900, and a face that does not serve the requested weight is
+  // matched to a neighbour: Space Grotesk stops at 600, so tide's 700 display rendered
+  // at 600, while Fraunces and Playfair Display jumped 700 up to 800.
+  const weights = [...new Set([400, 600, Number(theme.displayWeight) || 800])].sort((a, b) => a - b);
+  const q = fams.map((f) => `family=${f.replace(/ /g, "+")}:wght@${weights.join(";")}`).join("&");
   return [
     '<link rel="preconnect" href="https://fonts.googleapis.com" />',
     '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />',
@@ -109,9 +114,12 @@ function safeCss(s) {
   return String(s ?? "").replace(/[<>"'\\;{}]/g, "");
 }
 
+// An allowlist, matching the app's exporter: a scheme that executes never reaches the
+// page, and // is excluded because it leaves the origin rather than naming a local path.
 function safeHref(s) {
-  const href = String(s ?? "");
-  return /^https?:\/\//i.test(href) || href.startsWith("#") ? href : "#";
+  const href = String(s ?? "").trim();
+  if (href.startsWith("//")) return "#";
+  return /^(?:https?:\/\/|mailto:|tel:|#|\/|\.{1,2}\/)/i.test(href) ? href : "#";
 }
 
 function safeCssBlock(s) {

--- a/src/__tests__/exportProcedural.test.ts
+++ b/src/__tests__/exportProcedural.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { NextRequest } from "next/server";
+import { proceduralRuntimeSource } from "@/lib/generate2DFrames";
 
 const rateLimitMock = vi.hoisted(() => vi.fn());
 
@@ -29,6 +30,46 @@ async function proceduralHtml(over: Record<string, unknown> = {}): Promise<strin
   }));
   expect(res.status).toBe(200);
   return (await res.json()).html as string;
+}
+
+
+/**
+ * The runtime the page inlines, taken from the generator rather than sliced back out of
+ * the HTML. Slicing meant naming the functions, and a production build renames all of
+ * them: pinning "function hexToRgb" and "drawFrame2D" is exactly what let a black-screen
+ * export ship, because unminified those names are correct and in a real build neither
+ * string is in the page at all.
+ */
+function runtime(): { source: string; entry: string } {
+  return proceduralRuntimeSource();
+}
+
+/** The name the emitted page calls the runtime by. */
+function calledEntry(html: string): string {
+  const call = /([A-Za-z_$][\w$]*)\(ctx, cssW, cssH, p, recipe\)/.exec(html);
+  expect(call, "no procedural draw call in the page").not.toBeNull();
+  return call![1];
+}
+
+/** Every name the emitted block binds, so a call can be checked against them. */
+function declaredNames(source: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of source.matchAll(/\bfunction\s+([A-Za-z_$][\w$]*)\s*\(/g)) out.add(m[1]);
+  for (const m of source.matchAll(/\bvar\s+([A-Za-z_$][\w$]*)\s*=/g)) out.add(m[1]);
+  return out;
+}
+
+/** A 2D context that records what was drawn on it. */
+function recordingContext(calls: string[]) {
+  return new Proxy({} as Record<string, unknown>, {
+    get: (_t, prop: string) => {
+      if (prop === "createLinearGradient" || prop === "createRadialGradient") {
+        return () => ({ addColorStop: () => {} });
+      }
+      return (...args: unknown[]) => { calls.push(`${prop}(${args.length})`); };
+    },
+    set: () => true,
+  });
 }
 
 beforeEach(async () => {
@@ -116,22 +157,11 @@ describe("the inlined runtime is executable", () => {
     expect(recipe.style).toBe("gradient");
     expect(recipe.colors, "the colours array is not what drawFrame2D reads").toBeUndefined();
 
-    const start = html.indexOf("function hexToRgb");
-    const end = html.indexOf("var recipe =");
-    const runtime = html.slice(start, end);
-
+    const { source, entry } = runtime();
+    expect(html, "the page does not inline the runtime it is meant to").toContain(source);
     const calls: string[] = [];
-    const stub = new Proxy({} as Record<string, unknown>, {
-      get: (_t, prop: string) => {
-        if (prop === "createLinearGradient" || prop === "createRadialGradient") {
-          return () => ({ addColorStop: () => {} });
-        }
-        return (...args: unknown[]) => { calls.push(`${prop}(${args.length})`); };
-      },
-      set: () => true,
-    });
-
-    const run = new Function(`${runtime}; return drawFrame2D;`)() as (
+    const stub = recordingContext(calls);
+    const run = new Function(`${source}; return ${entry};`)() as (
       ctx: unknown, w: number, h: number, p: number, opts: unknown
     ) => void;
 
@@ -145,24 +175,11 @@ describe("the inlined runtime is executable", () => {
     // Pull the serialised functions out of the page and run them against a recording
     // stub, so a broken inline (bad syntax, a missing helper) fails here rather than
     // silently shipping a blank background.
-    const start = html.indexOf("function hexToRgb");
-    const end = html.indexOf("var recipe =");
-    expect(start).toBeGreaterThan(-1);
-    expect(end).toBeGreaterThan(start);
-    const runtime = html.slice(start, end);
-
+    const { source, entry } = runtime();
+    expect(html).toContain(source);
     const calls: string[] = [];
-    const stub = new Proxy({} as Record<string, unknown>, {
-      get: (_t, prop: string) => {
-        if (prop === "createLinearGradient" || prop === "createRadialGradient") {
-          return () => ({ addColorStop: () => {} });
-        }
-        return (...args: unknown[]) => { calls.push(`${prop}(${args.length})`); };
-      },
-      set: () => true,
-    });
-
-    const run = new Function(`${runtime}; return drawFrame2D;`)() as (
+    const stub = recordingContext(calls);
+    const run = new Function(`${source}; return ${entry};`)() as (
       ctx: unknown, w: number, h: number, p: number, opts: unknown
     ) => void;
 
@@ -173,5 +190,40 @@ describe("the inlined runtime is executable", () => {
       });
       expect(calls.length).toBeGreaterThan(0);
     }
+  });
+
+  it("calls a name the page declares, which a minified build renames", async () => {
+    // The whole failure in one assertion. proceduralRuntimeSource emits fn.toString(),
+    // so a production build ships the seven drawing functions as rJ, rK, rz and so on
+    // while the caller wrote drawFrame2D by hand. Measured in Chrome against a
+    // production build: "Uncaught ReferenceError: drawFrame2D is not defined" and a
+    // black canvas on every procedural export.
+    const html = await proceduralHtml();
+    const { source, entry } = runtime();
+    expect(calledEntry(html), "the call site does not match the runtime it is calling").toBe(entry);
+    expect(declaredNames(source), `${entry} is not declared in the runtime`).toContain(entry);
+  });
+
+  it("survives having every declared name rewritten", async () => {
+    // Unminified the emitted name and the source name agree, so nothing above can fail
+    // on a build Vitest sees. Renaming every declaration reproduces what the minifier
+    // does, and a hand-written call site cannot survive it.
+    const { source, entry } = runtime();
+    let mangledSource = source;
+    let mangledEntry = entry;
+    [...declaredNames(source)].forEach((name, i) => {
+      mangledSource = mangledSource.replace(new RegExp(`\\b${name}\\b`, "g"), `m${i}`);
+      if (mangledEntry === name) mangledEntry = `m${i}`;
+    });
+    expect(mangledEntry, "nothing was renamed, so this proves nothing").not.toBe(entry);
+
+    const calls: string[] = [];
+    const run = new Function(`${mangledSource}; return ${mangledEntry};`)() as (
+      ctx: unknown, w: number, h: number, p: number, opts: unknown
+    ) => void;
+    run(recordingContext(calls), 1280, 720, 0.5, {
+      style: "gradient", color1: "#111111", color2: "#222222", color3: "#333333", frameCount: 240,
+    });
+    expect(calls.length).toBeGreaterThan(0);
   });
 });

--- a/src/__tests__/exportQuality.test.ts
+++ b/src/__tests__/exportQuality.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { NextRequest } from "next/server";
 import { TEMPLATES } from "@/lib/templates";
 import { MAX_SECTIONS } from "@/lib/siteSchema";
+import { readFileSync } from "node:fs";
 import { faviconSvg, notFoundHtml, exportReadme } from "@/lib/exportAssets";
 
 /**
@@ -180,6 +181,30 @@ describe("the ZIP ships what a site needs to go online", () => {
     expect(svg).toContain("<svg");
     expect(svg).toContain("#7c3aed");
     expect(svg).toContain(">O<");
+  });
+
+  it("takes a whole character for the favicon glyph", () => {
+    // siteName[0] is half a surrogate pair for a name that opens with an emoji: not a
+    // character, and written into the SVG it rendered as the replacement glyph. Read
+    // the <text> rather than the whole file, since the name is also in the aria-label.
+    const glyph = (name: string) => {
+      const m = /<text[^>]*>([\s\S]*?)<\/text>/.exec(faviconSvg("#7c3aed", "#05070c", name));
+      expect(m, "the favicon has no text glyph").not.toBeNull();
+      return m![1];
+    };
+    expect(glyph("🚀 Rocket")).toBe("🚀");
+    expect(glyph("OrbitCRM")).toBe("O");
+    expect(glyph("   ")).toBe("•");
+  });
+
+  it("gives both frame folders the long-cache headers", () => {
+    // Mobile frames ship in frames-mobile/, which neither host config covered, so a
+    // phone re-downloaded every frame on every visit — the frames it does not share
+    // with desktop are exactly the ones it needs cached.
+    const editor = readFileSync("src/app/editor/page.tsx", "utf8");
+    for (const rule of ['for = "/frames/*"', 'for = "/frames-mobile/*"', 'source: "/frames/(.*)"', 'source: "/frames-mobile/(.*)"']) {
+      expect(editor, `${rule} is missing`).toContain(rule);
+    }
   });
 
   it("escapes a hostile site name in the favicon", () => {

--- a/src/__tests__/exportSectionParity.test.ts
+++ b/src/__tests__/exportSectionParity.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { NextRequest } from "next/server";
+import { readFileSync } from "node:fs";
 import { SECTION_LAYOUTS } from "@/lib/siteSchema";
+import { layoutStyle } from "@/lib/layoutStyles";
+import { TEMPLATES } from "@/lib/templates";
 
 const rateLimitMock = vi.hoisted(() => vi.fn());
 
@@ -17,13 +20,15 @@ function exportRequest(body: Record<string, unknown>): NextRequest {
   }) as unknown as NextRequest;
 }
 
-async function exportHtml(sections: unknown[]): Promise<string> {
-  const res = await POST(exportRequest({ sections, siteName: "Parity", frameCount: 10, fps: 24 }));
+async function exportHtml(sections: unknown[], over: Record<string, unknown> = {}): Promise<string> {
+  const res = await POST(exportRequest({ sections, siteName: "Parity", frameCount: 10, fps: 24, ...over }));
   expect(res.status).toBe(200);
   const json = await res.json();
   expect(typeof json.html).toBe("string");
   return json.html as string;
 }
+
+const EDITOR_SRC = readFileSync("src/app/editor/page.tsx", "utf8");
 
 beforeEach(async () => {
   vi.clearAllMocks();
@@ -288,5 +293,87 @@ describe("exported site description", () => {
     const html = await exportWith({ siteDescription: "x".repeat(500) });
     const match = html.match(/<meta name="description" content="(x+)"/);
     expect(match?.[1].length).toBe(300);
+  });
+});
+
+describe("the editor hands the exporter what the template asked for", () => {
+  const TEMPLATE = TEMPLATES.find((t) => t.sections.some((s) => s.layout && s.layout !== "center"))!;
+
+  it("sends the theme, without which the page ships as the untouched default", async () => {
+    // handleExport never included themeJson, so the route fell back to "" on every
+    // export: no Google Fonts link and none of the --sc- custom properties. Measured
+    // against a production build, an OrbitCRM export carried 0 font links and 3 vars
+    // where the template's own theme gives 3 and 11.
+    expect(EDITOR_SRC).toContain("themeJson: siteTheme ? JSON.stringify(siteTheme) : undefined,");
+
+    const withTheme = await exportHtml(TEMPLATE.sections, { themeJson: JSON.stringify(TEMPLATE.theme) });
+    for (const token of ["fonts.googleapis.com", "--sc-ink:", "--sc-muted:", "--sc-accent:", "--sc-font-display:"]) {
+      expect(withTheme, `${token} is missing`).toContain(token);
+    }
+    const without = await exportHtml(TEMPLATE.sections);
+    expect(without).not.toContain("fonts.googleapis.com");
+  });
+
+  it("does not stamp its blank-section defaults over a template's layout", () => {
+    // defaultSection supplies centre for textAlign, align and justify, which is right
+    // for a new empty section. toEditorSections spread it over template sections that
+    // carry none of the three, and both the renderer and the exporter read
+    // `s.align ?? L.align` — so the stamp won and every left, right and lower-third
+    // composition in the catalogue exported dead centre.
+    const fn = EDITOR_SRC.slice(EDITOR_SRC.indexOf("function toEditorSections"), EDITOR_SRC.indexOf("function EditorInner"));
+    expect(fn).toContain("const L = layoutStyle(s.layout);");
+    for (const line of ["textAlign: s.textAlign ?? L.textAlign,", "align: s.align ?? L.align,", "justify: s.justify ?? L.justify,"]) {
+      expect(fn, `${line} is missing`).toContain(line);
+    }
+    // From the exporter's own table, not a second copy of the placement rules.
+    expect(layoutStyle("lower-third")).toMatchObject({ align: "flex-end", justify: "flex-start", textAlign: "left" });
+  });
+
+  it("keeps a template's mix of placements once those defaults are resolved", async () => {
+    const resolved = TEMPLATE.sections.map((sec) => {
+      const L = layoutStyle(sec.layout);
+      return { ...sec, textAlign: sec.textAlign ?? L.textAlign, align: sec.align ?? L.align, justify: sec.justify ?? L.justify };
+    });
+    const html = await exportHtml(resolved);
+    const placements = new Set(
+      [...html.matchAll(/align-items:([a-z-]+); justify-content:([a-z-]+)/g)].map((m) => `${m[1]}/${m[2]}`)
+    );
+    expect(placements.size, "every section exported to the same placement").toBeGreaterThan(1);
+  });
+});
+
+describe("exported CTA links go where they say", () => {
+  const cta = async (href: string) => {
+    const html = await exportHtml([{ heading: "H", ctaLabel: "Go", ctaHref: href, scrollHeight: 1000 }]);
+    return /<a href="([^"]*)"[^>]*>Go<\/a>/.exec(html)?.[1];
+  };
+
+  it("keeps every form the CTA field accepts", async () => {
+    // ctaHrefSchema allows all of these and the editor's link field takes them, but the
+    // exporter allowed only http(s), so each shipped as a dead href="#" — an in-page
+    // anchor included.
+    for (const href of ["https://example.com", "mailto:a@b.com", "tel:+123456", "#pricing", "/pricing", "./docs", "../up"]) {
+      expect(await cta(href), `${href} was rewritten`).toBe(href);
+    }
+  });
+
+  it("still refuses anything that executes or leaves the origin unasked", async () => {
+    // The allowlist exists because of the XSS escaping pass; loosening it must not
+    // reopen it. // is excluded as well: it satisfies the schema's leading slash but
+    // jumps to another origin.
+    for (const href of ["javascript:alert(1)", "JaVaScRiPt:alert(1)", "  javascript:alert(1)", "data:text/html,x", "vbscript:x", "//evil.com"]) {
+      expect(await cta(href), `${href} survived`).toBe("#");
+    }
+  });
+});
+
+describe("exported reveals behave like the preview's", () => {
+  it("reveals a section once instead of replaying it on every pass", async () => {
+    // SiteRenderer only ever adds its visible class. The exported observer also removed
+    // it on exit, so each section faded back to nothing and re-animated every time the
+    // visitor scrolled past — a different page from the one they approved.
+    const html = await exportHtml([{ heading: "A", reveal: "rise", scrollHeight: 1000 }]);
+    expect(html).not.toContain("classList.remove('visible')");
+    expect(html).toContain("rootMargin: '0px 0px -8% 0px'");
   });
 });

--- a/src/__tests__/skillScaffold.test.ts
+++ b/src/__tests__/skillScaffold.test.ts
@@ -208,3 +208,89 @@ describe("skill build-site section images", () => {
     expect(html()).not.toContain("<script>alert(1)</script>");
   });
 });
+
+/**
+ * The skill's reference docs are the contract a reader follows. Each check below pins a
+ * place where they described something the scripts do not do.
+ */
+describe("the skill's docs describe the skill that exists", () => {
+  const root = "plugins/scrollcraft/skills/scrollcraft";
+  const initSrc = fs.readFileSync(`${root}/scripts/init.mjs`, "utf8");
+  const grammars = fs.readFileSync(`${root}/references/grammars.md`, "utf8");
+  const siteSpec = fs.readFileSync(`${root}/references/site-spec.md`, "utf8");
+
+  /** Rows in a markdown table under a `### name` heading, header excluded. */
+  function docRows(doc: string, name: string): number {
+    const section = new RegExp(`###\\s+\`?${name}\`?([\\s\\S]*?)(?=\\n###|$)`, "i").exec(doc);
+    expect(section, `grammars.md has no section for ${name}`).not.toBeNull();
+    const rows = section![1]
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.startsWith("|") && !/^\|[\s:-]+\|/.test(l));
+    return rows.length - 1;
+  }
+
+  function codeRows(name: string): number {
+    const all = /const GRAMMARS\s*=\s*\{([\s\S]*?)\n\};/.exec(initSrc);
+    expect(all, "init.mjs has no GRAMMARS table").not.toBeNull();
+    const one = new RegExp(`${name}:\\s*\\[([\\s\\S]*?)\\n\\s*\\]`).exec(all![1]);
+    expect(one, `init.mjs has no ${name} grammar`).not.toBeNull();
+    return (one![1].match(/\{/g) ?? []).length;
+  }
+
+  it("gives every grammar the number of sections the scaffolder emits", () => {
+    // catalogue documented six slots against five in the code, and dossier five against
+    // four, so a reader planning copy wrote a section that never appeared.
+    const names = [...(/const GRAMMARS\s*=\s*\{([\s\S]*?)\n\};/.exec(initSrc)![1].matchAll(/^\s{2}(\w+):\s*\[/gm))].map((m) => m[1]);
+    expect(names.length).toBeGreaterThan(3);
+    for (const name of names) {
+      expect(docRows(grammars, name), `${name}: grammars.md and init.mjs disagree`).toBe(codeRows(name));
+    }
+  });
+
+  it("documents every section field the schema carries", () => {
+    // scrim was missing outright: a real, tested feature with no entry at all.
+    const schema = fs.readFileSync("src/lib/siteSchema.ts", "utf8");
+    const block = /export const sectionSchema = object\(\{([\s\S]*?)\}\)/.exec(schema);
+    expect(block, "sectionSchema moved").not.toBeNull();
+    const fields = [...block![1].matchAll(/^\s{2}(\w+):/gm)].map((m) => m[1]).filter((f) => f !== "id");
+    expect(fields.length).toBeGreaterThan(10);
+    for (const field of fields) {
+      expect(siteSpec, `site-spec.md does not document \`${field}\``).toContain(`\`${field}\``);
+    }
+  });
+
+  it("quotes the eyebrow default the builder actually uses", () => {
+    const builder = fs.readFileSync(`${root}/scripts/build-site.mjs`, "utf8");
+    const fallback = /--sc-accent-text,\s*(#[0-9a-f]{6})/i.exec(builder);
+    expect(fallback, "the eyebrow fallback moved").not.toBeNull();
+    expect(siteSpec, "site-spec.md quotes a colour the builder never emits").toContain(fallback![1]);
+  });
+
+  it("points the README at scripts that exist", () => {
+    // Every command said `node scripts/<name>.mjs`, and there is no scripts/ directory
+    // at the repo root, so each one died with "Cannot find module".
+    const readme = fs.readFileSync("README.md", "utf8");
+    const paths = [...readme.matchAll(/node ([\w./-]+\.mjs)/g)].map((m) => m[1]);
+    expect(paths.length).toBeGreaterThan(3);
+    for (const rel of new Set(paths)) {
+      expect(fs.existsSync(rel), `README runs ${rel}, which does not exist`).toBe(true);
+    }
+  });
+
+  it("asks Google Fonts for the weight the theme declares", () => {
+    // The URL hardcoded 400;600;800 while displayWeight is free between 100 and 900.
+    // Space Grotesk serves no 800, so tide's 700 display resolved down to 600.
+    const builder = fs.readFileSync(`${root}/scripts/build-site.mjs`, "utf8");
+    expect(builder).not.toContain(":wght@400;600;800");
+    expect(builder).toContain("Number(theme.displayWeight)");
+  });
+
+  it("does not repaint frame 0 when the other frame set arrives", () => {
+    // export-contract.md promises crossing the breakpoint "does not snap the background
+    // back to frame 0"; the runtime did exactly that on every preload.
+    const runtime = fs.readFileSync(`${root}/engine/scrollcraft.runtime.js`, "utf8");
+    expect(runtime).not.toContain("isPrimary");
+    expect(runtime).toContain("if (i === currentFrame) drawFrame(i);");
+  });
+});

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -46,9 +46,16 @@ function safeCss(s: unknown): string {
   return String(s ?? "").replace(/[<>"'\\;{}]/g, "");
 }
 
+/**
+ * The CTA target, allowing what ctaHrefSchema allows and nothing else.
+ *
+ * An allowlist, so javascript:, data: and anything unlisted become "#". `//host` is
+ * excluded as well: it satisfies the schema's leading slash but leaves the origin.
+ */
 function safeHref(s: unknown): string {
-  const href = String(s ?? "");
-  return /^https?:\/\//i.test(href) ? href : "#";
+  const href = String(s ?? "").trim();
+  if (href.startsWith("//")) return "#";
+  return /^(?:https?:\/\/|mailto:|tel:|#|\/|\.{1,2}\/)/i.test(href) ? href : "#";
 }
 
 export async function POST(req: NextRequest) {
@@ -128,6 +135,7 @@ export async function POST(req: NextRequest) {
     // How many steps the procedural background is sampled over. Not files on disk, so
     // this costs nothing but smoothness.
     const PROCEDURAL_FRAMES = 240;
+    const proceduralRuntime = proceduralRuntimeSource();
     if (styleSpec) {
       if (frameCount !== undefined && frameCount !== 0 && !Number.isInteger(frameCount)) {
         return NextResponse.json({ error: "frameCount must be an integer" }, { status: 400 });
@@ -378,7 +386,7 @@ export async function POST(req: NextRequest) {
       ${styleSpec ? `
       // Procedural background: the ZIP ships no frames at all, the page draws each one
       // on demand at the viewport's own resolution.
-      ${proceduralRuntimeSource()}
+      ${proceduralRuntime.source}
 
       // drawFrame2D takes FrameOptions (color1/color2/color3) while a stored style
       // recipe holds a colours array. Emitting the recipe verbatim left every colour
@@ -394,7 +402,7 @@ export async function POST(req: NextRequest) {
       function drawFrame(index) {
         var cssW = window.innerWidth, cssH = window.innerHeight;
         var p = frameCount > 1 ? index / (frameCount - 1) : 0;
-        drawFrame2D(ctx, cssW, cssH, p, recipe);
+        ${proceduralRuntime.entry}(ctx, cssW, cssH, p, recipe);
       }
       ` : `
       function drawFrame(index) {
@@ -599,12 +607,13 @@ export async function POST(req: NextRequest) {
     (function() {
       // Observe the section-content divs (inside sticky wrappers) for entrance animations.
       const contents = document.querySelectorAll('.section-content');
+      // Add only, and the same rootMargin SiteRenderer uses, so a section reveals once
+      // here as it does in the preview rather than replaying on every pass.
       const observer = new IntersectionObserver(function(entries) {
         entries.forEach(function(entry) {
           if (entry.isIntersecting) entry.target.classList.add('visible');
-          else entry.target.classList.remove('visible');
         });
-      }, { threshold: 0.1 });
+      }, { threshold: 0.1, rootMargin: '0px 0px -8% 0px' });
       contents.forEach(function(el) { observer.observe(el); });
     })();
   </script>

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -20,6 +20,7 @@ import { toast } from "sonner";
 import dynamic from "next/dynamic";
 import { siteStyleSchema, themeSchema, type EditorSection, type SiteStyle, type Theme } from "@/lib/siteSchema";
 import { templateBySlug, type Template } from "@/lib/templates";
+import { layoutStyle } from "@/lib/layoutStyles";
 import { faviconSvg, notFoundHtml, exportReadme, renderSocialCard } from "@/lib/exportAssets";
 import { generate2DFrames } from "@/lib/generate2DFrames";
 import { AUTOSAVE_DEBOUNCE_MS, saveStatusLabel, type SaveState } from "@/lib/saveStatus";
@@ -106,9 +107,17 @@ const defaultSection = (i: number): Section => ({
  * reactive graph and stopped the React Compiler preserving the undo/redo memoization.
  */
 function toEditorSections(t: Template, secs: Template["sections"]): Section[] {
-  return secs.map((s, i) => ({
+  return secs.map((s, i) => {
+    // A template places its copy with `layout` and sets none of the three directly.
+    // defaultSection's "center" is right for a blank section but would outrank the
+    // layout here, since both renderers read `s.align ?? L.align`.
+    const L = layoutStyle(s.layout);
+    return {
     ...defaultSection(i),
     ...s,
+    textAlign: s.textAlign ?? L.textAlign,
+    align: s.align ?? L.align,
+    justify: s.justify ?? L.justify,
     id: `section-${i}-${t.slug}`,
     heading: s.heading ?? "",
     eyebrow: s.eyebrow ?? "",
@@ -120,7 +129,8 @@ function toEditorSections(t: Template, secs: Template["sections"]): Section[] {
     bodyColor: s.bodyColor ?? t.theme.muted ?? "rgba(255,255,255,0.7)",
     scrollHeight: s.scrollHeight ?? 1000,
     visible: true,
-  }));
+    };
+  });
 }
 
 function EditorInner() {
@@ -579,6 +589,9 @@ function EditorInner() {
           customCss,
           // With a background recipe the exported page draws its own frames, so the ZIP
           // ships none — tens of megabytes of JPEGs become a few hundred bytes of JSON.
+          // Without this the route falls back to themeJson = "": no font link and none
+          // of the --sc- custom properties.
+          themeJson: siteTheme ? JSON.stringify(siteTheme) : undefined,
           styleJson: exportProcedurally ? JSON.stringify(styleSpec) : undefined,
           frameCount: exportProcedurally ? 0 : frames.length,
           mobileFrameCount: exportProcedurally ? 0 : mobileFrames.length,
@@ -625,14 +638,16 @@ function EditorInner() {
       // GitHub Pages otherwise runs the output through Jekyll, which silently drops
       // any file or folder whose name begins with an underscore.
       zip.file(".nojekyll", "");
-      zip.file("netlify.toml", '[build]\n  publish = "."\n\n[[headers]]\n  for = "/frames/*"\n  [headers.values]\n    Cache-Control = "public, max-age=31536000, immutable"\n');
+      // Both folders: the mobile set is the one a phone cannot share with desktop.
+      const IMMUTABLE = "public, max-age=31536000, immutable";
+      zip.file("netlify.toml", `[build]\n  publish = "."\n\n[[headers]]\n  for = "/frames/*"\n  [headers.values]\n    Cache-Control = "${IMMUTABLE}"\n\n[[headers]]\n  for = "/frames-mobile/*"\n  [headers.values]\n    Cache-Control = "${IMMUTABLE}"\n`);
       zip.file("vercel.json", JSON.stringify({
         $schema: "https://openapi.vercel.sh/vercel.json",
         cleanUrls: true,
-        headers: [{
-          source: "/frames/(.*)",
-          headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
-        }],
+        headers: [
+          { source: "/frames/(.*)", headers: [{ key: "Cache-Control", value: IMMUTABLE }] },
+          { source: "/frames-mobile/(.*)", headers: [{ key: "Cache-Control", value: IMMUTABLE }] },
+        ],
       }, null, 2) + "\n");
 
       const ogBlob = await renderSocialCard(siteName, siteDescription, frames[0], siteTheme?.ground ?? "#05070c", siteTheme?.ink ?? "#ffffff");

--- a/src/lib/exportAssets.ts
+++ b/src/lib/exportAssets.ts
@@ -13,9 +13,13 @@ function esc(s: string): string {
     .replace(/"/g, "&quot;").replace(/'/g, "&#x27;");
 }
 
-/** First letter of the site name, for the icon glyph. Falls back to a dot. */
+/**
+ * First character of the site name, for the icon glyph. Falls back to a dot.
+ *
+ * By code point: `"🚀 Rocket"[0]` is half a surrogate pair, not a character.
+ */
 function initial(siteName: string): string {
-  const ch = siteName.trim()[0];
+  const ch = [...siteName.trim()][0];
   return ch ? ch.toUpperCase() : "•";
 }
 

--- a/src/lib/generate2DFrames.ts
+++ b/src/lib/generate2DFrames.ts
@@ -203,17 +203,32 @@ export function drawFrame2D(
   }
 }
 
+export interface ProceduralRuntime {
+  source: string;
+  /** What the emitted source calls the entry point, which a minified build renames. */
+  entry: string;
+}
+
 /**
  * The drawing core as plain JavaScript, for inlining into an exported site.
  *
  * The export has no bundler, so the runtime has to travel as source. Serialising the
  * real functions rather than keeping a hand-written copy means the exported background
  * and the in-app one cannot drift apart — there is still only one implementation.
+ *
+ * `entry` is returned rather than left for the caller to spell, because fn.toString()
+ * carries whatever names the build produced and a minified build produces short ones.
  */
-export function proceduralRuntimeSource(): string {
-  return [hexToRgb, lerp, drawGradient, drawGeometric, drawParticles, drawWave, drawFrame2D]
-    .map((fn) => fn.toString())
+export function proceduralRuntimeSource(): ProceduralRuntime {
+  const fns = [hexToRgb, lerp, drawGradient, drawGeometric, drawParticles, drawWave, drawFrame2D];
+  const source = fns
+    .map((fn) => {
+      const src = fn.toString();
+      // A declaration binds its own name; an expression binds nothing, so name it.
+      return /^\s*(async\s+)?function\b/.test(src) ? src : `var ${fn.name} = ${src};`;
+    })
     .join("\n\n");
+  return { source, entry: drawFrame2D.name };
 }
 
 export async function generate2DFrames(opts: FrameOptions, onProgress?: (pct: number) => void): Promise<string[]> {


### PR DESCRIPTION
The ZIP is the product, and it was not what the editor showed. Eight defects in the export path plus eight in the plugin skill, each measured against a **production build served over HTTP and loaded in Chrome** — because most are invisible to the test suite, and the worst one exists only after minification.

---

## 1. Every procedural export was a black page

`proceduralRuntimeSource()` inlines the drawing core with `fn.toString()`. A production build ships the seven functions as `rJ`, `rK`, `rz` … — consistent among themselves, since they are declared together — while the caller wrote `drawFrame2D(...)` **by hand**, a name declared nowhere in the emitted script.

| | `main` | this branch |
| --- | --- | --- |
| symbol called | `drawFrame2D` | `rz` |
| declared in the page? | **no** | yes |
| page errors | `Uncaught ReferenceError: drawFrame2D is not defined` | none |
| canvas centre pixel | `BLACK rgb(0,0,0)` | `PAINTED rgb(67,65,198)` |

This is the default path for any template or style-based site: with a recipe the ZIP ships **no frames at all**, so the background is entirely this code.

The function now returns `{ source, entry }` and the route calls `entry`.

## 2. The editor never sent the theme

`handleExport` omitted `themeJson`, so the route fell back to `""` on every export.

| OrbitCRM export | `main` | this branch |
| --- | --- | --- |
| Google Fonts links | **0** | 3 |
| `--sc-` properties | 3 | **11** |

No typeface, weight, tracking, ink, muted, accent or radius — every exported site shipped as the untouched default.

## 3. Template layouts flattened to centre

Templates place copy with `layout` and set `align` / `justify` / `textAlign` **nowhere** (0 occurrences across all 21). `toEditorSections` spread `defaultSection`'s `"center"` over all three, and *both* renderers read `s.align ?? L.align` — so the stamp outranked the layout.

| OrbitCRM, exported | `main` | this branch |
| --- | --- | --- |
| placements | 4 × `center/center` | `center/center`, `center/flex-start`, `center/flex-end` |
| text alignment | 4 × `center` | 2 × `center`, 2 × `left` |

Those three fields are now seeded from `layoutStyle()` — the same table the exporter reads, not a second copy.

**Before / after, same template, same scroll position:**

`main` — the whole page:

> a solid black frame, no background, no copy

this branch:

> the violet gradient, `PIPELINE` eyebrow in Archivo, left-aligned heading and body in IBM Plex Sans

## 4. CTA links went nowhere

`safeHref` allowed only `http(s)://`, while `ctaHrefSchema` and the editor's own link field accept much more. **OrbitCRM's own "Start free trial" button exported as `href="#"` instead of `href="#signup"`.**

| ctaHref | `main` | this branch |
| --- | --- | --- |
| `mailto:` `tel:` `#anchor` `/path` `./rel` `../up` | all → `#` | preserved |
| `javascript:` `data:` `vbscript:` `//evil.com` | `#` | `#` |

Now an allowlist mirroring the schema. It **keeps** the guarantee from `e9a693c` (the XSS escaping pass, which is why the restriction existed) and adds one: protocol-relative `//host` satisfies the schema's leading slash but leaves the origin, so it is refused. The skill's own `build-site.mjs` had the same restriction and gets the same fix.

## 5. Three smaller ones

- The exported `IntersectionObserver` **removed** `visible` on exit, so every section faded out and replayed its entrance on each scroll pass. `SiteRenderer` only ever adds it. Matched, `rootMargin` included.
- `frames-mobile/` got none of the long-cache headers written for `frames/`, so a phone re-downloaded every frame on every visit.
- The favicon glyph took `siteName[0]` — half a surrogate pair for a name opening with an emoji, rendered as the replacement character. `"🚀 Rocket"` now yields `🚀`.

---

## 6. The skill's docs described a skill that does not exist

All eight verified individually against the files:

| | was | now |
| --- | --- | --- |
| README's 8 script commands | `node scripts/…` — no such directory; `Cannot find module` | full `plugins/…` paths, each verified to run |
| Node floor | 20 (README, CONTRIBUTING) | 22 + `engines` — `verify.mjs` needs the global `WebSocket`, which is `undefined` under `--no-experimental-websocket` |
| `catalogue` / `dossier` grammars | 6 and 5 documented rows | 5 and 4, matching `init.mjs` |
| `scrim` | undocumented | documented |
| eyebrow default | `#ddd6fe` | `#ede9fe`, the value `build-site.mjs` emits |
| Google Fonts URL | hardcoded `wght@400;600;800` | built from `displayWeight` |
| runtime frame 0 | repainted on every preload | removed |

On the fonts one I queried the API per family rather than reasoning about it: **Space Grotesk serves only 400 and 600**, so `tide`'s `displayWeight: 700` resolved *down* to 600; Fraunces and Playfair Display serve 400/600/800, so `nebula` and `dusk` jumped 700 up to 800. Three of six built-in themes rendered their display face at a weight they did not ask for.

*Measured after merge, since the resolution step above was originally taken from the CSS Fonts L4 matching rule rather than run.* Rendered width of the same string at 100px in Chrome, with the old `wght@400;600;800` request:

| weight | Fraunces | Space Grotesk |
| --- | --- | --- |
| 400 | 554.92 | 561.02 |
| 600 | 573.09 | 562.14 |
| **700** | **600.38** | **562.14** |
| 800 | 600.38 | 562.14 |

Fraunces' 700 is pixel-identical to its 800; Space Grotesk's 700 is pixel-identical to its 600. Both halves of the claim hold.

The frame-0 repaint contradicted `export-contract.md`, which promises crossing the breakpoint "does not snap the background back to frame 0" — it did, on every preload. `isPrimary` was `true` at all four call sites, so it goes with the line.

## Tests

**Folded into the three existing export suites and the skill suite** rather than added as a new file.

The procedural pair is **rewritten, not extended**. It pinned `"function hexToRgb"` and `drawFrame2D` — which is precisely why it passed while production shipped a black page. It now takes the runtime from the generator and adds a **mangling pass**: rename every declaration consistently, then check the entry still binds. Run against `main`'s code that reproduces the real failure:

```
AssertionError: expected [Function] to not throw
  'ReferenceError: drawFrame2D is not defined'
```

| | before | after |
| --- | --- | --- |
| suite | 306 passed | **322 passed** |
| wall clock | 11.04s | 11.18s |

16 of the new assertions fail on `main`.

## Not fixed here

`verify.mjs` measures contrast against the **text node's own** `backgroundColor` and cannot see the scrim behind it, so it under-reports on any page that sets one and can hard-fail a page its own screenshots show as readable. Fixing it means sampling a screenshot instead of computed styles — a rework of the checker, and it does not belong in this diff.
