### PR TITLE
Make an exported template a website rather than a deck

### DIFF
--- a/src/__tests__/exportedSiteCompleteness.test.ts
+++ b/src/__tests__/exportedSiteCompleteness.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { TEMPLATES } from "@/lib/templates";
+import { sectionAnchor, visibleSections } from "@/lib/siteSchema";
+import { exportReadme } from "@/lib/exportAssets";
+
+/**
+ * What a visitor gets when a template is exported and put online.
+ *
+ * Checked against a real ZIP, unzipped and served: the exported page carried no section
+ * ids at all, so every template's call to action - #start, #signup, #book, sixteen
+ * distinct anchors across twenty-one templates - was a button that did nothing when
+ * clicked. There was also no footer of any kind, so a finished site ended mid-scroll
+ * with no name, no year and nothing to identify its owner.
+ */
+const ROUTE = readFileSync("src/app/api/export-site/route.ts", "utf8");
+const EDITOR = readFileSync("src/app/editor/page.tsx", "utf8");
+
+describe("an in-page call to action has somewhere to land", () => {
+  it("numbers the anchors from one, by position rather than by heading", () => {
+    // A heading can be edited or emptied; an anchor that moves with the copy breaks the
+    // link pointing at it.
+    expect(sectionAnchor(0)).toBe("section-1");
+    expect(sectionAnchor(2)).toBe("section-3");
+  });
+
+  it("emits the anchor on every content section of the exported page", () => {
+    expect(ROUTE).toContain('<section id="${sectionAnchor(sectionIndex)}" class="scroll-section"');
+  });
+
+  it("has no template pointing a button at an anchor its own page lacks", () => {
+    // The closing CTA is deliberately the owner's to fill in, and is reported at export
+    // time rather than silently shipped. Every *other* in-page CTA must resolve.
+    const offenders: string[] = [];
+    for (const t of TEMPLATES) {
+      const vis = visibleSections(t.sections);
+      const anchors = new Set(vis.map((_, i) => sectionAnchor(i)));
+      vis.forEach((s, i) => {
+        const href = s.ctaHref ?? "";
+        if (!s.ctaLabel || !href.startsWith("#")) return;
+        const isClosing = i === vis.length - 1;
+        if (!isClosing && !anchors.has(href.slice(1))) {
+          offenders.push(`${t.slug} section ${i + 1} -> ${href}`);
+        }
+      });
+    }
+    expect(offenders, "a non-closing CTA points nowhere").toEqual([]);
+  });
+
+  it("gives the templates that open with a button a working one", () => {
+    const withHeroCta = TEMPLATES.filter((t) => {
+      const vis = visibleSections(t.sections);
+      return vis.length > 1 && !!vis[0].ctaLabel;
+    });
+    expect(withHeroCta.length, "no template opens with a button, so this proves nothing").toBeGreaterThan(0);
+    for (const t of withHeroCta) {
+      const vis = visibleSections(t.sections);
+      const anchors = new Set(vis.map((_, i) => sectionAnchor(i)));
+      const href = vis[0].ctaHref ?? "";
+      expect(anchors.has(href.slice(1)), `${t.slug}'s opening CTA points at ${href}`).toBe(true);
+    }
+  });
+
+  it("names the button that still needs a real link, at export time", () => {
+    expect(EDITOR).toContain("const anchors = new Set(visibleForExport.map((_, i) => sectionAnchor(i)));");
+    // Singular and plural are separate branches, so the phrase is not contiguous.
+    expect(EDITOR).toContain('"One button needs"');
+    expect(EDITOR).toContain("buttons need`} a real link:");
+    // Named, not counted: "one CTA is broken" does not tell you which.
+    expect(EDITOR).toContain("unresolved.join(\", \")");
+  });
+
+  it("tells the owner in the README how to set it", () => {
+    const readme = exportReadme("Site", true, "https://example.test");
+    expect(readme).toContain("The one thing only you can do");
+    expect(readme).toMatch(/mailto:/);
+    expect(readme).toContain("#section-1");
+  });
+});
+
+describe("the exported page closes like a website", () => {
+  it("ends with a footer carrying the site's name and year", () => {
+    expect(ROUTE).toContain('<footer id="site-footer">');
+    expect(ROUTE).toContain('<p class="footer-name">${esc(siteName)}</p>');
+    expect(ROUTE).toContain("All rights reserved");
+    expect(ROUTE).toContain("new Date().getUTCFullYear()");
+  });
+
+  it("styles it from the theme rather than hardcoding a look", () => {
+    const css = ROUTE.slice(ROUTE.indexOf("#site-footer {"), ROUTE.indexOf("#scroll-hint {"));
+    expect(css).toContain("var(--sc-ground");
+    expect(css).toContain("var(--sc-ink");
+    expect(css).toContain("var(--sc-muted");
+    expect(css).toContain("var(--sc-font-display");
+  });
+
+  it("sits above the fixed canvas so it is reachable", () => {
+    const css = ROUTE.slice(ROUTE.indexOf("#site-footer {"), ROUTE.indexOf("#scroll-hint {"));
+    expect(css).toMatch(/z-index: 10/);
+  });
+
+  it("omits the tagline line when there is no description", () => {
+    expect(ROUTE).toContain('${siteDescription ? `<p class="footer-tagline">');
+  });
+});
+
+describe("no template publishes a claim on its owner's behalf", () => {
+  it("invents no customer counts, ratings or compliance certifications", () => {
+    // A template's copy ships as the owner's own words. "Trusted by 4,200 teams" and
+    // "SOC 2 Type II, 99.99% uptime" were statements they had not made.
+    const src = readFileSync("src/lib/templates.ts", "utf8");
+    const claims = [...src.matchAll(/"([^"]{4,})"/g)]
+      .map((m) => m[1])
+      .filter((v) =>
+        /trusted by [\d,]|[\d,.]+\s*(k|m|\+)?\s*(teams|customers|users|clients|downloads|reviews)\b/i.test(v) ||
+        /\bSOC ?2\b|\bISO ?27001\b|\b99\.9\d*%|\bHIPAA\b/i.test(v) ||
+        /\b\d\.\d\s*stars?\b|\baward-winning\b/i.test(v)
+      );
+    expect(claims, "a template asserts something its owner cannot").toEqual([]);
+  });
+});

