### PR TITLE
Stop the editor guessing what it is showing before it has looked

### DIFF
--- a/src/__tests__/editorAutosave.test.ts
+++ b/src/__tests__/editorAutosave.test.ts
@@ -128,3 +128,28 @@ describe("editor autosave", () => {
     expect(EDITOR).toMatch(/if \(!dirty\) return;/);
   });
 });
+
+describe("the editor's opening message tells the truth", () => {
+  /**
+   * The placeholder toast fired from a mount-time effect whenever the URL carried no
+   * frames - which is every template open ("pick a template", to someone who just did)
+   * and every cold open, where it then sat next to "Restored what you were working on".
+   * Verified in Chrome by polling toasts for the first six seconds of each load.
+   */
+  it("does not guess at mount", () => {
+    expect(EDITOR).not.toMatch(/useEffect\(\(\) => \{\s*if \(initialIsDemo\) \{\s*toast/);
+  });
+
+  it("calls the editor empty only after the restore has looked", () => {
+    const restore = EDITOR.slice(EDITOR.indexOf("const doc = await loadDocument()"), EDITOR.indexOf("if (Array.isArray(doc.sections)"));
+    expect(restore).toContain("if (!doc) {");
+    expect(restore).toContain("Showing a placeholder background");
+  });
+
+  it("says which half came back when the background did not", () => {
+    // "Restored" over a placeholder is the same lie as "Saved" over a dropped background.
+    expect(EDITOR).toContain("let backgroundRestored = false;");
+    expect(EDITOR).toContain("Restored your text, but the background is gone from this browser");
+    expect(EDITOR).toMatch(/if \(backgroundRestored\) \{\s*toast\.info\("Restored what you were working on"\);/);
+  });
+});

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -339,7 +339,13 @@ function EditorInner() {
     (async () => {
       try {
         const doc = await loadDocument().catch(() => null);
-        if (cancelled || !doc) return;
+        if (cancelled) return;
+        if (!doc) {
+          // Nothing in the URL and nothing saved: this is the one case that is really
+          // empty, and the only moment the editor knows it.
+          toast.info("Showing a placeholder background - pick a template or a style to replace it");
+          return;
+        }
 
         if (Array.isArray(doc.sections) && doc.sections.length) {
           const restored = doc.sections as Section[];
@@ -366,10 +372,12 @@ function EditorInner() {
         const storedFrames = doc.framesKey ? await loadFrames(doc.framesKey).catch(() => null) : null;
         const storedMobile = await loadFrames(SAVED_MOBILE_FRAMES_KEY).catch(() => null);
         if (cancelled) return;
+        let backgroundRestored = false;
         if (storedFrames?.length) {
           setFrames(storedFrames);
           setFrameCount(storedFrames.length);
           setIsDemo(false);
+          backgroundRestored = true;
           if (storedMobile?.length) setMobileFrames(storedMobile);
         } else if (recipe) {
           const mob = window.innerWidth < 768;
@@ -382,9 +390,17 @@ function EditorInner() {
             setFrames(regen);
             setFrameCount(regen.length);
             setIsDemo(false);
+            backgroundRestored = true;
           }
         }
-        if (!cancelled) toast.info("Restored what you were working on");
+        if (cancelled) return;
+        if (backgroundRestored) {
+          toast.info("Restored what you were working on");
+        } else {
+          // The text came back and the background did not: say which, rather than
+          // "Restored" over a placeholder.
+          toast.warning("Restored your text, but the background is gone from this browser. Pick a template or a style to make a new one.");
+        }
       } catch {
         // A restore failure is not fatal: the editor simply opens empty.
       } finally {
@@ -392,14 +408,6 @@ function EditorInner() {
       }
     })();
     return () => { cancelled = true; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Show demo toast once on mount — but not when reopening a saved site (it hydrates async)
-  useEffect(() => {
-    if (initialIsDemo) {
-      toast.info("Showing a placeholder background — pick a template or a style to replace it");
-    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
The placeholder toast fired from a mount-time effect keyed on `initialIsDemo` — which is just "the URL carried no frames":

```ts
useEffect(() => {
  if (initialIsDemo) {
    toast.info("Showing a placeholder background — pick a template or a style to replace it");
  }
}, []);
```

That is true of **every template open**, so it told someone who had just picked a template to pick a template. And it is true of **every cold open**, where it then sat next to `"Restored what you were working on"` — two messages contradicting each other about the same screen.

Whether the editor is actually empty is only knowable once the restore has looked in IndexedDB, so the decision moved there. Nothing in the URL *and* nothing saved is the one case that is genuinely empty.

## The restore also overstated what it recovered

It said "Restored what you were working on" even when only the text came back and the background was gone — the same lie as "Saved" over a dropped background, which #362 fixed on the write side. It now names which half survived.

## Measured in Chrome

Polling for toasts over the first six seconds of each load, against a production build:

| opening | before | after |
| --- | --- | --- |
| `?template=orbitcrm`, saved doc present | "pick a template or a style" | **none** |
| `/editor`, saved doc present | both messages at once | **"Restored what you were working on"** |
| `/editor`, fresh profile, nothing saved | "pick a template or a style" | **"pick a template or a style"** |

The last row is the one that had to keep working — a guard against fixing the noise by deleting the message.

Three new tests in `editorAutosave.test.ts`, all failing on `main`. Suite 347 passed.