### PR TITLE
Tell the owner about the audio the ZIP contains

### DIFF
--- a/src/__tests__/exportAudio.test.ts
+++ b/src/__tests__/exportAudio.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { exportReadme } from "@/lib/exportAssets";
+
+/**
+ * Background audio, and what the ZIP tells its owner about it.
+ *
+ * Exercised end to end in Chrome: uploading an MP3 and a WAV in the editor, exporting,
+ * unzipping and serving. Both ship byte-identical (60,857 and 264,678 bytes) under the
+ * extension the mime type maps to, the page loads exactly that path, the mute button
+ * toggles, and the served page reports zero console errors. The feature was sound; the
+ * README never mentioned it, so an owner met an undocumented folder and a track that
+ * appears not to work.
+ */
+const ROUTE = readFileSync("src/app/api/export-site/route.ts", "utf8");
+const EDITOR = readFileSync("src/app/editor/page.tsx", "utf8");
+
+describe("the ZIP and the page agree on the audio filename", () => {
+  it("derives the extension once, on the server, and hands it to the client", () => {
+    // Two independent guesses at the extension would ship a file the page never loads.
+    expect(ROUTE).toContain("const audioExt = AUDIO_EXT[baseMime] ?? \"mp3\";");
+    expect(ROUTE).toContain("new Audio('audio/track.${audioExt}')");
+    expect(ROUTE).toContain("audioExt,");
+    expect(EDITOR).toContain("const { html, audioExt } = await res.json();");
+    expect(EDITOR).toContain("zip.file(`audio/track.${audioExt}`, audioBase64, { base64: true });");
+  });
+
+  it("maps the formats a browser will actually decode", () => {
+    for (const mime of ["audio/mpeg", "audio/wav", "audio/mp4", "audio/ogg", "audio/webm"]) {
+      expect(ROUTE, `${mime} has no extension`).toContain(`"${mime}"`);
+    }
+  });
+});
+
+describe("the README explains the audio it shipped", () => {
+  const withAudio = exportReadme("Site", true, "https://example.test", { hasAudio: true });
+  const withoutAudio = exportReadme("Site", true, "https://example.test");
+
+  it("lists the folder in the file table", () => {
+    expect(withAudio).toContain("| `audio/` |");
+  });
+
+  it("says why the track does not start on load", () => {
+    // The likeliest support question, and the answer is a browser policy nobody can
+    // change: an owner otherwise deploys, hears nothing, and assumes it is broken.
+    expect(withAudio).toContain("## About the audio");
+    expect(withAudio).toMatch(/will not start on its own, and that is not a bug/);
+    expect(withAudio).toMatch(/first click, tap or\s+key press/);
+  });
+
+  it("says how to replace or remove it", () => {
+    expect(withAudio).toContain("replace the file in `audio/`");
+    expect(withAudio).toContain('<button id="audio-mute">');
+  });
+
+  it("says none of it when there is no audio", () => {
+    expect(withoutAudio).not.toContain("## About the audio");
+    expect(withoutAudio).not.toContain("| `audio/` |");
+    // and the rest of the README is unaffected
+    expect(withoutAudio).toContain("## Put it online");
+  });
+});

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -666,7 +666,7 @@ function EditorInner() {
       const iconBlob = await renderTouchIcon(iconAccent, iconGround, siteName);
       if (iconBlob) zip.file("apple-touch-icon.png", iconBlob);
 
-      zip.file("README.md", exportReadme(siteName, exportProcedurally, window.location.origin));
+      zip.file("README.md", exportReadme(siteName, exportProcedurally, window.location.origin, { hasAudio }));
 
       // A recipe-driven export ships no JPEGs at all — the page draws its own frames.
       if (!exportProcedurally) {

--- a/src/lib/exportAssets.ts
+++ b/src/lib/exportAssets.ts
@@ -80,7 +80,13 @@ export function notFoundHtml(siteName: string, ground: string, ink: string): str
 }
 
 /** Deploy instructions for the hosts people actually use, written for a non-developer. */
-export function exportReadme(siteName: string, procedural: boolean, madeWithUrl: string): string {
+export function exportReadme(
+  siteName: string,
+  procedural: boolean,
+  madeWithUrl: string,
+  opts: { hasAudio?: boolean } = {}
+): string {
+  const { hasAudio = false } = opts;
   return `# ${siteName}
 
 Your site, exported from [ScrollCraft](${madeWithUrl}).
@@ -137,12 +143,26 @@ Do **not** open \`index.html\` by double-clicking it. Browsers block a page load
 | \`og-image.jpg\` | The preview image when the link is shared |
 | \`apple-touch-icon.png\` | The icon when saved to a phone's home screen |
 | \`robots.txt\` | Tells search engines they may index the site |
+${hasAudio ? "| \`audio/\` | Your background track |\n" : ""}
 | \`lenis.min.js\` | Smooth scrolling. Remove it and scrolling still works |
 ${procedural
   ? "\nThe background is drawn in the browser from a small style recipe, so there is no\n`frames/` folder. The page itself is about 35 KB; the social preview image is the only\nfile larger than that."
   : "\n| `frames/` | The background images |\n\nKeep `frames/` beside `index.html`."}
 
-## Making changes
+${hasAudio ? `## About the audio
+
+Your track is in \`audio/\`. It loops, fades in as the visitor scrolls and fades out when
+they stop.
+
+**It will not start on its own, and that is not a bug.** Every browser blocks audio until
+the visitor has interacted with the page, so the track begins on their first click, tap or
+key press. The speaker button in the corner mutes and unmutes it.
+
+To change the track, replace the file in \`audio/\` keeping the same name, or edit the
+filename in \`index.html\`. To remove it, delete the folder and the \`<button id="audio-mute">\`
+line.
+
+` : ""}## Making changes
 
 Everything is editable in a text editor.
 


### PR DESCRIPTION
Audio was a whole feature I had never exercised, so I ran it: uploaded an MP3 and a WAV in the editor, exported through the real button, unzipped, served, and drove the page.

## The feature is sound

| | MP3 | WAV |
| --- | --- | --- |
| bytes in the ZIP | 60,857 | 264,678 |
| source bytes | 60,857 | 264,678 |
| header | `ID3` ✓ | `RIFF`/`WAVE` ✓ |
| shipped as | `audio/track.mp3` | `audio/track.wav` |
| page loads | `audio/track.mp3` | `audio/track.wav` |

Served page: `200 track.mp3`, zero console errors, mute button present with the right title, and clicking it cycles 🔊 → 🔇 → 🔊.

The extension is derived **once**, on the server, and handed back to the client for the ZIP filename — so the file shipped and the file requested cannot disagree. I checked WAV specifically because that is where a second independent guess would have shown up.

## What was missing

Documentation. The README's file table listed `index.html`, `404.html`, `favicon.svg`, `og-image.jpg`, `apple-touch-icon.png`, `robots.txt` and `lenis.min.js` — but **not `audio/`**. So an owner met an undocumented folder.

Worse, nothing explained this:

> **It will not start on its own, and that is not a bug.** Every browser blocks audio until the visitor has interacted with the page, so the track begins on their first click, tap or key press.

That is the likeliest support question this export will ever generate — someone uploads a track, deploys, opens the page, hears silence, and concludes it broke. The answer is a browser policy nobody can change, so it belongs in the README rather than in a reply.

The new section also covers replacing the track and removing it, and appears **only when the export actually has audio** — `exportReadme` takes `{ hasAudio }` and a silent export's README is unchanged.

Six new tests. Three fail on `main`; the other three pass either way on purpose, pinning the single-source-of-truth extension so it cannot drift into two guesses later.

Suite 383 passed.