### PR TITLE
Make the editor's section list readable at nine sections

### DIFF
--- a/src/__tests__/appAccessibility.test.ts
+++ b/src/__tests__/appAccessibility.test.ts
@@ -176,6 +176,44 @@ describe("the editor is reachable without a mouse", () => {
   });
 });
 
+describe("the editor's section list survives a nine-section template", () => {
+  /**
+   * Templates went from four sections to nine, which turned two small annoyances into
+   * an unusable list. Measured in Chrome on kiln-coffee: seven of nine labels were
+   * clipped to "Roasted t..." and "Light eno...", and two rows were spacers labelled
+   * "Section 4" and "Section 8" whose inspector offered an eyebrow, a heading, a body,
+   * a button and an image - five fields a spacer does not have. After: zero clipped.
+   */
+  const editor = readFileSync("src/app/editor/page.tsx", "utf8");
+
+  it("names a spacer instead of numbering it like content", () => {
+    expect(editor).toContain('<span className="text-xs flex-1 text-muted-foreground italic">Spacer · {s.scrollHeight}px</span>');
+  });
+
+  it("gives a heading the whole row rather than one clipped line", () => {
+    expect(editor).toContain('className="text-xs flex-1 line-clamp-2 leading-snug"');
+    // truncate is one line and was the reason seven of nine were unreadable.
+    expect(editor).not.toMatch(/<span className="text-xs flex-1 truncate">/);
+  });
+
+  it("takes the row controls out of the flow, so they reserve no width", () => {
+    // opacity-0 still occupies layout: four buttons held about 100px of a 224px panel
+    // even while invisible, which is what starved the label.
+    expect(editor).toContain('className="absolute right-1 top-1 flex items-center gap-0.5');
+    expect(editor).not.toMatch(/flex items-center gap-0\.5 flex-shrink-0 opacity-0/);
+    // Absolute positioning needs a containing block on the row.
+    expect(editor).toMatch(/className=\{`group relative flex items-start gap-2/);
+  });
+
+  it("offers a spacer only what a spacer has", () => {
+    const content = editor.slice(editor.indexOf('<TabsContent value="content"'), editor.indexOf('<TabsContent value="style"'));
+    expect(content).toContain('selectedSectionData.kind === "spacer" ?');
+    expect(content).toContain("This is a spacer");
+    // The height, which is the one thing it does have, stays on the Layout tab.
+    expect(editor).toContain('aria-label="Section height in pixels"');
+  });
+});
+
 describe("the editor fits a phone", () => {
   const editor = readFileSync("src/app/editor/page.tsx", "utf8");
 

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1069,13 +1069,21 @@ function EditorInner() {
                 aria-pressed={selectedSection === s.id}
                 onClick={() => setSelectedSection(s.id)}
                 onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setSelectedSection(s.id); } }}
-                className={`group flex items-center gap-2 p-2 rounded-lg cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary ${
+                className={`group relative flex items-start gap-2 p-2 pr-2 rounded-lg cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary ${
                   selectedSection === s.id ? "bg-primary/15 border border-primary/30" : "hover:bg-white/5"
                 }`}
               >
-                <div className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${s.visible ? "bg-primary" : "bg-white/20"}`} />
-                <span className="text-xs flex-1 truncate">{s.heading || `Section ${i + 1}`}</span>
-                <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+                <div className={`w-1.5 h-1.5 rounded-full flex-shrink-0 self-start mt-1.5 ${
+                  s.kind === "spacer" ? "bg-white/15" : s.visible ? "bg-primary" : "bg-white/20"
+                }`} />
+                {s.kind === "spacer" ? (
+                  <span className="text-xs flex-1 text-muted-foreground italic">Spacer · {s.scrollHeight}px</span>
+                ) : (
+                  <span className="text-xs flex-1 line-clamp-2 leading-snug">
+                    {s.heading || `Section ${i + 1}`}
+                  </span>
+                )}
+                <div className="absolute right-1 top-1 flex items-center gap-0.5 rounded-md bg-card/95 backdrop-blur-sm px-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
                   <button onClick={(e) => { e.stopPropagation(); moveSection(s.id, "up"); }} className="p-1.5 hover:text-primary-ink" title="Move up">
                     <ChevronUp className="w-3 h-3" />
                   </button>
@@ -1228,6 +1236,21 @@ function EditorInner() {
               </div>
 
               <TabsContent value="content" className="p-3 space-y-3 mt-0">
+                {selectedSectionData.kind === "spacer" ? (
+                  /* A spacer exists to give the section before it room to breathe. It
+                     renders nothing, so offering an eyebrow, a heading, a body, a button
+                     and an image is offering five fields that do nothing. Its height is
+                     the only thing it has, and that lives on the Layout tab. */
+                  <div className="rounded-lg border border-white/8 bg-white/2 p-4 space-y-2">
+                    <p className="text-sm font-medium">This is a spacer</p>
+                    <p className="text-xs text-muted-foreground leading-relaxed">
+                      It draws nothing. It holds {selectedSectionData.scrollHeight}px of scroll
+                      open so the section before it can finish before the next one arrives.
+                      Change that on the Layout tab, or delete it if the pacing feels slow.
+                    </p>
+                  </div>
+                ) : (
+                <>
                 <div className="space-y-1.5">
                   <label className="text-xs text-muted-foreground">Eyebrow text</label>
                   <Input
@@ -1324,6 +1347,8 @@ function EditorInner() {
                     </div>
                   </div>
                 ) : null}
+                </>
+                )}
               </TabsContent>
 
               <TabsContent value="style" className="p-3 space-y-3 mt-0">


### PR DESCRIPTION
Deepening the templates in #374 was the right change, but it broke something I built for four-section templates. Measured in Chrome on `kiln-coffee`:

| | before | after |
| --- | --- | --- |
| labels clipped | **7 of 9** | **0 of 9** |
| rows that are spacers labelled "Section N" | 2 | 0 |
| fields a spacer's Content tab offers | 5 | 0 |

The list read:

```
Roasted t...    Two farm...    Light eno...    Section 4
Bags are ...    A recipe ...   Open at s...    Section 8    Subscrib...
```

## Why the labels were starved

Not the panel width. The row's hover controls are `opacity-0`, which **still occupies layout** — four buttons reserving roughly 100px of a 224px panel while invisible. My first attempt made it worse by adding `flex-shrink-0` to them, which pinned that width instead of letting it collapse.

They are now `absolute right-1 top-1` over the right edge of the row, with the row as the containing block, so the label gets the full width across two lines.

## Spacers

A spacer draws nothing. Labelling it "Section 4" and then offering an eyebrow, heading, body, CTA and image URL invites you to fill in five fields that do nothing. It now reads `Spacer · 700px`, dimmed and italic, and selecting it says what it is for and points at the height control on the Layout tab — the one thing it actually has.

## Verified the controls still work

Lifting them out of the flow could easily have made them unclickable, so I checked rather than assumed:

```
controls hit-testable        yes, topmost element at the button's centre is the button
order before                 ["Roasted this morning…", "Two farms…", "Light enough…"]
after Move up                ["Two farms…", "Roasted this morning…", "Light enough…"]
after Duplicate              10 rows
after Undo                   9 rows, order preserved
```

Also checked at 390×844: full headings, spacer distinct, list scrolls within its cap.

Four new tests in `appAccessibility.test.ts`, all failing on `main`. Suite 369 passed.