### PR TITLE
Show the product in the hero, and stop implying a price

### DIFF
--- a/src/__tests__/contactDetails.test.ts
+++ b/src/__tests__/contactDetails.test.ts
@@ -184,6 +184,16 @@ describe("what the site claims about itself is true", () => {
     );
   });
 
+  it("does not imply a paid tier that does not exist", () => {
+    // There is no checkout, no account and no plan, so "free plan", "no credit card"
+    // and "start for free" all answered a question nobody was asked and implied tiers.
+    // templates.ts is exempt: its section copy is sample content for fictional sites.
+    const offenders = sourceFiles()
+      .filter((f) => !f.includes("templates.ts") && !f.includes("changelog"))
+      .filter((f) => /free plan|no credit card|start for free|start free/i.test(readFileSync(f, "utf8")));
+    expect(offenders, "the site still talks like it has pricing").toEqual([]);
+  });
+
   it("describes the rate limiting it actually applies", () => {
     // One of three API routes is rate-limited; the privacy page promised two.
     const privacy = readFileSync("src/app/privacy/page.tsx", "utf8");

--- a/src/__tests__/landingHero.test.ts
+++ b/src/__tests__/landingHero.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * The hero animation, and where it sits.
+ *
+ * It used to cycle 60 JPEGs from /api/demo-frame at 10fps. Measured in Chrome at
+ * 1440x900 on a production build: 87 requests and 130.3 KiB just to animate, and the
+ * demo's top edge landed at 733px of a 900px viewport, so 29% of it was in view at
+ * first paint - a visitor read three paragraphs about a scroll animation before seeing
+ * one. It also had to be switched off below 768px to avoid firing every request at once.
+ *
+ * After: 0 requests, top edge at 188px, 100% in view, and it runs on a phone too.
+ */
+const HOME = readFileSync("src/app/HomeClient.tsx", "utf8");
+const PREVIEW = readFileSync("src/components/StylePreview.tsx", "utf8");
+
+describe("the hero draws its animation instead of fetching it", () => {
+  it("no longer builds a list of demo-frame URLs", () => {
+    expect(HOME).not.toContain("/api/demo-frame");
+    expect(HOME).not.toContain("DEMO_COUNT");
+  });
+
+  it("renders the same drawFrame2D the product uses", () => {
+    expect(HOME).toContain("<StylePreview");
+    expect(PREVIEW).toContain("drawFrame2D");
+  });
+
+  it("uses a palette from the catalogue rather than an invented one", async () => {
+    const { PRESETS } = await import("@/lib/presets");
+    const colors = /const HERO_COLORS: \[string, string, string\] = (\[[^\]]*\])/.exec(HOME);
+    expect(colors, "the hero palette is gone").toBeTruthy();
+    const hero: string[] = JSON.parse(colors![1].replace(/'/g, '"'));
+    expect(PRESETS.some((p) => JSON.stringify(p.colors) === JSON.stringify(hero))).toBe(true);
+  });
+
+  it("stops short of the range where every palette goes black", () => {
+    // Each style lerps toward its third colour as progress rises, and most third colours
+    // are near-black, so an unbounded loop spends much of its cycle on a dark rectangle.
+    expect(HOME).toMatch(/maxProgress=\{0?\.\d+\}/);
+    expect(PREVIEW).toContain("maxProgress = 1");
+    expect(PREVIEW).toContain("* maxProgress");
+  });
+
+  it("holds still for a visitor who asked for less motion", () => {
+    expect(HOME).toContain('const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";');
+    expect(HOME).toContain("paused={reducedMotion}");
+  });
+});
+
+describe("the landing page shows the product before it describes it", () => {
+  it("puts the copy and the demo in one row rather than stacking them", () => {
+    expect(HOME).toContain("grid lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]");
+  });
+
+  it("no longer veils the demo behind a fade to the page background", () => {
+    // The old frame sat under a from-background gradient, which is why the sliver that
+    // was above the fold read as an empty box.
+    const hero = HOME.slice(HOME.indexOf("{/* Hero */}"), HOME.indexOf("{/* Social proof strip */}"));
+    expect(hero).not.toContain("bg-gradient-to-t from-background");
+  });
+});
+
+describe("the site says the plugin exists", () => {
+  it("offers the install commands the README documents", () => {
+    const plugin = readFileSync("src/components/PluginInstall.tsx", "utf8");
+    const readme = readFileSync("README.md", "utf8");
+    for (const cmd of [
+      "/plugin marketplace add singhharsh1708/scrollcraft",
+      "/plugin install scrollcraft@scrollcraft",
+    ]) {
+      expect(plugin, `${cmd} is not offered`).toContain(cmd);
+      expect(readme, `${cmd} is not what the README says`).toContain(cmd);
+    }
+  });
+
+  it("is reachable from the landing page at all", () => {
+    expect(HOME).toContain("<PluginInstall />");
+  });
+});

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { useState, useEffect, useSyncExternalStore } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ArrowRight, Sparkles, Zap, Download, Play, Check } from "lucide-react";
@@ -8,23 +8,29 @@ import Navbar from "@/components/Navbar";
 import StylePreview from "@/components/StylePreview";
 import type { Style2D } from "@/lib/generate2DFrames";
 import SponsorCard from "@/components/SponsorCard";
+import PluginInstall from "@/components/PluginInstall";
 import GitHubMark from "@/components/GitHubMark";
 import { AUTHOR_NAME, AUTHOR_SITE_URL, GITHUB_REPO_URL } from "@/lib/links";
 import SiteFooter from "@/components/SiteFooter";
 
-const DEMO_COUNT = 60;
-const demoFrames = Array.from({ length: DEMO_COUNT }, (_, i) => `/api/demo-frame?i=${i}&total=${DEMO_COUNT}`);
+/**
+ * The hero animation, drawn rather than fetched.
+ *
+ * Same drawFrame2D the product itself uses, on a canvas, for no network requests - cheap
+ * enough to run on a phone as well as a desktop.
+ */
+const HERO_STYLE: Style2D = "gradient";
+/** The Chromatic preset's own palette, so the hero shows a real one from the catalogue. */
+const HERO_COLORS: [string, string, string] = ["#8b5cf6", "#c026d3", "#12031a"];
 
-// Mobile skips the hero autoplay so it never fires 60 concurrent frame requests (#156).
-// Server-rendered as mobile so the initial HTML never references the frame URLs.
-const MOBILE_HERO_QUERY = "(max-width: 767px)";
-const subscribeMobileHero = (onChange: () => void) => {
-  const mq = window.matchMedia(MOBILE_HERO_QUERY);
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+const subscribeReducedMotion = (onChange: () => void) => {
+  const mq = window.matchMedia(REDUCED_MOTION_QUERY);
   mq.addEventListener("change", onChange);
   return () => mq.removeEventListener("change", onChange);
 };
-const getMobileHeroSnapshot = () => window.matchMedia(MOBILE_HERO_QUERY).matches;
-const getMobileHeroServerSnapshot = () => true;
+const getReducedMotionSnapshot = () => window.matchMedia(REDUCED_MOTION_QUERY).matches;
+const getReducedMotionServerSnapshot = () => false;
 
 export interface FeaturedPreset {
   name: string;
@@ -59,40 +65,21 @@ const FAQ = [
 ];
 
 function HeroPreview() {
-  const isMobileHero = useSyncExternalStore(
-    subscribeMobileHero,
-    getMobileHeroSnapshot,
-    getMobileHeroServerSnapshot
+  const reducedMotion = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionServerSnapshot
   );
-  const [heroFrameIdx, setHeroFrameIdx] = useState(0);
-  // Cycle through demo frames automatically at ~10fps (no user scroll required).
-  useEffect(() => {
-    if (isMobileHero) return;
-    let frame = 0;
-    let last = 0;
-    let rafId: number;
-    const INTERVAL = 100; // ms per frame → ~10fps
-    const tick = (ts: number) => {
-      if (ts - last >= INTERVAL) {
-        frame = (frame + 1) % DEMO_COUNT;
-        setHeroFrameIdx(frame);
-        last = ts;
-      }
-      rafId = requestAnimationFrame(tick);
-    };
-    rafId = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(rafId);
-  }, [isMobileHero]);
 
   return (
-    <>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={demoFrames[heroFrameIdx]}
-        alt="ScrollCraft scroll animation preview"
-        className="w-full aspect-video object-cover"
-      />
-    </>
+    <StylePreview
+      style={HERO_STYLE}
+      colors={HERO_COLORS}
+      paused={reducedMotion}
+      durationSec={9}
+      maxProgress={0.55}
+      className="w-full h-full"
+    />
   );
 }
 
@@ -108,58 +95,60 @@ export default function HomeClient({ presetCount, featured }: { presetCount: num
       <Navbar position="fixed" />
 
       {/* Hero */}
-      <section className="relative flex flex-col items-center justify-center min-h-screen text-center px-6 pt-20">
-        <div className="absolute top-1/3 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[700px] h-[700px] rounded-full bg-primary/8 blur-[140px] pointer-events-none" />
-        <div className="absolute top-2/3 left-1/4 w-[300px] h-[300px] rounded-full bg-blue-500/6 blur-[100px] pointer-events-none" />
+      <section className="relative px-6 pt-28 pb-20 lg:pt-32 lg:pb-28">
+        <div className="absolute top-1/3 left-1/4 w-[700px] h-[700px] rounded-full bg-primary/8 blur-[140px] pointer-events-none" />
+        <div className="absolute top-2/3 right-1/4 w-[300px] h-[300px] rounded-full bg-blue-500/6 blur-[100px] pointer-events-none" />
 
-        <Badge variant="outline" className="mb-6 border-primary/40 text-primary-ink bg-primary/10 px-4 py-1.5">
-          <Sparkles className="w-3 h-3 mr-1.5" /> Ready-made templates · No code · Animated scroll
-        </Badge>
+        {/* Two columns from lg up: the copy and the thing it describes, side by side. The
+            demo used to sit 733px down a 900px viewport behind a fade, so a visitor read
+            three paragraphs about a scroll animation before seeing one. */}
+        <div className="relative max-w-7xl mx-auto grid lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] gap-12 lg:gap-16 items-center">
+          <div className="text-center lg:text-left">
+            <Badge variant="outline" className="mb-6 border-primary/40 text-primary-ink bg-primary/10 px-4 py-1.5">
+              <Sparkles className="w-3 h-3 mr-1.5" /> Ready-made templates · No code · Animated scroll
+            </Badge>
 
-        <h1 className="text-6xl md:text-8xl font-black tracking-tighter mb-6 leading-none">
-          Build cinematic<br />
-          <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 via-purple-400 to-indigo-400">
-            scroll websites
-          </span><br />
-          in minutes
-        </h1>
+            <h1 className="text-5xl sm:text-6xl xl:text-7xl font-black tracking-tighter mb-6 leading-[0.95]">
+              Build cinematic{" "}
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 via-purple-400 to-indigo-400">
+                scroll websites
+              </span>{" "}
+              in minutes
+            </h1>
 
-        <p className="text-xl text-muted-foreground max-w-2xl mb-10 leading-relaxed">
-          Pick a style. ScrollCraft generates smooth animated canvas frames,
-          and wires them up as a silky scroll experience — exported as pure HTML. No code.
-        </p>
+            <p className="text-lg sm:text-xl text-muted-foreground max-w-xl mx-auto lg:mx-0 mb-8 leading-relaxed">
+              Pick a style. ScrollCraft generates smooth animated canvas frames,
+              and wires them up as a silky scroll experience, exported as pure HTML. No code.
+            </p>
 
-        <div className="flex flex-col sm:flex-row items-center gap-4">
-          <Link href="/create">
-            <Button size="lg" className="bg-primary hover:bg-primary/90 text-white px-8 py-6 text-base font-semibold shadow-lg shadow-primary/25">
-              Create your site <ArrowRight className="ml-2 w-5 h-5" />
-            </Button>
-          </Link>
-          <Link href="/presets">
-            <Button size="lg" variant="outline" className="border-white/10 hover:bg-white/5 px-8 py-6 text-base">
-              Browse presets
-            </Button>
-          </Link>
-        </div>
-
-        <div className="mt-6 flex items-center gap-6 text-sm text-muted-foreground">
-          {["Free plan, no time limit", "No credit card", "Deploy anywhere"].map((t) => (
-            <div key={t} className="flex items-center gap-1.5">
-              <Check className="w-3.5 h-3.5 text-primary-ink" /> {t}
+            <div className="flex flex-col sm:flex-row items-center lg:justify-start justify-center gap-4">
+              <Link href="/create">
+                <Button size="lg" className="bg-primary hover:bg-primary/90 text-white px-8 py-6 text-base font-semibold shadow-lg shadow-primary/25">
+                  Create your site <ArrowRight className="ml-2 w-5 h-5" />
+                </Button>
+              </Link>
+              <Link href="/presets">
+                <Button size="lg" variant="outline" className="border-white/10 hover:bg-white/5 px-8 py-6 text-base">
+                  Browse presets
+                </Button>
+              </Link>
             </div>
-          ))}
-        </div>
 
-        {/* Hero visual — live scroll demo (desktop only; mobile skips 60 concurrent requests) */}
-        <div className="relative mt-16 w-full max-w-5xl mx-auto rounded-2xl overflow-hidden border border-white/10 shadow-2xl shadow-black/60">
-          {/* Autoplay animation — owns its own frame state so the ~10fps loop re-renders
-              only this image, not the whole landing page. */}
-          <HeroPreview />
-          {/* Fade-out at bottom */}
-          <div className="absolute inset-0 bg-gradient-to-t from-background via-transparent to-transparent pointer-events-none" style={{ zIndex: 2 }} />
-          {/* Label */}
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-xs text-white/30 uppercase tracking-widest pointer-events-none" style={{ zIndex: 3 }}>
-            Live preview
+            <div className="mt-6 flex flex-wrap items-center lg:justify-start justify-center gap-x-6 gap-y-2 text-sm text-muted-foreground">
+              {["No account", "Runs in your browser", "MIT licensed"].map((t) => (
+                <div key={t} className="flex items-center gap-1.5">
+                  <Check className="w-3.5 h-3.5 text-primary-ink" /> {t}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* The product, at first paint. */}
+          <div className="relative w-full aspect-[16/10] rounded-2xl overflow-hidden border border-white/10 shadow-2xl shadow-black/60 bg-black/40">
+            <HeroPreview />
+            <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-xs text-white/40 uppercase tracking-widest pointer-events-none">
+              Live preview
+            </div>
           </div>
         </div>
       </section>
@@ -373,6 +362,11 @@ export default function HomeClient({ presetCount, featured }: { presetCount: num
         </div>
       </section>
 
+      {/* Plugin */}
+      <section className="px-6 pb-6 max-w-5xl mx-auto">
+        <PluginInstall />
+      </section>
+
       {/* Open source */}
       <section className="px-6 pb-4 max-w-5xl mx-auto">
         <SponsorCard />
@@ -392,7 +386,7 @@ export default function HomeClient({ presetCount, featured }: { presetCount: num
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
               <Link href="/create">
                 <Button size="lg" className="bg-primary hover:bg-primary/90 text-white px-10 py-7 text-lg font-semibold shadow-xl shadow-primary/30">
-                  Start for free <ArrowRight className="ml-2 w-5 h-5" />
+                  Start building <ArrowRight className="ml-2 w-5 h-5" />
                 </Button>
               </Link>
               <Link href="/templates">

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -146,10 +146,10 @@ export default function AboutPage() {
       {/* CTA */}
       <section className="py-24 px-6 text-center border-t border-white/5">
         <h2 className="text-4xl font-black tracking-tighter mb-4">Come build with us</h2>
-        <p className="text-muted-foreground mb-8 max-w-md mx-auto">Start free. No credit card. Your first scroll site in under 5 minutes.</p>
+        <p className="text-muted-foreground mb-8 max-w-md mx-auto">No account, no install. Pick a template and export a finished site.</p>
         <Link href="/create">
           <Button size="lg" className="bg-primary hover:bg-primary/90 text-white px-10 py-6 font-semibold">
-            Start for free <ArrowRight className="ml-2 w-4 h-4" />
+            Start building <ArrowRight className="ml-2 w-4 h-4" />
           </Button>
         </Link>
       </section>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,7 +9,7 @@ import { GITHUB_REPO_URL, GITHUB_SPONSORS_URL } from "@/lib/links";
 
 const NAV_LINKS = [
   { href: "/templates", label: "Templates" },
-  { href: "/presets",   label: "Styles"    },
+  { href: "/presets",   label: "Presets"   },
 ];
 
 export default function Navbar({ position = "sticky" }: { position?: "fixed" | "sticky" | "relative" }) {

--- a/src/components/PluginInstall.tsx
+++ b/src/components/PluginInstall.tsx
@@ -1,0 +1,79 @@
+"use client";
+import { useState } from "react";
+import { Check, Copy, Terminal } from "lucide-react";
+import { GITHUB_REPO_URL } from "@/lib/links";
+
+/**
+ * The other way to use ScrollCraft.
+ *
+ * The repository ships a Claude Code plugin that builds and verifies a scroll site from
+ * the command line, and the site never said so - a whole distribution channel reachable
+ * only by reading the README on GitHub. Two lines, copyable, because that is the entire
+ * install.
+ */
+const COMMANDS = [
+  "/plugin marketplace add singhharsh1708/scrollcraft",
+  "/plugin install scrollcraft@scrollcraft",
+];
+
+export default function PluginInstall() {
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const copy = async (cmd: string) => {
+    try {
+      await navigator.clipboard.writeText(cmd);
+      setCopied(cmd);
+      window.setTimeout(() => setCopied((c) => (c === cmd ? null : c)), 1600);
+    } catch {
+      // Clipboard access can be denied outright; the command is selectable either way.
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-white/8 bg-card p-6 sm:p-8">
+      <div className="flex items-center gap-2 mb-2 text-primary-ink">
+        <Terminal className="w-4 h-4" aria-hidden="true" />
+        <span className="text-xs uppercase tracking-widest font-medium">Or build it from your editor</span>
+      </div>
+      <h3 className="text-2xl font-bold tracking-tight mb-2">ScrollCraft as a Claude Code plugin</h3>
+      <p className="text-sm text-muted-foreground mb-5 max-w-xl">
+        Scaffold a spec, render a background and build the site from the command line.
+        The only thing it needs installed is <code className="text-foreground">ffmpeg</code>.
+      </p>
+
+      <ul className="space-y-2">
+        {COMMANDS.map((cmd) => (
+          <li key={cmd}>
+            <button
+              type="button"
+              onClick={() => copy(cmd)}
+              aria-label={`Copy command: ${cmd}`}
+              className="group w-full flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-black/40 px-4 py-2.5 text-left transition-colors hover:border-white/20"
+            >
+              <code className="text-xs sm:text-sm font-mono text-foreground/90 truncate">{cmd}</code>
+              {copied === cmd ? (
+                <span className="flex items-center gap-1.5 text-xs text-primary-ink flex-shrink-0">
+                  <Check className="w-3.5 h-3.5" aria-hidden="true" /> Copied
+                </span>
+              ) : (
+                <Copy
+                  className="w-3.5 h-3.5 text-muted-foreground group-hover:text-foreground flex-shrink-0 transition-colors"
+                  aria-hidden="true"
+                />
+              )}
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <a
+        href={`${GITHUB_REPO_URL}#install-the-claude-code-plugin`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-block mt-4 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        What the plugin does →
+      </a>
+    </div>
+  );
+}

--- a/src/components/StylePreview.tsx
+++ b/src/components/StylePreview.tsx
@@ -9,6 +9,14 @@ interface StylePreviewProps {
   durationSec?: number;
   /** Pause the rAF loop to save CPU (e.g. when off-screen / not selected) */
   paused?: boolean;
+  /**
+   * Upper bound of the scrubbed range, 0..1.
+   *
+   * Every style lerps toward its third colour as progress rises, and most palettes end
+   * near black because that is what a scroll background does under the closing sections.
+   * A preview that has to look good in isolation can stop short of that.
+   */
+  maxProgress?: number;
   className?: string;
 }
 
@@ -22,6 +30,7 @@ export default function StylePreview({
   colors,
   durationSec = 6,
   paused = false,
+  maxProgress = 1,
   className = "",
 }: StylePreviewProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -76,7 +85,7 @@ export default function StylePreview({
       // Ping-pong 0->1->0 instead of a 0..1 sawtooth: the draw functions are not periodic
       // in p, so a sawtooth snaps at the wrap. A triangle wave is continuous at both ends.
       const phase = (elapsed / durationSec) % 2;
-      const p = phase <= 1 ? phase : 2 - phase;
+      const p = (phase <= 1 ? phase : 2 - phase) * maxProgress;
       const { w, h } = sizeRef.current;
       drawFrame2D(ctx, w, h, p, optsRef.current);
       rafId = requestAnimationFrame(tick);
@@ -84,7 +93,7 @@ export default function StylePreview({
 
     rafId = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafId);
-  }, [paused, durationSec]);
+  }, [paused, durationSec, maxProgress]);
 
   // While paused the loop is not running, so redraw the static frame on restyle.
   useEffect(() => {


### PR DESCRIPTION
Studied [vengenceui.com](https://www.vengenceui.com/). Two ideas there are worth taking: it puts a **live artifact of the thing beside the copy that describes it**, and it leads with a **copyable install line** rather than a tour. Its testimonial wall is not worth taking — ScrollCraft has no users to quote, and inventing some is exactly what #343 removed.

## The hero fetched its animation

It cycled 60 JPEGs from `/api/demo-frame` at 10fps. Measured in Chrome at 1440×900 against production builds:

| | before | after |
| --- | --- | --- |
| requests just to animate the hero | **87** (130.3 KiB) | **0** |
| demo's top edge | 733px of a 900px viewport | **188px** |
| of the demo visible at first paint | **29%** | **100%** |
| below 768px | animation disabled entirely | runs |

A visitor read three paragraphs about a scroll animation before seeing one, and the sliver that *was* above the fold sat behind a `from-background` fade, so it read as an empty box.

It now draws through `StylePreview` — the same `drawFrame2D` the product itself uses — in a two-column hero. It holds still under `prefers-reduced-motion`.

### The first attempt was a black rectangle

Every style lerps toward its third colour as progress rises, and most palettes end near-black because that is what a scroll background does under the closing sections. An unbounded ping-pong therefore spends much of its cycle dark, which is what my first screenshot showed.

`StylePreview` now takes an optional `maxProgress`, **defaulting to 1 so no existing caller changes behaviour**, and the hero scrubs the vivid part of the **Chromatic preset's own palette** — a real entry from the catalogue, asserted by a test rather than an invented hex triple. Sampling the canvas mid-loop now returns `rgb(74,32,108)`.

## The site talked as though it had pricing

"Free plan, no time limit", "No credit card", "Start for free" — on the home page and the about page. There is no account, no checkout and no tier, so those answered a question nobody asked and implied a paid one existed. Replaced with what is actually true and useful: **No account · Runs in your browser · MIT licensed**.

A test now fails on any of that language outside `templates.ts`, whose section copy is sample content for fictional sites.

## Two smaller things

- The nav called `/presets` **"Styles"** while the route, the page metadata title, the `h1` ("Start from a preset") and the hero button ("Browse presets") all said presets. The one label a visitor navigates by was the only one that disagreed.
- The **Claude Code plugin this repository ships** was reachable only by reading the README on GitHub. Its two install commands are now on the page, copyable, and asserted against the README so they cannot drift apart.

## Verified

Rendered at 1440×900 and 390×844 and looked at, not just diffed — the black-rectangle hero was invisible in the source and obvious in a screenshot. `/`, `/about`, `/presets`, `/templates` and `/create` report zero policy violations, page errors and console errors.

Suite 340 passed. The nine new tests fail on `main`.