### PR TITLE
Ship the social card as JPEG and give iOS a square icon

### DIFF
--- a/src/__tests__/exportQuality.test.ts
+++ b/src/__tests__/exportQuality.test.ts
@@ -166,8 +166,33 @@ describe("the exported page is shareable and installable", () => {
   it("declares a social image, having promised a large card", async () => {
     const html = await exportHtml();
     expect(html).toContain('name="twitter:card" content="summary_large_image"');
-    expect(html).toContain('property="og:image"');
-    expect(html).toContain('name="twitter:image"');
+    // JPEG: the card is a photographic gradient. Measured on a real export, the same
+    // 1200x630 image was 544 KB as PNG - 94% of a procedural ZIP - and 46 KB as JPEG.
+    expect(html).toContain('property="og:image" content="og-image.jpg"');
+    expect(html).toContain('property="og:image:type" content="image/jpeg"');
+    expect(html).toContain('property="og:image:width" content="1200"');
+    expect(html).toContain('property="og:image:height" content="630"');
+    expect(html).toContain('name="twitter:image" content="og-image.jpg"');
+    expect(html).not.toContain("og-image.png");
+  });
+
+  it("gives iOS a square home-screen icon rather than the wide card", async () => {
+    // apple-touch-icon pointed at the 1200x630 card, which iOS squashes into a square.
+    const html = await exportHtml();
+    expect(html).toContain('rel="apple-touch-icon" href="apple-touch-icon.png"');
+    expect(html).not.toMatch(/rel="apple-touch-icon" href="og-image/);
+  });
+
+  it("ships the icon it links, in the favicon's colours", () => {
+    const editor = readFileSync("src/app/editor/page.tsx", "utf8");
+    expect(editor).toContain('zip.file("og-image.jpg", ogBlob)');
+    expect(editor).toContain('zip.file("apple-touch-icon.png", iconBlob)');
+    // Same accent and ground feed the favicon and the touch icon.
+    expect(editor).toContain("faviconSvg(iconAccent, iconGround, siteName)");
+    expect(editor).toContain("renderTouchIcon(iconAccent, iconGround, siteName)");
+    const assets = readFileSync("src/lib/exportAssets.ts", "utf8");
+    expect(assets).toContain('canvas.toBlob((b) => resolve(b), "image/jpeg", 0.85)');
+    expect(assets).toMatch(/const S = 180;/);
   });
 
   it("declares a favicon and a theme colour", async () => {
@@ -281,4 +306,21 @@ describe("the in-app renderer matches the exporter", () => {
     expect(src).toContain(".sc-site a:focus-visible");
   });
 
+});
+
+describe("the export README describes the ZIP it is in", () => {
+  it("lists the social card and the touch icon under the names they ship with", () => {
+    const readme = exportReadme("Site", true, "https://example.test");
+    expect(readme).toContain("`og-image.jpg`");
+    expect(readme).toContain("`apple-touch-icon.png`");
+    expect(readme).not.toContain("og-image.png");
+  });
+
+  it("does not call a 580 KB ZIP 'a few kilobytes'", () => {
+    // Measured: index.html 19.5 KB + lenis 11.6 KB, plus the card. The old sentence was
+    // written before the card existed.
+    const readme = exportReadme("Site", true, "https://example.test");
+    expect(readme).not.toMatch(/few kilobytes/);
+    expect(readme).toMatch(/about 35 KB/);
+  });
 });

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -292,11 +292,14 @@ export async function POST(req: NextRequest) {
   <meta property="og:title" content="${esc(siteName || "My ScrollCraft Site")}" />
   <meta property="og:description" content="${esc(metaDescription)}" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta property="og:image" content="og-image.png" />
-  <meta name="twitter:image" content="og-image.png" />
+  <meta property="og:image" content="og-image.jpg" />
+  <meta property="og:image:type" content="image/jpeg" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta name="twitter:image" content="og-image.jpg" />
   <meta name="theme-color" content="${esc(compiledTheme.vars["--sc-ground"] ?? "#000000")}" />
   <link rel="icon" href="favicon.svg" type="image/svg+xml" />
-  <link rel="apple-touch-icon" href="og-image.png" />
+  <link rel="apple-touch-icon" href="apple-touch-icon.png" />
   <style>
     ${themeVarsCss}
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -21,7 +21,7 @@ import dynamic from "next/dynamic";
 import { siteStyleSchema, themeSchema, type EditorSection, type SiteStyle, type Theme } from "@/lib/siteSchema";
 import { templateBySlug, type Template } from "@/lib/templates";
 import { layoutStyle } from "@/lib/layoutStyles";
-import { faviconSvg, notFoundHtml, exportReadme, renderSocialCard } from "@/lib/exportAssets";
+import { faviconSvg, notFoundHtml, exportReadme, renderSocialCard, renderTouchIcon } from "@/lib/exportAssets";
 import { generate2DFrames } from "@/lib/generate2DFrames";
 import { AUTOSAVE_DEBOUNCE_MS, saveStatusLabel, type SaveState } from "@/lib/saveStatus";
 
@@ -631,7 +631,10 @@ function EditorInner() {
       // a robots.txt, and config so one drag-and-drop deploys correctly on the
       // hosts people actually use.
       setExportStage("Adding site files…");
-      zip.file("favicon.svg", faviconSvg(siteTheme?.accent ?? "#7c3aed", siteTheme?.ground ?? "#05070c", siteName));
+      // One pair of colours for every icon the ZIP carries, so they cannot drift apart.
+      const iconAccent = siteTheme?.accent ?? "#7c3aed";
+      const iconGround = siteTheme?.ground ?? "#05070c";
+      zip.file("favicon.svg", faviconSvg(iconAccent, iconGround, siteName));
       zip.file("robots.txt", "User-agent: *\nAllow: /\n");
       zip.file("404.html", notFoundHtml(siteName, siteTheme?.ground ?? "#05070c", siteTheme?.ink ?? "#ffffff"));
 
@@ -651,7 +654,9 @@ function EditorInner() {
       }, null, 2) + "\n");
 
       const ogBlob = await renderSocialCard(siteName, siteDescription, frames[0], siteTheme?.ground ?? "#05070c", siteTheme?.ink ?? "#ffffff");
-      if (ogBlob) zip.file("og-image.png", ogBlob);
+      if (ogBlob) zip.file("og-image.jpg", ogBlob);
+      const iconBlob = await renderTouchIcon(iconAccent, iconGround, siteName);
+      if (iconBlob) zip.file("apple-touch-icon.png", iconBlob);
 
       zip.file("README.md", exportReadme(siteName, exportProcedurally, window.location.origin));
 

--- a/src/lib/exportAssets.ts
+++ b/src/lib/exportAssets.ts
@@ -134,11 +134,12 @@ Do **not** open \`index.html\` by double-clicking it. Browsers block a page load
 | \`index.html\` | Your whole site |
 | \`404.html\` | Shown for an address that does not exist |
 | \`favicon.svg\` | The icon in the browser tab |
-| \`og-image.png\` | The preview image when the link is shared |
+| \`og-image.jpg\` | The preview image when the link is shared |
+| \`apple-touch-icon.png\` | The icon when saved to a phone's home screen |
 | \`robots.txt\` | Tells search engines they may index the site |
 | \`lenis.min.js\` | Smooth scrolling. Remove it and scrolling still works |
 ${procedural
-  ? "\nThe background is drawn in the browser from a small style recipe, so there is no\n`frames/` folder and the whole site is a few kilobytes."
+  ? "\nThe background is drawn in the browser from a small style recipe, so there is no\n`frames/` folder. The page itself is about 35 KB; the social preview image is the only\nfile larger than that."
   : "\n| `frames/` | The background images |\n\nKeep `frames/` beside `index.html`."}
 
 ## Making changes
@@ -147,17 +148,17 @@ Everything is editable in a text editor.
 
 - **Words** — search \`index.html\` for the text you want to change.
 - **Colours** — near the top of the \`<style>\` block, the \`--sc-\` custom properties.
-- **Social preview** — replace \`og-image.png\` with your own 1200×630 image.
+- **Social preview** — replace \`og-image.jpg\` with your own 1200×630 image.
 - **Icon** — replace \`favicon.svg\`.
 
 ### One thing worth doing
 
 The social preview and canonical address are relative, which works on most platforms but
-not all. Once you know your real address, search \`index.html\` for \`og-image.png\` and make
+not all. Once you know your real address, search \`index.html\` for \`og-image.jpg\` and make
 it absolute:
 
 \`\`\`html
-<meta property="og:image" content="https://your-domain.com/og-image.png" />
+<meta property="og:image" content="https://your-domain.com/og-image.jpg" />
 \`\`\`
 
 ## Accessibility
@@ -257,6 +258,61 @@ export async function renderSocialCard(
       ctx.fillText(desc, 80, y + 8);
       ctx.globalAlpha = 1;
     }
+
+    // JPEG, not PNG: this is a photographic gradient, which PNG cannot compress. The same
+    // 1200x630 card measured 544 KB as PNG and 46 KB as JPEG at this quality - it was 94%
+    // of a procedural export's ZIP.
+    return await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob((b) => resolve(b), "image/jpeg", 0.85);
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A square home-screen icon in the favicon's own design.
+ *
+ * iOS ignores SVG for apple-touch-icon and wants a 180x180 PNG; the export pointed the
+ * tag at the 1200x630 social card, which iOS squashes into its square. Drawn here, in the
+ * browser, from the same accent, ground and initial the favicon uses.
+ */
+export async function renderTouchIcon(accent: string, ground: string, siteName: string): Promise<Blob | null> {
+  try {
+    const S = 180;
+    const canvas = document.createElement("canvas");
+    canvas.width = S;
+    canvas.height = S;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+
+    const r = S * 14 / 64;
+    const rounded = (x: number, y: number, w: number, h: number, rad: number) => {
+      ctx.beginPath();
+      ctx.moveTo(x + rad, y);
+      ctx.arcTo(x + w, y, x + w, y + h, rad);
+      ctx.arcTo(x + w, y + h, x, y + h, rad);
+      ctx.arcTo(x, y + h, x, y, rad);
+      ctx.arcTo(x, y, x + w, y, rad);
+      ctx.closePath();
+    };
+
+    ctx.fillStyle = ground;
+    rounded(0, 0, S, S, r);
+    ctx.fill();
+
+    ctx.strokeStyle = accent;
+    ctx.globalAlpha = 0.9;
+    ctx.lineWidth = S * 3 / 64;
+    rounded(S * 4 / 64, S * 4 / 64, S * 56 / 64, S * 56 / 64, S * 12 / 64);
+    ctx.stroke();
+    ctx.globalAlpha = 1;
+
+    ctx.fillStyle = accent;
+    ctx.font = `700 ${Math.round(S * 30 / 64)}px system-ui, -apple-system, "Segoe UI", sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "alphabetic";
+    ctx.fillText(initial(siteName), S / 2, S * 43 / 64);
 
     return await new Promise<Blob | null>((resolve) => {
       canvas.toBlob((b) => resolve(b), "image/png");


### PR DESCRIPTION
Clicked **Export** in the real editor (headless Chrome, real download) and opened the ZIP. This is the deliverable, so I wanted to see exactly what a user gets.

## The card was 94% of the ZIP

| file | bytes |
| --- | ---: |
| og-image.png | **544,204** |
| index.html | 19,519 |
| lenis.min.js | 11,635 |
| everything else | 5,447 |
| **total** | **580,805** |

A 1200×630 canvas of a gradient, encoded as PNG — which cannot compress a photograph. The README in the same ZIP called the site *"a few kilobytes"*.

Now JPEG at quality 0.85, with `og:image:type`, `width` and `height` declared so share-card consumers don't have to fetch it to learn its shape:

| | before | after |
| --- | ---: | ---: |
| social card | 544,204 (PNG) | **18,378** (JPEG) |
| whole ZIP | 580,805 | **63,554** |

The README now says what's measured — about 35 KB for the page, with the card the only file larger than that.

## iOS was handed the wide card as its icon

```html
<link rel="apple-touch-icon" href="og-image.png" />
```

iOS ignores SVG for this and squashes a 1200×630 image into its square. The ZIP now ships `apple-touch-icon.png`, a real 180×180 PNG drawn in the browser in the favicon's own design — rounded square, accent ring, initial — from **one** pair of accent/ground colours that the favicon and icon now share, so they cannot drift.

## Verified end to end

Export through the real button before and after, unzip, serve, drive the served site in Chrome: zero errors, zero 404s, background scrubs with scroll (whole-canvas hash differs at 5 of 5 scroll positions), reveals stay revealed on the way back up.

Lighthouse on the served export:

| | before | after |
| --- | --- | --- |
| mobile perf / a11y / bp / seo | 99 / 100 / 100 / 100 | **100** / 100 / 100 / 100 |
| mobile LCP | 1.7 s | **1.3 s** |
| desktop | 100 across | 100 across |

Same checks on a **frames** export (real 8-second clip uploaded through `/create`, 120 frames): identical outcome, card 290 KB → JPEG.

Five new tests in `exportQuality.test.ts`; all five fail on `main`. Suite 344 passed.