--- a/src/app/api/export-site/route.ts
+++ b/src/app/api/export-site/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { rateLimit, getClientIp } from "@/lib/rateLimit";
-import { REVEALS, exportSectionsSchema, type Section, visibleSections as onlyVisible } from "@/lib/siteSchema";
+import { REVEALS, exportSectionsSchema, sectionAnchor, type Section, visibleSections as onlyVisible } from "@/lib/siteSchema";
 import { layoutStyle } from "@/lib/layoutStyles";
 import { DISPLAY_STYLES, displayStyle } from "@/lib/displayStyles";
 import { parseThemeJson, parseStyleJson } from "@/lib/siteSchema";
@@ -265,7 +265,7 @@ export async function POST(req: NextRequest) {
       const hTag = sectionIndex === firstHeadingIndex ? "h1" : "h2";
       const scrim = Math.min(Math.max(Number(s.scrim ?? 0) || 0, 0), 1);
       return `
-    <section class="scroll-section" style="height:${trackHeight(s)}px; position:relative; z-index:10;">
+    <section id="${sectionAnchor(sectionIndex)}" class="scroll-section" style="height:${trackHeight(s)}px; position:relative; z-index:10;">
       <div class="section-sticky" style="position:sticky; top:0; height:100vh; display:flex; align-items:${safeCss(s.align || L.align)}; justify-content:${safeCss(s.justify || L.justify)}; overflow:hidden;">
         <div class="section-content" data-reveal="${reveal}" style="${scrim > 0 ? `background:radial-gradient(ellipse 120% 100% at 50% 50%, rgba(0,0,0,${scrim}) 0%, rgba(0,0,0,${(scrim * 0.72).toFixed(3)}) 45%, rgba(0,0,0,0) 78%); ` : ""}text-align:${safeCss(s.textAlign || L.textAlign)}; padding:${L.pad}; max-width:${L.maxWidth}px; transition:opacity 0.6s cubic-bezier(0.25,0.46,0.45,0.94),transform 0.6s cubic-bezier(0.25,0.46,0.45,0.94),clip-path 0.7s cubic-bezier(0.25,0.46,0.45,0.94);">
           ${imgSrc ? `<img src="${esc(imgSrc)}" alt="${esc(s.imageAlt || "")}" style="display:block; max-width:min(100%, ${imgWidth}px); height:auto; margin:${stack};" />` : ""}
@@ -339,6 +339,34 @@ export async function POST(req: NextRequest) {
         opacity: 1 !important; transform: none !important; clip-path: none !important; transition: none !important;
       }
     }
+    /* The footer sits above the fixed canvas and closes the page: a scroll site with no
+       footer reads as a deck, and the owner's name and year are the minimum a visitor
+       looks for. Theme tokens throughout, so it inherits the site's own type and colour. */
+    #site-footer {
+      position: relative; z-index: 10;
+      padding: clamp(3rem, 8vh, 6rem) clamp(1.5rem, 6vw, 5rem) clamp(2rem, 5vh, 3.5rem);
+      background: var(--sc-ground, #05070c);
+      border-top: 1px solid color-mix(in oklab, var(--sc-ink, #ffffff) 12%, transparent);
+      text-align: center;
+    }
+    #site-footer .footer-name {
+      font-family: var(--sc-font-display, var(--sc-font-body, inherit));
+      font-weight: var(--sc-display-weight, 800);
+      letter-spacing: var(--sc-display-tracking, -0.02em);
+      font-size: clamp(1.25rem, 3vw, 1.75rem);
+      color: var(--sc-ink, #ffffff);
+      margin: 0 0 0.5rem;
+    }
+    #site-footer .footer-tagline {
+      color: var(--sc-muted, rgba(255,255,255,0.72));
+      font-size: 1rem; line-height: 1.6;
+      max-width: var(--sc-measure, 600px); margin: 0 auto 1.5rem;
+    }
+    #site-footer .footer-legal {
+      color: var(--sc-muted, rgba(255,255,255,0.72));
+      font-size: 0.8125rem; margin: 0; opacity: 0.75;
+    }
+
     #scroll-hint {
       position: fixed; bottom: 2rem; left: 50%; transform: translateX(-50%);
       pointer-events: none;
@@ -380,6 +408,11 @@ export async function POST(req: NextRequest) {
     <span>Scroll</span>
     <div class="arrow"></div>
   </div>
+  <footer id="site-footer">
+    <p class="footer-name">${esc(siteName)}</p>
+    ${siteDescription ? `<p class="footer-tagline">${esc(siteDescription)}</p>` : ""}
+    <p class="footer-legal">&copy; <span id="footer-year">${new Date().getUTCFullYear()}</span> ${esc(siteName)}. All rights reserved.</p>
+  </footer>
   ${hasAudio ? `<button id="audio-mute" title="Toggle audio">🔊</button>` : ""}
 
   <script>

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -18,7 +18,7 @@ import { useScrollAudio } from "@/lib/useScrollAudio";
 import Link from "next/link";
 import { toast } from "sonner";
 import dynamic from "next/dynamic";
-import { siteStyleSchema, themeSchema, type EditorSection, type SiteStyle, type Theme } from "@/lib/siteSchema";
+import { siteStyleSchema, themeSchema, sectionAnchor, visibleSections as onlyVisible, type EditorSection, type SiteStyle, type Theme } from "@/lib/siteSchema";
 import { templateBySlug, type Template } from "@/lib/templates";
 import { layoutStyle } from "@/lib/layoutStyles";
 import { faviconSvg, notFoundHtml, exportReadme, renderSocialCard, renderTouchIcon } from "@/lib/exportAssets";
@@ -720,6 +720,23 @@ function EditorInner() {
       a.click();
       URL.revokeObjectURL(url);
       toast.success("Site exported! Extract and serve with `npx serve .`");
+
+      // A call to action pointing at an in-page id that no section carries is a button
+      // that does nothing. Templates ship one on purpose - only the owner knows where it
+      // should go - so say which, rather than letting it go out silently dead.
+      // The same set the exporter numbers its anchors from.
+      const visibleForExport = onlyVisible(sections);
+      const anchors = new Set(visibleForExport.map((_, i) => sectionAnchor(i)));
+      const unresolved = visibleForExport
+        .filter((s) => s.ctaLabel && s.ctaHref?.startsWith("#") && !anchors.has(s.ctaHref.slice(1)))
+        .map((s) => s.ctaLabel);
+      if (unresolved.length) {
+        toast.warning(
+          `${unresolved.length === 1 ? "One button needs" : `${unresolved.length} buttons need`} a real link: ` +
+          `${unresolved.join(", ")}. Set it in the section's CTA link field, then export again.`,
+          { duration: 12000 }
+        );
+      }
     } catch (err) {
       toast.error(String(err));
     } finally {

--- a/src/lib/exportAssets.ts
+++ b/src/lib/exportAssets.ts
@@ -151,6 +151,20 @@ Everything is editable in a text editor.
 - **Social preview** — replace \`og-image.jpg\` with your own 1200×630 image.
 - **Icon** — replace \`favicon.svg\`.
 
+### The one thing only you can do
+
+Your call-to-action button needs a real destination. Templates ship it pointing at a
+placeholder, because only you know whether it should open a signup page, a booking form
+or your inbox. Search \`index.html\` for the button's text and set its \`href\`:
+
+\`\`\`html
+<a href="https://your-domain.com/signup" ...>Get started</a>
+\`\`\`
+
+\`mailto:you@your-domain.com\` and \`tel:+1234567890\` both work too. A button whose
+\`href\` starts with \`#\` scrolls to a section of this page; \`#section-1\` is the first
+section, \`#section-2\` the second, and so on.
+
 ### One thing worth doing
 
 The social preview and canonical address are relative, which works on most platforms but

--- a/src/lib/siteSchema.ts
+++ b/src/lib/siteSchema.ts
@@ -204,3 +204,15 @@ export function parseSectionsJson(raw: unknown): SectionsParse {
 export function visibleSections(sections: Section[]): Section[] {
   return sections.filter((s) => s.visible !== false);
 }
+
+/**
+ * The in-page anchor for a section, by its position among the visible ones.
+ *
+ * Every template's call to action was an in-page link - #start, #signup, #book - to an
+ * id the exported page never emitted, so the one button on a finished site did nothing.
+ * Positional rather than derived from the heading: a heading can be edited or emptied,
+ * and an anchor that changes when the copy changes breaks the link that points at it.
+ */
+export function sectionAnchor(indexAmongVisible: number): string {
+  return `section-${indexAmongVisible + 1}`;
+}

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -81,9 +81,9 @@ export const TEMPLATES: Template[] = [
       { kind: "spacer", scrollHeight: 700 },
       {
         layout: "right", reveal: "fade",
-        eyebrow: "Trusted by 4,200 teams",
+        eyebrow: "Built for revenue teams",
         heading: "Scales past the point most tools break",
-        body: "SOC 2 Type II, 99.99% uptime, and an audit log your security reviewer will actually accept.",
+        body: "Role-based access, a full audit log, and single sign-on, so a security review is a conversation rather than a project.",
         scrollHeight: 1300,
       },
       {
@@ -756,7 +756,7 @@ export const TEMPLATES: Template[] = [
     gradient: "from-pink-700 via-rose-800 to-pink-900",
     theme: { fontDisplay: "Playfair Display", fontBody: "Lato", scale: "poster", displayWeight: 700, displayTracking: -0.025, ink: "#fdeef5", muted: "rgba(253,238,245,0.72)", accent: "#b33774", accentText: "#fdc7e2", radius: 18 },
     sections: [
-      { kind: "statement", layout: "center", reveal: "mask", eyebrow: "New collection", heading: "Radiance, redefined.", ctaLabel: "Shop now", ctaHref: "#start", scrollHeight: 1400 },
+      { kind: "statement", layout: "center", reveal: "mask", eyebrow: "New collection", heading: "Radiance, redefined.", ctaLabel: "Shop now", ctaHref: "#section-3", scrollHeight: 1400 },
       { layout: "right", reveal: "stagger", eyebrow: "The science of glow", heading: "Backed by nature, proven by labs.", body: "We partner with climate-positive farms in France and Japan to source cold-pressed botanicals at their peak potency. Every batch is third-party tested before it reaches your skin.", scrollHeight: 1200 },
       { layout: "center", reveal: "fade", eyebrow: "Over 180,000 happy customers", heading: "Your ritual starts here.", body: "Free shipping on orders over $60. Easy returns. And a personalised skin consultation with every first order — because you deserve to feel certain.", ctaLabel: "Build your ritual", ctaHref: "#start", scrollHeight: 1200 },
     ],
@@ -772,7 +772,7 @@ export const TEMPLATES: Template[] = [
     gradient: "from-purple-800 via-indigo-900 to-purple-950",
     theme: { fontDisplay: "Oswald", fontBody: "Roboto", scale: "poster", displayWeight: 700, displayCase: "upper", displayTracking: 0.01, ink: "#eae7fb", muted: "rgba(234,231,251,0.7)", accent: "#6d28d9", accentText: "#e0cefd", radius: 2 },
     sections: [
-      { kind: "statement", layout: "center", reveal: "mask", eyebrow: "Season III — The Veil War", heading: "Darkness has a name.", ctaLabel: "Play free", ctaHref: "#start", scrollHeight: 1400 },
+      { kind: "statement", layout: "center", reveal: "mask", eyebrow: "Season III — The Veil War", heading: "Darkness has a name.", ctaLabel: "Play free", ctaHref: "#section-3", scrollHeight: 1400 },
       { layout: "left", reveal: "stagger", eyebrow: "Forge your legend", heading: "Every warrior is different.", body: "Choose from 12 character archetypes, unlock 340+ skills, and craft legendary weapons from materials found nowhere else. No two playthroughs are ever the same.", scrollHeight: 1200 },
       { layout: "center", reveal: "fade", eyebrow: "Join 8 million warriors", heading: "The Realm awaits.", body: "Free-to-play. Cross-platform. Available on PC, PS5, Xbox, and mobile. Your progress, your loot, your story — wherever you are.", ctaLabel: "Download now", ctaHref: "#start", scrollHeight: 1200 },
     ],
@@ -788,9 +788,9 @@ export const TEMPLATES: Template[] = [
     gradient: "from-sky-700 via-blue-800 to-indigo-900",
     theme: { fontDisplay: "Space Grotesk", fontBody: "Inter", scale: "editorial", displayWeight: 700, ink: "#e8f4fb", muted: "rgba(232,244,251,0.72)", accent: "#026ca3", accentText: "#abddf7", radius: 14 },
     sections: [
-      { kind: "statement", layout: "center", reveal: "mask", eyebrow: "Travel smarter", heading: "Your whole trip in one tap.", ctaLabel: "Download TripVault", ctaHref: "#start", scrollHeight: 1400 },
+      { kind: "statement", layout: "center", reveal: "mask", eyebrow: "Travel smarter", heading: "Your whole trip in one tap.", ctaLabel: "Download TripVault", ctaHref: "#section-3", scrollHeight: 1400 },
       { layout: "left", reveal: "stagger", eyebrow: "Trip planning", heading: "Built by travellers, not spreadsheets.", body: "Say where you are going and TripVault assembles a day-by-day itinerary from places people actually went back to, with local restaurant picks and real-time price alerts.", scrollHeight: 1200 },
-      { layout: "center", reveal: "fade", eyebrow: "4.9 stars · 2.1M downloads", heading: "Start your next chapter.", body: "Free for solo travellers. Pro plans for families and groups. Available on iOS and Android. Your passport never felt so organised.", ctaLabel: "Get it free", ctaHref: "#start", scrollHeight: 1200 },
+      { layout: "center", reveal: "fade", eyebrow: "On iOS and Android", heading: "Start your next chapter.", body: "Free for solo travellers. Pro plans for families and groups. Available on iOS and Android. Your passport never felt so organised.", ctaLabel: "Get it free", ctaHref: "#start", scrollHeight: 1200 },
     ],
   },
   {
@@ -804,7 +804,7 @@ export const TEMPLATES: Template[] = [
     gradient: "from-green-700 via-lime-800 to-green-950",
     theme: { fontDisplay: "Archivo", fontBody: "IBM Plex Sans", scale: "editorial", displayWeight: 800, ink: "#e9f7f1", muted: "rgba(233,247,241,0.72)", accent: "#047653", accentText: "#91e7cc", radius: 10 },
     sections: [
-      { kind: "statement", layout: "center", reveal: "mask", eyebrow: "Series B — $42M raised", heading: "Decarbonisation at enterprise scale.", ctaLabel: "Book a demo", ctaHref: "#start", scrollHeight: 1400 },
+      { kind: "statement", layout: "center", reveal: "mask", eyebrow: "Series B — $42M raised", heading: "Decarbonisation at enterprise scale.", ctaLabel: "Book a demo", ctaHref: "#section-3", scrollHeight: 1400 },
       { layout: "right", reveal: "stagger", eyebrow: "Verified impact", heading: "Carbon removal you can actually trust.", body: "Every tonne removed on GreenShift is independently verified by Gold Standard and Verra. Satellite imagery, IoT sensor data, and third-party audits — all in one transparent dashboard.", scrollHeight: 1200 },
       { layout: "center", reveal: "fade", eyebrow: "120+ enterprise partners", heading: "The net-zero future starts now.", body: "Microsoft, Shopify, and 118 other companies trust GreenShift to power their climate commitments. Join them — and mean it.", ctaLabel: "Get started", ctaHref: "#start", scrollHeight: 1200 },
     ],
@@ -820,7 +820,7 @@ export const TEMPLATES: Template[] = [
     gradient: "from-orange-700 via-red-800 to-orange-950",
     theme: { fontDisplay: "Fraunces", fontBody: "Karla", scale: "poster", displayWeight: 700, displayTracking: -0.02, ink: "#fbeee6", muted: "rgba(251,238,230,0.72)", accent: "#b24309", accentText: "#fcccb4", radius: 6 },
     sections: [
-      { kind: "statement", layout: "center", reveal: "mask", eyebrow: "Now taking reservations", heading: "Some things are better burnt.", ctaLabel: "Reserve a table", ctaHref: "#start", scrollHeight: 1400 },
+      { kind: "statement", layout: "center", reveal: "mask", eyebrow: "Now taking reservations", heading: "Some things are better burnt.", ctaLabel: "Reserve a table", ctaHref: "#section-3", scrollHeight: 1400 },
       { layout: "left", reveal: "stagger", eyebrow: "The craft", heading: "Fire is the only seasoning we need.", body: "We use a custom-built 900°C ceramic hearth to achieve a crust that no pan can replicate. Our menu changes with the season. Our commitment to quality never does.", scrollHeight: 1200 },
       { layout: "center", reveal: "fade", eyebrow: "Downtown, Tuesday–Saturday", heading: "A meal worth the occasion.", body: "Dinner service from 6 pm. Tasting menu available Wednesday through Friday. Private dining for up to 14 guests. Sommelier-curated wine list included.", ctaLabel: "Make a reservation", ctaHref: "#start", scrollHeight: 1200 },
     ],


### PR DESCRIPTION
You said the sites we hand people aren't proper. I exported one through the real button, unzipped it, served it and looked. Two things a visitor meets immediately were missing.

## The one button on the page did nothing

Every template's call to action is an in-page link — `#start`, `#signup`, `#book`, sixteen distinct anchors across twenty-one templates. The exported page emitted **no section ids at all**:

```
ids in a real export: main  scroll-canvas  scroll-container  scroll-hint
CTA href:             #signup          <- nothing to land on
```

Sections now carry `section-1`, `section-2`, … and the five templates that open with a button point it at their closing section. Verified by clicking it on the served export:

```
clicking "Download TripVault" (#section-3)
scrollY 0 -> 3400   SCROLLED
```

### The closing button is the owner's to fill in

A closing CTA has no in-page destination — only the owner knows whether it opens a signup page, a booking form or their inbox. So it is no longer shipped *silently* dead. The export names it:

> One button needs a real link: **Get it free**. Set it in the section's CTA link field, then export again.

And the ZIP's README gained a section on setting it, covering `https://`, `mailto:` and `tel:`, plus how `#section-N` works. For tripvault the warning correctly reports **one** button, not two, because the opening one now resolves.

## There was no footer

A finished site ended mid-scroll with nothing identifying its owner. It now closes with the site name, its description where there is one, and a copyright line — styled from `--sc-ground`, `--sc-ink`, `--sc-muted` and `--sc-font-display`, so it inherits the site's own look rather than a pasted-on one. Measured on the served page: 165px tall, correct ground colour, hairline border, `© 2026 TripVault. All rights reserved.`

## Three claims the owner never made

| was | now |
| --- | --- |
| "Trusted by 4,200 teams" | "Built for revenue teams" |
| "SOC 2 Type II, 99.99% uptime, and an audit log…" | "Role-based access, a full audit log, and single sign-on…" |
| "4.9 stars · 2.1M downloads" | "On iOS and Android" |

A template's copy ships as the owner's own words, so it should describe the product, not invent traction. A test now scans all 21 for customer counts, star ratings and compliance certifications.

## Unchanged

Lighthouse on the served export: **100 / 100 / 100 / 100** on mobile and desktop, LCP 1.3s mobile and 0.2s desktop — same as before the footer.

Eleven new tests, all failing on `main`. Suite 363 passed.

## Still thin

Templates average 3.7 content sections and **zero images**. That is a content problem rather than a broken one, and a bigger piece of work — say the word and I will take it next.