### PR TITLE
Make the portrait frame set mean something

### DIFF
--- a/src/__tests__/appAccessibility.test.ts
+++ b/src/__tests__/appAccessibility.test.ts
@@ -295,7 +295,7 @@ describe("every form control has a name a screen reader can read", () => {
     // role="switch" with aria-checked and no name announces only its state.
     const create = readFileSync("src/app/create/page.tsx", "utf8");
     const sw = create.slice(create.indexOf('role="switch"') - 400, create.indexOf('role="switch"') + 200);
-    expect(sw).toContain('aria-label="Generate mobile variant"');
+    expect(sw).toMatch(/aria-label="(Generate mobile variant|Portrait frames for an uploaded video)"/);
   });
 });
 

--- a/src/__tests__/mobileFrames.test.ts
+++ b/src/__tests__/mobileFrames.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * The portrait frame set, which a phone gets instead of a letterboxed landscape one.
+ *
+ * It used to be generated on the path where it cannot survive and ignored on the path
+ * where it matters. Measured by running both flows in Chrome:
+ *
+ *   style path, toggle on   two full renders, hasMobileFrames=1 carried to the editor,
+ *                           then a 64 KB procedural export with hasMobile=false and no
+ *                           frames-mobile folder - the second render was discarded
+ *   video path, toggle on   the toggle was never read: no portrait set, no parameter
+ *
+ * Now: the style path renders once, and the video path ships both sets. Verified from a
+ * real 1280x720 clip - 120 landscape at 1280x720, 120 portrait at 720x1280 - and the
+ * served page fetches 120 portrait and 0 landscape at 390x844, the reverse at 1440x900.
+ */
+const CREATE = readFileSync("src/app/create/page.tsx", "utf8");
+const EXTRACT = readFileSync("src/lib/extractFramesInBrowser.ts", "utf8");
+
+describe("a style background renders once", () => {
+  it("does not render a portrait set the exporter will drop", () => {
+    // exportProcedurally wins whenever a style recipe is present and the frames are
+    // locally generated, and that path ships no frames at all.
+    const gen = CREATE.slice(CREATE.indexOf("const handleGenerate"), CREATE.indexOf("const handleUpload"));
+    expect(gen).not.toContain("Generating mobile portrait frames");
+    expect(gen).not.toContain('storeFrames("scrollcraft_mobile_frames"');
+    expect(gen).toContain('deleteFrames("scrollcraft_mobile_frames")');
+    expect(gen).not.toContain("hasMobileFrames");
+  });
+});
+
+describe("uploaded footage gets a real portrait set", () => {
+  const upload = CREATE.slice(CREATE.indexOf("const handleUpload"), CREATE.indexOf("useEffect", CREATE.indexOf("const handleUpload")));
+
+  it("samples a second pass at portrait dimensions when asked", () => {
+    expect(upload).toContain("if (generateMobile) {");
+    expect(upload).toContain("width: 720,");
+    expect(upload).toContain("height: 1280,");
+    expect(upload).toContain('storeFrames("scrollcraft_mobile_frames", portrait.frames)');
+  });
+
+  it("tells the exporter the set exists, and only when it does", () => {
+    expect(upload).toContain("hasMobile ? { hasMobileFrames: \"1\" } : {}");
+    // A failed second pass must not lose the upload that already succeeded.
+    expect(upload).toContain("Could not sample the portrait set");
+    expect(upload).toMatch(/\}\)\.catch\(\(\) => null\)/);
+  });
+
+  it("clears the slot when not asked, so a previous upload's set cannot leak in", () => {
+    expect(upload).toContain('deleteFrames("scrollcraft_mobile_frames")');
+  });
+});
+
+describe("changing the aspect ratio crops rather than stretches", () => {
+  it("draws from a centred source rectangle when the ratios differ", () => {
+    // drawImage(video, 0, 0, w, h) scales the whole frame into the box: a 16:9 clip in a
+    // 9:16 box is stretched about 3x vertically, which distorts every face in it.
+    expect(EXTRACT).toContain("const cover = Math.abs(srcAspect - dstAspect) > 0.01;");
+    expect(EXTRACT).toContain("if (cover) ctx.drawImage(video, sx, sy, sw, sh, 0, 0, w, h);");
+    expect(EXTRACT).toContain("else ctx.drawImage(video, 0, 0, w, h);");
+  });
+
+  it("keeps the crop's aspect ratio within half a percent of the target", () => {
+    // The maths from the source, run rather than eyeballed.
+    const crop = (srcW: number, srcH: number, w: number, h: number) => {
+      const srcAspect = srcW / srcH;
+      const dstAspect = w / h;
+      const cover = Math.abs(srcAspect - dstAspect) > 0.01;
+      const sw = cover && srcAspect > dstAspect ? Math.round(srcH * dstAspect) : srcW;
+      const sh = cover && srcAspect > dstAspect ? srcH : Math.round(srcW / dstAspect);
+      return { cover, sw, sh };
+    };
+    for (const [srcW, srcH, w, h] of [
+      [1920, 1080, 720, 1280], [3840, 2160, 720, 1280], [640, 480, 720, 1280],
+      [1080, 1920, 720, 1280], [1920, 1080, 1280, 720],
+    ]) {
+      const { sw, sh } = crop(srcW, srcH, w, h);
+      const deviation = Math.abs(sw / sh - w / h) / (w / h);
+      expect(deviation, `${srcW}x${srcH} -> ${w}x${h} distorts by ${(deviation * 100).toFixed(2)}%`).toBeLessThan(0.005);
+    }
+  });
+
+  it("leaves a matching aspect ratio uncropped", () => {
+    const srcAspect = 1920 / 1080;
+    const dstAspect = 1280 / 720;
+    expect(Math.abs(srcAspect - dstAspect) > 0.01).toBe(false);
+  });
+});
+
+describe("the toggle says what it does", () => {
+  it("names the upload it applies to, and why a style needs nothing", () => {
+    expect(CREATE).toContain("Portrait frames for an uploaded video");
+    expect(CREATE).toContain("A style background needs no second set");
+    expect(CREATE).not.toContain("Also create portrait 9:16 frames for phones");
+  });
+});

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -72,24 +72,15 @@ function CreatePageInner() {
     try {
       const opts = { style: selectedStyle, color1: colors[0], color2: colors[1], color3: colors[2], frameCount };
 
-      setProgressLabel(generateMobile ? "Generating desktop frames…" : "Generating frames…");
+      setProgressLabel("Generating frames…");
       const frames = await generate2DFrames(
         { ...opts, width: 1280, height: 720 },
-        (p) => setProgress(generateMobile ? Math.round(p * 0.5) : p)
+        (p) => setProgress(p)
       );
-
-      if (generateMobile) {
-        setProgressLabel("Generating mobile portrait frames…");
-        const mobileFrames = await generate2DFrames(
-          { ...opts, width: 720, height: 1280 },
-          (p) => setProgress(50 + Math.round(p * 0.5))
-        );
-        // Mobile frames are ~8–12 MB — far beyond sessionStorage's 5 MB quota.
-        // Store in IndexedDB which supports hundreds of MB.
-        await storeFrames("scrollcraft_mobile_frames", mobileFrames);
-      } else {
-        await deleteFrames("scrollcraft_mobile_frames").catch(() => {});
-      }
+      // A style background needs no portrait set: the exported page carries the recipe
+      // and redraws every frame at whatever size the viewport is, so a phone gets a
+      // portrait background for free and at its own resolution.
+      await deleteFrames("scrollcraft_mobile_frames").catch(() => {});
 
       // Store frames in IndexedDB — sessionStorage's 5 MB quota is too small for even one
       // 120-frame set. IndexedDB handles hundreds of MB without issue.
@@ -102,7 +93,6 @@ function CreatePageInner() {
         name: templateLabel || STYLES.find(s => s.id === selectedStyle)?.label || selectedStyle,
         style: selectedStyle,
         c1: colors[0], c2: colors[1], c3: colors[2],
-        ...(generateMobile ? { hasMobileFrames: "1" } : {}),
       });
       router.push(`/editor?${params.toString()}`);
     } catch (err) {
@@ -121,7 +111,7 @@ function CreatePageInner() {
       // no server involved at all.
       const { frames, frameCount: count, duration, sourceDuration } = await extractFramesInBrowser(file, {
         frameCount,
-        onProgress: (pct) => setProgress(Math.max(5, pct)),
+        onProgress: (pct) => setProgress(Math.max(5, generateMobile ? Math.round(pct * 0.5) : pct)),
       });
       // Sampling stops at a cap, and silently returning a shortened site is worse than
       // saying so - the missing footage is the first thing the user looks for.
@@ -133,11 +123,34 @@ function CreatePageInner() {
       }
       await storeFrames("scrollcraft_desktop_frames", frames);
 
+      let hasMobile = false;
+      if (generateMobile) {
+        setProgressLabel("Sampling a portrait set for phones…");
+        const portrait = await extractFramesInBrowser(file, {
+          frameCount,
+          width: 720,
+          height: 1280,
+          onProgress: (pct) => setProgress(50 + Math.round(pct * 0.5)),
+        }).catch(() => null);
+        if (portrait?.frames.length) {
+          await storeFrames("scrollcraft_mobile_frames", portrait.frames);
+          hasMobile = true;
+        } else {
+          // Losing the portrait set must not lose the upload: the landscape frames are
+          // already stored and a phone falls back to them.
+          toast.warning("Could not sample the portrait set. Your site will use the landscape frames on phones.");
+          await deleteFrames("scrollcraft_mobile_frames").catch(() => {});
+        }
+      } else {
+        await deleteFrames("scrollcraft_mobile_frames").catch(() => {});
+      }
+
       const params = new URLSearchParams({
         framesKey: "scrollcraft_desktop_frames",
         frameCount: String(count),
         fps: "24",
         name: file.name.replace(/\.[^.]+$/, "") || "Video upload",
+        ...(hasMobile ? { hasMobileFrames: "1" } : {}),
       });
       router.push(`/editor?${params.toString()}`);
     } catch (err) {
@@ -337,15 +350,19 @@ function CreatePageInner() {
 
               <div className="flex items-center justify-between pt-1">
                 <div>
-                  <p className="font-medium text-sm">Generate mobile variant</p>
-                  <p className="text-xs text-muted-foreground">Also create portrait 9:16 frames for phones</p>
+                  <p className="font-medium text-sm">Portrait frames for an uploaded video</p>
+                  <p className="text-xs text-muted-foreground">
+                    Samples a second 9:16 set, centre-cropped, so a phone is not shown a
+                    letterboxed landscape frame. A style background needs no second set:
+                    it is redrawn at whatever size the screen is.
+                  </p>
                 </div>
                 <button
                   onClick={() => setGenerateMobile(m => !m)}
                   className={`relative w-10 h-6 rounded-full transition-colors ${generateMobile ? "bg-primary" : "bg-white/10"}`}
                   role="switch"
                   aria-checked={generateMobile}
-                  aria-label="Generate mobile variant"
+                  aria-label="Portrait frames for an uploaded video"
                 >
                   <span className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${generateMobile ? "translate-x-5" : "translate-x-1"}`} />
                 </button>

--- a/src/lib/extractFramesInBrowser.ts
+++ b/src/lib/extractFramesInBrowser.ts
@@ -117,11 +117,23 @@ export async function extractFramesInBrowser(
     const ctx = canvas.getContext("2d");
     if (!ctx) throw new VideoExtractError("This browser cannot draw to a canvas.");
 
+    // When an explicit size changes the aspect ratio - a portrait set out of landscape
+    // footage - fill the box by covering it and cropping the overflow, centred. Scaling
+    // the source into the box instead stretches every face in the clip.
+    const srcAspect = srcW / srcH;
+    const dstAspect = w / h;
+    const cover = Math.abs(srcAspect - dstAspect) > 0.01;
+    const sw = cover && srcAspect > dstAspect ? Math.round(srcH * dstAspect) : srcW;
+    const sh = cover && srcAspect > dstAspect ? srcH : Math.round(srcW / dstAspect);
+    const sx = Math.round((srcW - sw) / 2);
+    const sy = Math.round((srcH - sh) / 2);
+
     const frames: string[] = [];
     for (let i = 0; i < frameCount; i++) {
       const t = (i / Math.max(frameCount - 1, 1)) * duration;
       await seekTo(video, t);
-      ctx.drawImage(video, 0, 0, w, h);
+      if (cover) ctx.drawImage(video, sx, sy, sw, sh, 0, 0, w, h);
+      else ctx.drawImage(video, 0, 0, w, h);
       frames.push(canvas.toDataURL("image/jpeg", quality));
       opts.onProgress?.(Math.round(((i + 1) / frameCount) * 100));
       // Yield so the progress bar can paint between frames.


### PR DESCRIPTION
I had touched this feature twice without ever running it, so I ran both flows in Chrome. The **"Generate mobile variant"** toggle was generated on the path where its output cannot survive, and ignored on the path where it matters.

## Style path: rendered twice, discarded once

| | |
| --- | --- |
| what happened | two full renders, `hasMobileFrames=1` into the editor, 120 portrait frames in IndexedDB |
| what shipped | a **64 KB** procedural export, `hasMobile=false`, `mobileCount=0`, no `frames-mobile/` |

The second render roughly doubled the wait and was thrown away every time.

**The discarding is correct.** A style background ships as a *recipe* and is redrawn at whatever size the viewport is, so a phone already gets a portrait background at its own resolution — strictly better than fixed portrait JPEGs. So the fix is to stop rendering it: the style path now renders once and clears the slot.

## Video path: the toggle was never read

`handleUpload` never looked at `generateMobile`. No portrait set, no parameter, nothing. Footage is the one case a portrait set *cannot* be derived from — nothing can redraw someone's video at a new aspect ratio — so that is where the toggle now does its work, as a second sampling pass at 720×1280.

### That pass would have shipped distorted frames

`ctx.drawImage(video, 0, 0, w, h)` scales the whole frame into the box, stretching a 16:9 clip about **3× vertically**. I caught this before shipping. It now draws from a centred source rectangle when the ratios differ:

| source → target | crop | aspect deviation |
| --- | --- | --- |
| 1920×1080 → 720×1280 | 608×1080 | 0.08% |
| 3840×2160 → 720×1280 | 1215×2160 | 0.00% |
| 640×480 → 720×1280 | 270×480 | 0.00% |
| 1080×1920 → 720×1280 | no crop | 0.00% |
| 1920×1080 → 1280×720 | no crop | 0.00% |

A failed second pass cannot lose the upload that already succeeded — the landscape frames are stored first, and the user is told the phone will fall back to them.

## Verified end to end

Real 1280×720 clip uploaded through `/create` with the toggle on, exported through the real button:

```
frames/         120 files   1280x720
frames-mobile/  120 files   720x1280      (genuine centre crop, checked by eye)
page:           hasMobile = true   mobileCount = 120
```

Served and loaded at two widths:

| viewport | landscape fetched | portrait fetched |
| --- | --- | --- |
| 390×844 | **0** | **120** |
| 1440×900 | **120** | **0** |

One set, never both — the guard against a phone pulling ~70 MB on cellular still holds, and the canvas paints in both cases.

The toggle's label now names the upload it applies to and says why a style background needs nothing.

Eight new tests in `mobileFrames.test.ts`, six failing on `main` (two are pure maths that hold either way). Suite 377 passed.