### PR TITLE
Give the display type one definition, shared by preview and export

### DIFF
--- a/src/__tests__/displayParity.test.ts
+++ b/src/__tests__/displayParity.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { DISPLAY_STYLES, displayStyle } from "@/lib/displayStyles";
+
+/**
+ * The preview has to predict the ZIP.
+ *
+ * Measured by rendering the same template in both and diffing computed style, property
+ * by property, across text-align, padding, max-width, flex alignment, heading weight /
+ * tracking / case / size / colour, body colour / size / measure / margins, image width
+ * and CTA radius. On the previous build orbitcrm differed on exactly one: a statement
+ * heading's letter-spacing, -4.224px in the preview against -6.336px in the export,
+ * because the preview branched on `kind` for size and line-height but not for weight or
+ * tracking. Both now read DISPLAY_STYLES, and orbitcrm, tripvault, meridian-watch and
+ * ledger-fintech all come out at zero differences.
+ */
+const PREVIEW = readFileSync("src/components/SiteRenderer.tsx", "utf8");
+const ROUTE = readFileSync("src/app/api/export-site/route.ts", "utf8");
+
+describe("the display treatment has one definition", () => {
+  it("gives a statement tighter tracking and less weight than an ordinary heading", () => {
+    // The reason the two differ at all: a statement is set far larger.
+    expect(DISPLAY_STYLES.statement.letterSpacing).toContain("-0.045em");
+    expect(DISPLAY_STYLES.heading.letterSpacing).toContain("-0.03em");
+    expect(DISPLAY_STYLES.statement.fontWeight).toContain("800");
+    expect(DISPLAY_STYLES.heading.fontWeight).toContain("900");
+    expect(DISPLAY_STYLES.statement.lineHeight).toBeLessThan(DISPLAY_STYLES.heading.lineHeight);
+  });
+
+  it("lets a theme override every default", () => {
+    // A theme that sets displayWeight or displayTracking must still win in both paths.
+    for (const s of [DISPLAY_STYLES.heading, DISPLAY_STYLES.statement]) {
+      expect(s.fontWeight).toContain("var(--sc-display-weight");
+      expect(s.letterSpacing).toContain("var(--sc-display-tracking");
+    }
+  });
+
+  it("routes an unknown kind to the ordinary heading", () => {
+    expect(displayStyle(undefined)).toBe(DISPLAY_STYLES.heading);
+    expect(displayStyle("text")).toBe(DISPLAY_STYLES.heading);
+    expect(displayStyle("statement")).toBe(DISPLAY_STYLES.statement);
+  });
+
+  it("is read by the preview rather than restated", () => {
+    expect(PREVIEW).toContain('from "@/lib/displayStyles"');
+    expect(PREVIEW).toContain("displayStyle(s.kind).letterSpacing");
+    expect(PREVIEW).toContain("displayStyle(s.kind).fontWeight");
+    // The literals that used to live here are what drifted.
+    expect(PREVIEW).not.toContain("-0.03em");
+    expect(PREVIEW).not.toContain("clamp(2.75rem,11vw,9rem)");
+  });
+
+  it("is read by the exporter rather than restated", () => {
+    expect(ROUTE).toContain('from "@/lib/displayStyles"');
+    expect(ROUTE).toContain("const H = displayStyle(s.kind);");
+    expect(ROUTE).toContain("${DISPLAY_STYLES.statement.letterSpacing}");
+    expect(ROUTE).not.toContain("-0.045em");
+  });
+});

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/logger";
 import { rateLimit, getClientIp } from "@/lib/rateLimit";
 import { REVEALS, exportSectionsSchema, type Section, visibleSections as onlyVisible } from "@/lib/siteSchema";
 import { layoutStyle } from "@/lib/layoutStyles";
+import { DISPLAY_STYLES, displayStyle } from "@/lib/displayStyles";
 import { parseThemeJson, parseStyleJson } from "@/lib/siteSchema";
 import { proceduralRuntimeSource } from "@/lib/generate2DFrames";
 import { compileTheme, varsToCss } from "@/lib/themeCss";
