### PR TITLE
Close out the audit's remaining findings

### DIFF
--- a/src/__tests__/appAccessibility.test.ts
+++ b/src/__tests__/appAccessibility.test.ts
@@ -274,6 +274,34 @@ describe("Enter belongs to the control that has focus", () => {
   });
 });
 
+describe("controls that open something say whether it is open", () => {
+  /**
+   * Both are disclosure widgets rendered as plain buttons: the state was visible only
+   * as a rotating "+" or a swapped icon, so a screen reader was told a button existed
+   * and nothing about what it did. Verified in Chrome on both builds - before, neither
+   * carried aria-expanded at all; after, both toggle it and their aria-controls
+   * resolves to the element that appears.
+   */
+  it("tells assistive tech whether the mobile menu is open", () => {
+    const navbar = readFileSync("src/components/Navbar.tsx", "utf8");
+    expect(navbar).toContain("aria-expanded={open}");
+    expect(navbar).toContain('aria-controls="mobile-menu"');
+    // aria-controls pointing at nothing is worse than omitting it.
+    expect(navbar).toContain('id="mobile-menu"');
+  });
+
+  it("wires each FAQ row to the answer it reveals", () => {
+    const home = readFileSync("src/app/HomeClient.tsx", "utf8");
+    expect(home).toContain("aria-expanded={openFaq === i}");
+    expect(home).toContain("aria-controls={`faq-answer-${i}`}");
+    expect(home).toContain("id={`faq-question-${i}`}");
+    expect(home).toContain('role="region"');
+    expect(home).toContain("aria-labelledby={`faq-question-${i}`}");
+    // The "+" is decoration; the state is on the button.
+    expect(home).toMatch(/<span aria-hidden="true" className=\{`text-muted-foreground text-lg/);
+  });
+});
+
 describe("analytics does not break a self-hosted deploy", () => {
   it("only mounts the Vercel script when Vercel is serving", () => {
     // Mounted unconditionally the insights script 404s and trips strict MIME checking,

--- a/src/__tests__/contactDetails.test.ts
+++ b/src/__tests__/contactDetails.test.ts
@@ -184,6 +184,16 @@ describe("what the site claims about itself is true", () => {
     );
   });
 
+  it("describes the rate limiting it actually applies", () => {
+    // One of three API routes is rate-limited; the privacy page promised two.
+    const privacy = readFileSync("src/app/privacy/page.tsx", "utf8");
+    expect(privacy).not.toContain("rate-limit the two API routes");
+    const limited = readdirSync("src/app/api", { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .filter((d) => readFileSync(join("src/app/api", d.name, "route.ts"), "utf8").includes("rateLimit("));
+    expect(limited.map((d) => d.name)).toEqual(["export-site"]);
+  });
+
   it("keeps the legal pages dated to when they were last rewritten", () => {
     // They described the August teardown while dated June, which reads as unmaintained.
     for (const file of ["src/app/terms/page.tsx", "src/app/cookies/page.tsx", "src/app/privacy/page.tsx"]) {

--- a/src/__tests__/exportQuality.test.ts
+++ b/src/__tests__/exportQuality.test.ts
@@ -106,6 +106,22 @@ describe("the export route validates the shape of what it is given", () => {
   });
 });
 
+describe("the request body is capped while it is read, not after", () => {
+  it("stops reading instead of buffering the whole stream", () => {
+    // The Content-Length check is only as honest as the sender. Omit the header, send
+    // chunked, and req.text() held the entire stream in memory before anything looked
+    // at its size. Measured with a 120 MB chunked body and no Content-Length: the
+    // previous build accepted all 120,021,432 bytes before answering 413; this one
+    // stops at ~12.8 MB, one chunk past the cap.
+    const route = readFileSync("src/app/api/export-site/route.ts", "utf8");
+    expect(route).toContain("await readCapped(req, MAX_BODY)");
+    expect(route).not.toMatch(/const raw = await req\.text\(\);/);
+    // The cap has to be enforced inside the read loop, not after it.
+    const helper = route.slice(route.indexOf("async function readCapped"));
+    expect(helper.slice(0, helper.indexOf("\n}"))).toContain("if (seen > limit) return null;");
+  });
+});
+
 describe("the exported page has a real document outline", () => {
   it("gives the page exactly one h1", async () => {
     const html = await exportHtml();

--- a/src/__tests__/exportSectionParity.test.ts
+++ b/src/__tests__/exportSectionParity.test.ts
@@ -377,3 +377,20 @@ describe("exported reveals behave like the preview's", () => {
     expect(html).toContain("rootMargin: '0px 0px -8% 0px'");
   });
 });
+
+describe("the exported CTA uses the theme's corner radius", () => {
+  it("takes the radius from the theme, as the preview already does", async () => {
+    // The preview renders borderRadius: var(--sc-radius, 8px); the export hardcoded
+    // 0.5rem, which is 8px, so only the two templates that ask for 8 were right.
+    // Nineteen of twenty-one ask for something else, three of them for square corners.
+    const html = await exportHtml(
+      [{ heading: "H", ctaLabel: "Go", ctaHref: "https://x.com", scrollHeight: 1000 }],
+      { themeJson: JSON.stringify({ radius: 20 }) }
+    );
+    const cta = /<a href="https:\/\/x\.com"[^>]*style="([^"]*)"/.exec(html);
+    expect(cta, "no CTA anchor was emitted").toBeTruthy();
+    expect(cta![1]).toContain("border-radius:var(--sc-radius, 8px)");
+    expect(cta![1]).not.toContain("border-radius:0.5rem");
+    expect(html).toContain("--sc-radius:20px");
+  });
+});

--- a/src/__tests__/videoExtraction.test.ts
+++ b/src/__tests__/videoExtraction.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * Sampling stops at MAX_DURATION_SECONDS, and used to stop silently.
+ *
+ * The extractor returned one number called `duration` — documented as "source duration"
+ * but actually the capped value — and the caller destructured only `frames` and
+ * `frameCount`, so nothing anywhere knew the clip had been cut. A user uploaded five
+ * minutes of footage, got the first two, and was told nothing.
+ *
+ * Verified in Chrome with real clips rendered by ffmpeg: a 150s clip warns on this
+ * build and did not on the previous one; an 8s clip warns on neither.
+ */
+const EXTRACTOR = readFileSync("src/lib/extractFramesInBrowser.ts", "utf8");
+const CREATE = readFileSync("src/app/create/page.tsx", "utf8");
+
+describe("a truncated video says so", () => {
+  it("reports the clip's own length alongside what was sampled", () => {
+    expect(EXTRACTOR).toContain("sourceDuration: number;");
+    expect(EXTRACTOR).toContain("sourceDuration: video.duration");
+    // `duration` is the capped value; the two must not be conflated again.
+    expect(EXTRACTOR).toContain("const duration = Math.min(video.duration, MAX_DURATION_SECONDS);");
+  });
+
+  it("still has a cap to report against", () => {
+    const cap = /const MAX_DURATION_SECONDS = (\d+);/.exec(EXTRACTOR);
+    expect(cap, "the cap is gone, so this suite tests nothing").toBeTruthy();
+    expect(Number(cap![1])).toBeGreaterThan(0);
+  });
+
+  it("warns the uploader, and only when something was actually cut", () => {
+    expect(CREATE).toContain("const { frames, frameCount: count, duration, sourceDuration }");
+    // The tolerance matters: video.duration is a float, so an exact inequality would
+    // fire on clips that were not truncated at all.
+    expect(CREATE).toContain("if (sourceDuration > duration + 0.5)");
+    expect(CREATE).toMatch(/Used the first \$\{Math\.round\(duration\)\}s of your \$\{Math\.round\(sourceDuration\)\}s clip/);
+  });
+});

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -350,12 +350,20 @@ export default function HomeClient({ presetCount, featured }: { presetCount: num
                 <button
                   onClick={() => setOpenFaq(openFaq === i ? null : i)}
                   className="w-full text-left px-5 py-4 flex items-center justify-between gap-4 hover:bg-white/3 transition-colors"
+                  aria-expanded={openFaq === i}
+                  aria-controls={`faq-answer-${i}`}
+                  id={`faq-question-${i}`}
                 >
                   <span className="font-medium text-sm">{item.q}</span>
-                  <span className={`text-muted-foreground text-lg leading-none transition-transform flex-shrink-0 ${openFaq === i ? "rotate-45" : ""}`}>+</span>
+                  <span aria-hidden="true" className={`text-muted-foreground text-lg leading-none transition-transform flex-shrink-0 ${openFaq === i ? "rotate-45" : ""}`}>+</span>
                 </button>
                 {openFaq === i && (
-                  <div className="px-5 pb-4 text-sm text-muted-foreground leading-relaxed border-t border-white/5 pt-3">
+                  <div
+                    id={`faq-answer-${i}`}
+                    role="region"
+                    aria-labelledby={`faq-question-${i}`}
+                    className="px-5 pb-4 text-sm text-muted-foreground leading-relaxed border-t border-white/5 pt-3"
+                  >
                     {item.a}
                   </div>
                 )}

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -52,6 +52,28 @@ function safeCss(s: unknown): string {
  * An allowlist, so javascript:, data: and anything unlisted become "#". `//host` is
  * excluded as well: it satisfies the schema's leading slash but leaves the origin.
  */
+/** The body, or null once it exceeds `limit` — at which point reading stops. */
+async function readCapped(req: NextRequest, limit: number): Promise<string | null> {
+  const body = req.body;
+  if (!body) return "";
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  let seen = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      seen += value.byteLength;
+      if (seen > limit) return null;
+      out += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return out + decoder.decode();
+}
+
 function safeHref(s: unknown): string {
   const href = String(s ?? "").trim();
   if (href.startsWith("//")) return "#";
@@ -75,8 +97,12 @@ export async function POST(req: NextRequest) {
     if (Number.isFinite(declaredLen) && declaredLen > MAX_BODY) {
       return NextResponse.json({ error: "Request body too large." }, { status: 413 });
     }
-    const raw = await req.text();
-    if (raw.length > MAX_BODY) {
+    // Read with a running cap rather than buffering first and measuring after. The
+    // header check above is only as honest as the sender: omit Content-Length, send
+    // chunked, and req.text() would hold the whole stream in memory before anyone
+    // looked at its size.
+    const raw = await readCapped(req, MAX_BODY);
+    if (raw === null) {
       return NextResponse.json({ error: "Request body too large." }, { status: 413 });
     }
     let body;
@@ -246,7 +272,7 @@ export async function POST(req: NextRequest) {
             ? `<${hTag} class="sc-display sc-statement" style="color:${safeCss(s.headingColor || "var(--sc-ink, #ffffff)")}; margin-bottom:1rem;">${esc(s.heading)}</${hTag}>`
             : `<${hTag} class="sc-display" style="font-size:var(--sc-heading-size, clamp(2rem,5vw,4rem)); font-weight:var(--sc-display-weight, 900); line-height:1; letter-spacing:var(--sc-display-tracking, -0.03em); text-transform:var(--sc-display-case, none); color:${safeCss(s.headingColor || "var(--sc-ink, #ffffff)")}; margin-bottom:1rem;">${esc(s.heading)}</${hTag}>`) : ""}
           ${s.body ? `<p style="font-size:var(--sc-body-size, 1.125rem); line-height:1.7; color:${safeCss(s.bodyColor || "var(--sc-muted, rgba(255,255,255,0.72))")}; max-width:var(--sc-measure, 600px); margin:${stack};">${esc(s.body)}</p>` : ""}
-          ${s.ctaLabel ? `<a href="${esc(safeHref(s.ctaHref || "#"))}" style="display:inline-block; background:${safeCss(s.accentColor || "var(--sc-accent, #7c3aed)")}; color:white; padding:0.875rem 2rem; border-radius:0.5rem; font-weight:600; text-decoration:none; font-size:1rem;">${esc(s.ctaLabel)}</a>` : ""}
+          ${s.ctaLabel ? `<a href="${esc(safeHref(s.ctaHref || "#"))}" style="display:inline-block; background:${safeCss(s.accentColor || "var(--sc-accent, #7c3aed)")}; color:white; padding:0.875rem 2rem; border-radius:var(--sc-radius, 8px); font-weight:600; text-decoration:none; font-size:1rem;">${esc(s.ctaLabel)}</a>` : ""}
         </div>
       </div>
     </section>`;

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -119,10 +119,18 @@ function CreatePageInner() {
     try {
       // Extracted here, in the browser. The video never leaves the device and there is
       // no server involved at all.
-      const { frames, frameCount: count } = await extractFramesInBrowser(file, {
+      const { frames, frameCount: count, duration, sourceDuration } = await extractFramesInBrowser(file, {
         frameCount,
         onProgress: (pct) => setProgress(Math.max(5, pct)),
       });
+      // Sampling stops at a cap, and silently returning a shortened site is worse than
+      // saying so - the missing footage is the first thing the user looks for.
+      if (sourceDuration > duration + 0.5) {
+        toast.info(
+          `Used the first ${Math.round(duration)}s of your ${Math.round(sourceDuration)}s clip. ` +
+          "Past that the frames are too far apart to scrub smoothly."
+        );
+      }
       await storeFrames("scrollcraft_desktop_frames", frames);
 
       const params = new URLSearchParams({

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -137,8 +137,8 @@ function EditorInner() {
   const searchParams = useSearchParams();
   const previewScrollRef = useRef<HTMLDivElement>(null);
 
-  // Derive initial frame state. Frames live in IndexedDB (primary) with sessionStorage as a
-  // legacy fallback for any in-flight sessions created before this change.
+  // Derive initial frame state. Frames live in IndexedDB; nothing reads sessionStorage,
+  // which was too small at 5 MB to hold a frame sequence.
   const pickedTemplate = templateBySlug(searchParams.get("template") ?? "");
   // A template arrives as a finished site: its sections become the starting document,
   // with the ids the editor needs to track selection and undo.
@@ -154,7 +154,7 @@ function EditorInner() {
   const countParam = searchParams.get("frameCount");
   const fpsParam = searchParams.get("fps");
 
-  // Synchronous fast path: check legacy sessionStorage only (may be empty for new sessions)
+  // Synchronous fast path: the legacy ?frames= URL parameter, which predates IndexedDB.
   const parsedFrames: string[] | null = (() => {
     if (framesParam) {
       try {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -37,8 +37,8 @@ export default function PrivacyPage() {
           </li>
           <li>
             <strong>Ordinary request logs.</strong> Our host records the usual server access
-            logs, including IP addresses, which we also use to rate-limit the two API routes
-            so one visitor cannot exhaust them for everyone.
+            logs, including IP addresses, which we also use to rate-limit the export endpoint
+            so one visitor cannot exhaust it for everyone.
           </li>
         </ul>
         <p>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -70,6 +70,8 @@ export default function Navbar({ position = "sticky" }: { position?: "fixed" | "
           className="md:hidden p-2 rounded-md text-muted-foreground hover:text-foreground cursor-pointer"
           onClick={() => setOpen((v) => !v)}
           aria-label="Toggle menu"
+          aria-expanded={open}
+          aria-controls="mobile-menu"
         >
           {open ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
         </button>
@@ -77,7 +79,7 @@ export default function Navbar({ position = "sticky" }: { position?: "fixed" | "
 
       {/* Mobile drawer */}
       {open && (
-        <div className="md:hidden border-t border-white/5 bg-background/95 backdrop-blur-xl px-5 py-4 flex flex-col gap-3">
+        <div id="mobile-menu" className="md:hidden border-t border-white/5 bg-background/95 backdrop-blur-xl px-5 py-4 flex flex-col gap-3">
           {NAV_LINKS.map(({ href, label }) => (
             <Link
               key={href}

--- a/src/lib/extractFramesInBrowser.ts
+++ b/src/lib/extractFramesInBrowser.ts
@@ -22,8 +22,16 @@ export interface BrowserExtractOptions {
 export interface BrowserExtractResult {
   frames: string[];
   frameCount: number;
-  /** Source duration in seconds, for reporting. */
+  /** Seconds actually sampled. Capped at MAX_DURATION_SECONDS. */
   duration: number;
+  /**
+   * The clip's own length, which is not always what was sampled.
+   *
+   * The two were reported as one number called `duration`, and the caller read neither,
+   * so a clip past the cap was quietly cut and the user was told nothing: they uploaded
+   * five minutes of footage and got the first two with no explanation.
+   */
+  sourceDuration: number;
 }
 
 /** Longest clip worth sampling. Past this the frames are far apart and the result is a slideshow. */
@@ -120,7 +128,7 @@ export async function extractFramesInBrowser(
       if (i % 5 === 0) await new Promise((r) => setTimeout(r, 0));
     }
 
-    return { frames, frameCount: frames.length, duration };
+    return { frames, frameCount: frames.length, duration, sourceDuration: video.duration };
   } finally {
     video.pause();
     video.removeAttribute("src");


### PR DESCRIPTION
The tail of the eight-dimension audit — seven leftovers, none of them data loss. Every one verified against a `main` worktree built and served beside this branch, rather than by swapping files in place.

## Silent video truncation

Sampling stops at `MAX_DURATION_SECONDS = 120`. The extractor returned one number called `duration`, documented as *"Source duration in seconds, for reporting"* but actually the **capped** value — and `handleUpload` destructured only `frames` and `frameCount`. So nothing anywhere knew the clip had been cut.

Real clips rendered with ffmpeg, uploaded through `/create` in Chrome:

| clip | `main` | this branch |
| --- | --- | --- |
| 150s | no warning, silently truncated | *"Used the first 120s of your 150s clip. Past that the frames are too far apart to scrub smoothly."* |
| 8s | no warning | no warning |

The second row matters as much as the first: `video.duration` is a float, so the check carries a 0.5s tolerance rather than an exact inequality.

## The exported CTA ignored the theme's radius

The preview renders `borderRadius: var(--sc-radius, 8px)`. The export hardcoded `border-radius:0.5rem`. `0.5rem` **is** 8px, so the two agreed — for the two templates that ask for `radius: 8`. The other nineteen did not, and three of them want square corners:

```
radius values across the catalogue:
  0 ×3   2 ×2   4 ×3   6 ×3   8 ×2   10 ×2   12 ×1   14 ×2   16 ×1   18 ×1   20 ×1
```

With `themeJson: {"radius":20}`, `main` emits `border-radius:0.5rem` beside its own `--sc-radius:20px`; this branch emits `var(--sc-radius, 8px)`.

## The body guard buffered before it measured

The `Content-Length` check is only as honest as the sender — omit the header, send chunked, and `req.text()` held the entire stream before anything looked at its size.

120 MB chunked body, no `Content-Length`:

| | status | bytes the server accepted | time |
| --- | --- | --- | --- |
| `main` | 413 | **120,021,432** — all of it | 0.150s |
| this branch | 413 | **12,797,298** — one chunk past the cap | 0.021s |

Same answer, a tenth of the memory. `readCapped` enforces the limit inside the read loop.

## Two disclosure widgets with no disclosed state

The mobile menu button and the FAQ rows are plain `<button>`s whose state existed only as a rotated `+` and a swapped icon. In Chrome, before → after:

| | `main` | this branch |
| --- | --- | --- |
| hamburger | `aria-expanded` absent, no `aria-controls` | `false → true`, `aria-controls="mobile-menu"` resolves |
| FAQ rows | 0 of 5 carry `aria-expanded` | 5 of 5; answer is a `region` labelled by its question |

The `+` is now `aria-hidden` — it was being read as content.

## Two things the code said that were not true

- `privacy/page.tsx` said IP addresses rate-limit *"the two API routes"*. One of three is rate-limited; the test now derives that from `src/app/api` rather than restating it.
- Two comments in the editor described a sessionStorage fallback for frames. Nothing reads sessionStorage — the only remaining legacy path is the `?frames=` URL parameter.

## Not included

`verify.mjs`'s contrast check still cannot see the scrim behind section text, deferred with its reasoning in #367. Three preview/export nits the audit raised (statement-heading weight and tracking defaults, body-image centring) I have not verified myself and am not fixing on an unverified report.

Suite 330 passed. All seven new tests fail against `main`.