@@ -252,6 +253,7 @@ export async function POST(req: NextRequest) {
 
     const sectionsHtml = visibleSections.map((s: Section, sectionIndex: number) => {
       const L = layoutFor(s);
+      const H = displayStyle(s.kind);
       const stack = L.textAlign === "center" ? "0 auto 1.5rem" : "0 0 1.5rem";
       const imgSrc = exportableImage(s.image);
       const imgWidth = Math.min(Number(s.imageWidth) || 480, 1600);
@@ -270,7 +272,7 @@ export async function POST(req: NextRequest) {
           ${s.eyebrow ? `<p class="eyebrow" style="font-size:0.875rem; font-weight:600; letter-spacing:0.1em; text-transform:uppercase; color:${safeCss(s.accentColor || "var(--sc-accent-text, #ede9fe)")}; margin-bottom:0.75rem;">${esc(s.eyebrow)}</p>` : ""}
           ${s.heading ? (s.kind === "statement"
             ? `<${hTag} class="sc-display sc-statement" style="color:${safeCss(s.headingColor || "var(--sc-ink, #ffffff)")}; margin-bottom:1rem;">${esc(s.heading)}</${hTag}>`
-            : `<${hTag} class="sc-display" style="font-size:var(--sc-heading-size, clamp(2rem,5vw,4rem)); font-weight:var(--sc-display-weight, 900); line-height:1; letter-spacing:var(--sc-display-tracking, -0.03em); text-transform:var(--sc-display-case, none); color:${safeCss(s.headingColor || "var(--sc-ink, #ffffff)")}; margin-bottom:1rem;">${esc(s.heading)}</${hTag}>`) : ""}
+            : `<${hTag} class="sc-display" style="font-size:${H.fontSize}; font-weight:${H.fontWeight}; line-height:${H.lineHeight}; letter-spacing:${H.letterSpacing}; text-transform:var(--sc-display-case, none); color:${safeCss(s.headingColor || "var(--sc-ink, #ffffff)")}; margin-bottom:1rem;">${esc(s.heading)}</${hTag}>`) : ""}
           ${s.body ? `<p style="font-size:var(--sc-body-size, 1.125rem); line-height:1.7; color:${safeCss(s.bodyColor || "var(--sc-muted, rgba(255,255,255,0.72))")}; max-width:var(--sc-measure, 600px); margin:${stack};">${esc(s.body)}</p>` : ""}
           ${s.ctaLabel ? `<a href="${esc(safeHref(s.ctaHref || "#"))}" style="display:inline-block; background:${safeCss(s.accentColor || "var(--sc-accent, #7c3aed)")}; color:white; padding:0.875rem 2rem; border-radius:var(--sc-radius, 8px); font-weight:600; text-decoration:none; font-size:1rem;">${esc(s.ctaLabel)}</a>` : ""}
         </div>
@@ -331,7 +333,7 @@ export async function POST(req: NextRequest) {
     .section-content[data-reveal="stagger"].visible > *:nth-child(3) { transition-delay: 180ms; }
     .section-content[data-reveal="stagger"].visible > *:nth-child(n+4) { transition-delay: 270ms; }
     .sc-display { font-family: var(--sc-font-display, var(--sc-font-body, system-ui, sans-serif)); }
-    .sc-statement { font-size: clamp(2.75rem, 11vw, 9rem); font-weight: var(--sc-display-weight, 800); line-height: 0.92; letter-spacing: var(--sc-display-tracking, -0.045em); text-transform: var(--sc-display-case, none); margin: 0; }
+    .sc-statement { font-size: ${DISPLAY_STYLES.statement.fontSize}; font-weight: ${DISPLAY_STYLES.statement.fontWeight}; line-height: ${DISPLAY_STYLES.statement.lineHeight}; letter-spacing: ${DISPLAY_STYLES.statement.letterSpacing}; text-transform: var(--sc-display-case, none); margin: 0; }
     @media (prefers-reduced-motion: reduce) {
       .section-content[data-reveal], .section-content[data-reveal="stagger"] > * {
         opacity: 1 !important; transform: none !important; clip-path: none !important; transition: none !important;

--- a/src/components/SiteRenderer.tsx
+++ b/src/components/SiteRenderer.tsx
@@ -7,6 +7,7 @@ import ScrollEngine from "@/components/ScrollEngine";
 import { generate2DFrames } from "@/lib/generate2DFrames";
 import { loadFrames, storeFrames } from "@/lib/frameStorage";
 import { layoutStyle } from "@/lib/layoutStyles";
+import { displayStyle } from "@/lib/displayStyles";
 
 const REVEAL_CSS = `
 .sc-reveal{opacity:0;will-change:opacity,transform;transition:opacity .6s cubic-bezier(.25,.46,.45,.94),transform .6s cubic-bezier(.25,.46,.45,.94),clip-path .7s cubic-bezier(.25,.46,.45,.94)}
@@ -271,12 +272,10 @@ export default function SiteRenderer({
                   {s.heading && (
                     <Heading style={{
                       fontFamily: "var(--sc-font-display, var(--sc-font-body, inherit))",
-                      fontSize: s.kind === "statement"
-                        ? "clamp(2.75rem,11vw,9rem)"
-                        : "var(--sc-heading-size, clamp(2rem,5vw,4rem))",
-                      fontWeight: "var(--sc-display-weight, 900)" as unknown as number,
-                      lineHeight: s.kind === "statement" ? 0.92 : 1,
-                      letterSpacing: "var(--sc-display-tracking, -0.03em)",
+                      fontSize: displayStyle(s.kind).fontSize,
+                      fontWeight: displayStyle(s.kind).fontWeight as unknown as number,
+                      lineHeight: displayStyle(s.kind).lineHeight,
+                      letterSpacing: displayStyle(s.kind).letterSpacing,
                       textTransform: "var(--sc-display-case, none)" as "none" | "uppercase",
                       color: s.headingColor ?? "var(--sc-ink, #fff)",
                       marginBottom: "1rem",

--- a/src/lib/displayStyles.ts
+++ b/src/lib/displayStyles.ts
@@ -1,0 +1,37 @@
+/**
+ * The display-type treatment, shared by the editor preview and the exporter.
+ *
+ * A statement section is set much larger than an ordinary heading, so it wants tighter
+ * tracking, a shorter line and slightly less weight. The exporter had all four of those;
+ * the preview branched on size and line-height only and left a statement at the ordinary
+ * heading's weight and tracking, so the preview promised looser type than the ZIP
+ * delivered. Both now read these, the way both already read layoutStyles.
+ *
+ * Every field is a CSS value with the theme's custom property first, so a theme that sets
+ * displayWeight or displayTracking still wins.
+ */
+export interface DisplayStyle {
+  fontSize: string;
+  fontWeight: string;
+  lineHeight: number;
+  letterSpacing: string;
+}
+
+export const DISPLAY_STYLES: Record<"heading" | "statement", DisplayStyle> = {
+  heading: {
+    fontSize: "var(--sc-heading-size, clamp(2rem,5vw,4rem))",
+    fontWeight: "var(--sc-display-weight, 900)",
+    lineHeight: 1,
+    letterSpacing: "var(--sc-display-tracking, -0.03em)",
+  },
+  statement: {
+    fontSize: "clamp(2.75rem,11vw,9rem)",
+    fontWeight: "var(--sc-display-weight, 800)",
+    lineHeight: 0.92,
+    letterSpacing: "var(--sc-display-tracking, -0.045em)",
+  },
+};
+
+export function displayStyle(kind: string | undefined): DisplayStyle {
+  return kind === "statement" ? DISPLAY_STYLES.statement : DISPLAY_STYLES.heading;
+}


### PR DESCRIPTION
The preview's job is to predict the ZIP, so I built a harness that checks it: render the same template in the editor preview (`SiteRenderer`, at `/templates/<slug>`) and in the **exported page**, then diff computed style property by property — `text-align`, padding, `max-width`, flex alignment, heading weight / tracking / case / size / colour, body colour / size / measure / margins, image width, CTA radius.

## What it found

On orbitcrm, exactly one difference:

```
section 0 <H1> "Close deals at the speed of "
    head.letterSpacing:  preview=-4.224px   export=-6.336px
```

The exporter gives a statement section its own treatment, because it is set far larger:

| | ordinary heading | statement |
| --- | --- | --- |
| font-size | `var(--sc-heading-size, clamp(2rem,5vw,4rem))` | `clamp(2.75rem,11vw,9rem)` |
| font-weight | `var(--sc-display-weight, 900)` | `var(--sc-display-weight, 800)` |
| line-height | 1 | 0.92 |
| letter-spacing | `var(--sc-display-tracking, -0.03em)` | `var(--sc-display-tracking, -0.045em)` |

The preview branched on `kind` for **size and line-height only**, leaving weight and tracking at the ordinary heading's values — so it promised looser type than the ZIP delivered. Six of the 21 templates set no `displayTracking`, and 17 have a statement section, so this was live.

Both paths now read `DISPLAY_STYLES` from `src/lib/displayStyles.ts`, the way both already read `layoutStyles`. A theme's own `displayWeight` / `displayTracking` still wins in both.

## Verified across four templates

Exported through the real button, unzipped, served, compared against the preview:

| template | statements | layouts | sets tracking | differences |
| --- | --- | --- | --- | --- |
| orbitcrm | 1 | center, left, right | no | **0** |
| tripvault | 1 | center, left | no | **0** |
| meridian-watch | 1 | center, left, right | yes | **0** |
| ledger-fintech | 0 | upper-third, center | no | **0** |

Between them: statement and ordinary headings, five layouts, a theme that sets tracking and three that don't, and an uppercase display case.

## A note on the harness

My first multi-template run reported 30 and 45 differences. Those were false: reusing one browser across runs, the script latched onto a **stale** `downloadProgress` event and compared the *previous* template's ZIP — tripvault's "export" contained ledger-fintech's headings, and its download reported 0.5s against the usual 2.5s. The harness now clears events before clicking and refuses to compare unless the ZIP's `<h1>` matches the template it asked for. With that guard, all four are zero.

Two of the five new tests fail on `main`. Suite 349 passed.