### PR TITLE
Rewrite site copy from a plain-language instruction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,9 @@ SENTRY_PROJECT=""
 SENTRY_AUTH_TOKEN=""
 SENTRY_TRACES_SAMPLE_RATE=""
 NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=""
+
+# The editor's assistant, which rewrites sections from a plain-language instruction.
+# Without a key the assistant is not offered at all. Get one at dashboard.sarvam.ai.
+SARVAM_API_KEY=""
+# Defaults to sarvam-105b. The -conversations variant has a smaller context window.
+SARVAM_MODEL=""

--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@ NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=""
 SARVAM_API_KEY=""
 # Defaults to sarvam-105b. The -conversations variant has a smaller context window.
 SARVAM_MODEL=""
+# Optional. Any endpoint that speaks the OpenAI chat-completions shape.
+# Defaults to https://api.sarvam.ai/v1.
+SARVAM_BASE_URL=""

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ those sites without WebGL, an animation library, or a render farm.
    `robots.txt` and host config for Netlify, Vercel, GitHub Pages and Cloudflare.
    Deploying is dragging a folder.
 
-Everything runs in the browser. There is no account, no database and nothing to buy.
+Everything runs in the browser. There is no account, no database and nothing to buy. The
+one exception is the copy assistant below, which is off unless you configure a key.
 
 ## Features
 
@@ -44,6 +45,10 @@ Everything runs in the browser. There is no account, no database and nothing to 
   device.
 - **Scroll-linked audio.** Attach a track that fades in as the reader scrolls and out when
   they stop.
+- **Copy rewriting, if you configure it.** Describe the change you want and the editor
+  rewrites the section copy from it, in one undo step. It touches the words only, never
+  the layout, colours, images or button links. It needs an API key, and without one the
+  button is not shown at all. See [Environment variables](#environment-variables).
 
 ## Two ways to use it
 
@@ -156,6 +161,9 @@ Every variable is optional. See [`.env.example`](.env.example).
 | `UPSTASH_REDIS_REST_*` | Shared rate limiting across instances; falls back to in-memory |
 | `NEXT_PUBLIC_SENTRY_DSN` | Error reporting; leave empty to disable |
 | `SENTRY_*` | Source map upload for readable stack traces |
+| `SARVAM_API_KEY` | Turns on the editor's copy assistant. Absent, the button is not shown |
+| `SARVAM_MODEL` | `sarvam-105b` (default) or `sarvam-105b-conversations` |
+| `SARVAM_BASE_URL` | Any endpoint speaking the OpenAI chat-completions shape. Defaults to Sarvam |
 
 ## Where your work lives
 
@@ -183,7 +191,7 @@ unsaved changes.
 ```
 src/
 ├── app/
-│   ├── api/              # Route handlers (export-site, demo-frame, health)
+│   ├── api/              # Route handlers (export-site, edit-site, demo-frame, health)
 │   ├── templates/        # Template gallery and preview (/templates, /templates/[slug])
 │   ├── editor/           # The visual scroll-site editor
 │   └── create/           # Style and upload flow into the editor

--- a/src/__tests__/assistant.test.ts
+++ b/src/__tests__/assistant.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi } from "vitest";
+import { extractJsonArray, mergeCopyOnly, rewriteSections, systemPrompt } from "@/lib/assistant";
+import type { Section } from "@/lib/siteSchema";
+
+function reply(content: string) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ choices: [{ message: { content } }] }),
+  } as unknown as Response;
+}
+
+function fetchReturning(content: string) {
+  return vi.fn(async () => reply(content)) as unknown as typeof fetch;
+}
+
+const DOC: Section[] = [
+  {
+    id: "s1",
+    kind: "text",
+    layout: "left",
+    reveal: "rise",
+    scrollHeight: 1400,
+    eyebrow: "Studio",
+    heading: "Original heading",
+    body: "Original body copy.",
+    ctaLabel: "See the work",
+    ctaHref: "#section-3",
+  },
+  { id: "s2", kind: "spacer", scrollHeight: 600 },
+];
+
+const opts = { apiKey: "k" };
+
+describe("extractJsonArray", () => {
+  it("reads a bare array", () => {
+    expect(extractJsonArray('[{"heading":"a"}]')).toEqual([{ heading: "a" }]);
+  });
+
+  it("reads an array inside a json code fence", () => {
+    expect(extractJsonArray('```json\n[{"heading":"a"}]\n```')).toEqual([{ heading: "a" }]);
+  });
+
+  it("reads an array inside an unlabelled code fence", () => {
+    expect(extractJsonArray('```\n[{"heading":"a"}]\n```')).toEqual([{ heading: "a" }]);
+  });
+
+  it("reads an array the model wrapped in prose", () => {
+    expect(extractJsonArray('Sure! Here you go:\n[{"heading":"a"}]\nHope that helps.')).toEqual([
+      { heading: "a" },
+    ]);
+  });
+
+  it("throws when there is no array at all", () => {
+    expect(() => extractJsonArray("I cannot help with that.")).toThrow();
+  });
+});
+
+describe("mergeCopyOnly", () => {
+  it("takes the copy and keeps every structural field", () => {
+    const merged = mergeCopyOnly(DOC, [
+      { heading: "New heading", body: "New body.", layout: "center", scrollHeight: 20_000 },
+      {},
+    ]);
+    expect(merged[0].heading).toBe("New heading");
+    expect(merged[0].body).toBe("New body.");
+    expect(merged[0].layout).toBe("left");
+    expect(merged[0].scrollHeight).toBe(1400);
+    expect(merged[0].id).toBe("s1");
+  });
+
+  it("leaves a spacer exactly as it was", () => {
+    const merged = mergeCopyOnly(DOC, [{}, { heading: "spacers have no copy" }]);
+    expect(merged[1]).toEqual(DOC[1]);
+  });
+
+  it("keeps a field the reply omitted", () => {
+    const merged = mergeCopyOnly(DOC, [{ heading: "New" }, {}]);
+    expect(merged[0].eyebrow).toBe("Studio");
+    expect(merged[0].ctaLabel).toBe("See the work");
+  });
+});
+
+describe("rewriteSections", () => {
+  it("applies a well formed rewrite", async () => {
+    const res = await rewriteSections(DOC, "make it warmer", {
+      ...opts,
+      fetchImpl: fetchReturning(
+        JSON.stringify([{ heading: "Warmer heading", body: "Warmer body." }, {}])
+      ),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.sections[0].heading).toBe("Warmer heading");
+    expect(res.sections).toHaveLength(2);
+  });
+
+  // The whole safety argument for the feature: the reply is copy, not a document. A model
+  // that redirects the call to action, restyles the page or stretches the scroll track
+  // changes nothing, because none of those fields are read back.
+  it("ignores every field that is not copy, including the call to action target", async () => {
+    const res = await rewriteSections(DOC, "improve it", {
+      ...opts,
+      fetchImpl: fetchReturning(
+        JSON.stringify([
+          {
+            heading: "Fine",
+            ctaHref: "https://example.invalid/collect",
+            layout: "center",
+            headingColor: "#ff0000",
+            scrollHeight: 19_000,
+            visible: false,
+          },
+          {},
+        ])
+      ),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.sections[0].ctaHref).toBe("#section-3");
+    expect(res.sections[0].layout).toBe("left");
+    expect(res.sections[0].headingColor).toBeUndefined();
+    expect(res.sections[0].scrollHeight).toBe(1400);
+    expect(res.sections[0].visible).toBeUndefined();
+  });
+
+  it("rejects a reply that changes the section count", async () => {
+    const res = await rewriteSections(DOC, "trim it", {
+      ...opts,
+      fetchImpl: fetchReturning(JSON.stringify([{ heading: "Only one" }])),
+    });
+    expect(res).toMatchObject({ ok: false, status: 422 });
+  });
+
+  it("rejects a reply that is not JSON", async () => {
+    const res = await rewriteSections(DOC, "hi", {
+      ...opts,
+      fetchImpl: fetchReturning("I am afraid I cannot do that."),
+    });
+    expect(res).toMatchObject({ ok: false, status: 422 });
+  });
+
+  it("rejects a reply that is JSON but not a section list", async () => {
+    const res = await rewriteSections(DOC, "hi", {
+      ...opts,
+      fetchImpl: fetchReturning('[{"heading": 42}, {}]'),
+    });
+    expect(res).toMatchObject({ ok: false, status: 422 });
+  });
+
+  it("rejects copy that exceeds what the schema allows", async () => {
+    const res = await rewriteSections(DOC, "expand", {
+      ...opts,
+      fetchImpl: fetchReturning(JSON.stringify([{ heading: "x".repeat(501) }, {}])),
+    });
+    expect(res).toMatchObject({ ok: false, status: 422 });
+  });
+
+  it("reports an empty completion rather than wiping the copy", async () => {
+    const res = await rewriteSections(DOC, "hi", { ...opts, fetchImpl: fetchReturning("   ") });
+    expect(res).toMatchObject({ ok: false, status: 502 });
+  });
+
+  it("passes an upstream rate limit through as a rate limit", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 429 }) as Response);
+    const res = await rewriteSections(DOC, "hi", { ...opts, fetchImpl: fetchImpl as typeof fetch });
+    expect(res).toMatchObject({ ok: false, status: 429 });
+  });
+
+  it("does not leak an authentication failure to the caller as a rate limit", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 401 }) as Response);
+    const res = await rewriteSections(DOC, "hi", { ...opts, fetchImpl: fetchImpl as typeof fetch });
+    expect(res).toMatchObject({ ok: false, status: 502 });
+    if (res.ok) return;
+    expect(res.error).not.toMatch(/401|key|token/i);
+  });
+
+  it("survives a transport failure", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNRESET");
+    });
+    const res = await rewriteSections(DOC, "hi", { ...opts, fetchImpl: fetchImpl as typeof fetch });
+    expect(res).toMatchObject({ ok: false, status: 502 });
+  });
+
+  it("sends the key as a bearer token and the instruction with the sections", async () => {
+    const fetchImpl = fetchReturning(JSON.stringify([{ heading: "ok" }, {}]));
+    await rewriteSections(DOC, "translate to Hindi", {
+      apiKey: "secret-key",
+      model: "sarvam-105b-conversations",
+      fetchImpl,
+    });
+    const [url, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("https://api.sarvam.ai/v1/chat/completions");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer secret-key");
+    const sent = JSON.parse(String(init.body));
+    expect(sent.model).toBe("sarvam-105b-conversations");
+    expect(sent.messages[1].content).toContain("translate to Hindi");
+    expect(sent.messages[1].content).toContain("Original heading");
+  });
+
+  it("defaults to the larger model", async () => {
+    const fetchImpl = fetchReturning(JSON.stringify([{ heading: "ok" }, {}]));
+    await rewriteSections(DOC, "hi", { apiKey: "k", fetchImpl });
+    const init = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(String(init.body)).model).toBe("sarvam-105b");
+  });
+});
+
+describe("systemPrompt", () => {
+  it("forbids inventing the claims a site owner would have to defend", () => {
+    const prompt = systemPrompt();
+    expect(prompt).toMatch(/never invent statistics/i);
+    expect(prompt).toMatch(/spacer/i);
+  });
+});

--- a/src/__tests__/assistant.test.ts
+++ b/src/__tests__/assistant.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
-import { extractJsonArray, mergeCopyOnly, rewriteSections, systemPrompt } from "@/lib/assistant";
+import {
+  completionsUrl,
+  extractJsonArray,
+  mergeCopyOnly,
+  rewriteSections,
+  systemPrompt,
+} from "@/lib/assistant";
 import type { Section } from "@/lib/siteSchema";
 
 function reply(content: string) {
@@ -207,6 +213,25 @@ describe("rewriteSections", () => {
     await rewriteSections(DOC, "hi", { apiKey: "k", fetchImpl });
     const init = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
     expect(JSON.parse(String(init.body)).model).toBe("sarvam-105b");
+  });
+});
+
+describe("completionsUrl", () => {
+  it("defaults to Sarvam", () => {
+    expect(completionsUrl()).toBe("https://api.sarvam.ai/v1/chat/completions");
+    expect(completionsUrl("")).toBe("https://api.sarvam.ai/v1/chat/completions");
+  });
+
+  it("takes a gateway that speaks the same shape", () => {
+    expect(completionsUrl("http://127.0.0.1:8080/v1")).toBe(
+      "http://127.0.0.1:8080/v1/chat/completions"
+    );
+  });
+
+  it("does not double the slash on a base that ends in one", () => {
+    expect(completionsUrl("https://gw.example.com/v1///")).toBe(
+      "https://gw.example.com/v1/chat/completions"
+    );
   });
 });
 

--- a/src/__tests__/contactDetails.test.ts
+++ b/src/__tests__/contactDetails.test.ts
@@ -169,13 +169,34 @@ describe("what the site claims about itself is true", () => {
     }
   });
 
-  it("promises no AI, which the product does not have", () => {
-    // The changelog records its removal by name, so it is the one file allowed to say it.
-    for (const file of ["README.md", "src/app/presets/page.tsx", "src/app/HomeClient.tsx", "src/app/create/page.tsx", "src/app/about/page.tsx"]) {
+  it("does not promise the copy assistant on pages that cannot know it exists", () => {
+    // The assistant depends on a key, so a self-hosted copy usually does not have one.
+    // The landing, presets, create and about pages are served the same either way and
+    // cannot tell, so none of them may promise it. The README can, because it says in
+    // the same breath that a key is required. What none of them may do is slip back into
+    // the register the v0.4.0 teardown removed.
+    const marketing = ["src/app/presets/page.tsx", "src/app/HomeClient.tsx", "src/app/create/page.tsx", "src/app/about/page.tsx"];
+    for (const file of marketing) {
+      const text = readFileSync(file, "utf8");
+      expect(text, `${file} promises an assistant it cannot know is configured`).not.toMatch(
+        /rewrit\w* (?:your|the) (?:copy|site|words)|copy assistant/i
+      );
+    }
+    for (const file of ["README.md", ...marketing]) {
       expect(readFileSync(file, "utf8"), `${file} advertises AI`).not.toMatch(
         /\bthe AI\b|AI generates|AI-generated|AI-powered/i
       );
     }
+  });
+
+  it("says the assistant needs a key wherever it mentions the assistant", () => {
+    // "It rewrites your copy" on its own would be a promise a fresh clone cannot keep.
+    const readme = readFileSync("README.md", "utf8");
+    expect(readme).toMatch(/rewrites the section copy/i);
+    expect(readme, "the README mentions rewriting without mentioning the key").toMatch(
+      /needs an API key/i
+    );
+    expect(readme).toContain("SARVAM_API_KEY");
   });
 
   it("promises no release cadence it does not keep", () => {

--- a/src/__tests__/contactDetails.test.ts
+++ b/src/__tests__/contactDetails.test.ts
@@ -195,13 +195,25 @@ describe("what the site claims about itself is true", () => {
   });
 
   it("describes the rate limiting it actually applies", () => {
-    // One of three API routes is rate-limited; the privacy page promised two.
+    // The privacy page once promised limits on two routes when only one had them. It now
+    // names the endpoints, so the wording has to keep up with the routes themselves.
     const privacy = readFileSync("src/app/privacy/page.tsx", "utf8");
     expect(privacy).not.toContain("rate-limit the two API routes");
     const limited = readdirSync("src/app/api", { withFileTypes: true })
       .filter((d) => d.isDirectory())
       .filter((d) => readFileSync(join("src/app/api", d.name, "route.ts"), "utf8").includes("rateLimit("));
-    expect(limited.map((d) => d.name)).toEqual(["export-site"]);
+    expect(limited.map((d) => d.name).sort()).toEqual(["edit-site", "export-site"]);
+    expect(privacy, "the privacy page names the limited endpoints").toMatch(
+      /rate-limit the export and\s+rewrite endpoints/
+    );
+  });
+
+  it("discloses every request that leaves the browser", () => {
+    // "Nothing you type reaches us" stopped being the whole truth the moment an
+    // instruction could be sent to a third party for rewriting.
+    const privacy = readFileSync("src/app/privacy/page.tsx", "utf8");
+    expect(privacy, "the rewrite request is not disclosed").toMatch(/Sarvam AI/);
+    expect(privacy).not.toContain("Two things do leave your browser");
   });
 
   it("keeps the legal pages dated to when they were last rewritten", () => {

--- a/src/__tests__/editSiteRoute.test.ts
+++ b/src/__tests__/editSiteRoute.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+const fakeEnv: { SARVAM_API_KEY?: string; SARVAM_MODEL?: string } = { SARVAM_API_KEY: "test-key" };
+vi.mock("@/lib/env", () => ({ env: fakeEnv, getEnvIssues: () => [] }));
+
+const { GET, POST } = await import("@/app/api/edit-site/route");
+
+const SECTIONS = [
+  { id: "s1", kind: "text", layout: "left", heading: "Before", body: "Old copy." },
+  { id: "s2", kind: "spacer" },
+];
+
+/** A fresh IP per request, so one test's allowance is never another test's failure. */
+let ipCounter = 0;
+function post(body: unknown, init: RequestInit = {}): NextRequest {
+  ipCounter += 1;
+  return new Request("https://scrollcraft.app/api/edit-site", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": `203.0.113.${ipCounter % 250}` },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    ...init,
+  }) as unknown as NextRequest;
+}
+
+function completion(content: string) {
+  return vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ choices: [{ message: { content } }] }),
+  })) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  fakeEnv.SARVAM_API_KEY = "test-key";
+  delete fakeEnv.SARVAM_MODEL;
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("assistant availability", () => {
+  it("reports available when a key is configured", async () => {
+    expect(await (await GET()).json()).toEqual({ available: true });
+  });
+
+  it("reports unavailable when no key is configured", async () => {
+    delete fakeEnv.SARVAM_API_KEY;
+    expect(await (await GET()).json()).toEqual({ available: false });
+  });
+
+  it("is never cached, so a newly configured key takes effect on a reload", async () => {
+    expect((await GET()).headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("refuses to rewrite when no key is configured", async () => {
+    delete fakeEnv.SARVAM_API_KEY;
+    const res = await POST(post({ sections: SECTIONS, instruction: "warmer" }));
+    expect(res.status).toBe(503);
+  });
+
+  it("does not call out when no key is configured", async () => {
+    delete fakeEnv.SARVAM_API_KEY;
+    const spy = completion("[]");
+    vi.stubGlobal("fetch", spy);
+    await POST(post({ sections: SECTIONS, instruction: "warmer" }));
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/edit-site input handling", () => {
+  it("rewrites the copy and leaves the structure alone", async () => {
+    vi.stubGlobal(
+      "fetch",
+      completion(JSON.stringify([{ heading: "After", body: "New copy." }, {}]))
+    );
+    const res = await POST(post({ sections: SECTIONS, instruction: "make it warmer" }));
+    expect(res.status).toBe(200);
+    const { sections } = await res.json();
+    expect(sections[0].heading).toBe("After");
+    expect(sections[0].layout).toBe("left");
+    expect(sections[1]).toEqual(SECTIONS[1]);
+  });
+
+  it("rejects an empty instruction before spending a call", async () => {
+    const spy = completion("[]");
+    vi.stubGlobal("fetch", spy);
+    const res = await POST(post({ sections: SECTIONS, instruction: "   " }));
+    expect(res.status).toBe(400);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing instruction", async () => {
+    const res = await POST(post({ sections: SECTIONS }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an instruction long enough to be a prompt dump", async () => {
+    const spy = completion("[]");
+    vi.stubGlobal("fetch", spy);
+    const res = await POST(post({ sections: SECTIONS, instruction: "x".repeat(601) }));
+    expect(res.status).toBe(400);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("rejects sections that are not sections", async () => {
+    const res = await POST(post({ sections: [{ heading: 5 }], instruction: "warmer" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an empty site", async () => {
+    const res = await POST(post({ sections: [], instruction: "warmer" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects more sections than one call should carry", async () => {
+    const many = Array.from({ length: 41 }, (_, i) => ({ id: `s${i}`, heading: "h" }));
+    const spy = completion("[]");
+    vi.stubGlobal("fetch", spy);
+    const res = await POST(post({ sections: many, instruction: "warmer" }));
+    expect(res.status).toBe(400);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a body that is not JSON", async () => {
+    const res = await POST(post("not json at all"));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an oversized body on its declared length", async () => {
+    const req = post({ sections: SECTIONS, instruction: "warmer" });
+    req.headers.set("content-length", "9000000");
+    const res = await POST(req);
+    expect(res.status).toBe(413);
+  });
+});
+
+describe("POST /api/edit-site upstream failures", () => {
+  it("does not apply an edit the model malformed", async () => {
+    vi.stubGlobal("fetch", completion("sorry, I cannot"));
+    const res = await POST(post({ sections: SECTIONS, instruction: "warmer" }));
+    expect(res.status).toBe(422);
+    expect(await res.json()).not.toHaveProperty("sections");
+  });
+
+  it("does not apply an edit that drops a section", async () => {
+    vi.stubGlobal("fetch", completion(JSON.stringify([{ heading: "Only one" }])));
+    const res = await POST(post({ sections: SECTIONS, instruction: "shorter" }));
+    expect(res.status).toBe(422);
+  });
+
+  it("never puts the key in a response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 401 }) as Response) as unknown as typeof fetch
+    );
+    const res = await POST(post({ sections: SECTIONS, instruction: "warmer" }));
+    expect(JSON.stringify(await res.json())).not.toContain("test-key");
+  });
+});
+
+describe("POST /api/edit-site rate limiting", () => {
+  it("cuts one caller off well before the export limit", async () => {
+    vi.stubGlobal("fetch", completion(JSON.stringify([{ heading: "ok" }, {}])));
+    const ip = "198.51.100.7";
+    const statuses: number[] = [];
+    for (let i = 0; i < 12; i++) {
+      const req = new Request("https://scrollcraft.app/api/edit-site", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-forwarded-for": ip },
+        body: JSON.stringify({ sections: SECTIONS, instruction: "warmer" }),
+      }) as unknown as NextRequest;
+      statuses.push((await POST(req)).status);
+    }
+    expect(statuses.filter((s) => s === 429).length).toBeGreaterThan(0);
+    expect(statuses.filter((s) => s === 200).length).toBeLessThanOrEqual(10);
+  });
+});

--- a/src/app/api/edit-site/route.ts
+++ b/src/app/api/edit-site/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from "next/server";
+import { env } from "@/lib/env";
+import { logger } from "@/lib/logger";
+import { rateLimit, getClientIp } from "@/lib/rateLimit";
+import { sectionsSchema } from "@/lib/siteSchema";
+import { MAX_INSTRUCTION_CHARS, MAX_SECTIONS_IN, rewriteSections } from "@/lib/assistant";
+
+/**
+ * Rewrite a site's copy from a plain-language instruction.
+ *
+ * Only reachable when a key is configured. The editor asks first with GET, and hides the
+ * panel entirely when the answer is no, because a button that cannot do the thing it
+ * offers is worse than no button.
+ */
+
+const configured = () => Boolean(env.SARVAM_API_KEY);
+
+export async function GET() {
+  return NextResponse.json(
+    { available: configured() },
+    { headers: { "Cache-Control": "no-store" } }
+  );
+}
+
+/** The body, or null once it exceeds `limit` — at which point reading stops. */
+async function readCapped(req: NextRequest, limit: number): Promise<string | null> {
+  const body = req.body;
+  if (!body) return "";
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  let seen = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      seen += value.byteLength;
+      if (seen > limit) return null;
+      out += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return out + decoder.decode();
+}
+
+export async function POST(req: NextRequest) {
+  if (!configured()) {
+    return NextResponse.json(
+      { error: "This instance has no assistant configured." },
+      { status: 503 }
+    );
+  }
+
+  // Tighter than the export bucket: an export costs CPU, a rewrite costs credit that
+  // runs out for everyone at once.
+  const rl = await rateLimit(getClientIp(req), {
+    bucket: "edit-site",
+    limit: 10,
+    windowMs: 5 * 60_000,
+  });
+  if (!rl.allowed) {
+    const retryAfter = Math.max(1, Math.ceil((rl.resetAt - Date.now()) / 1000));
+    return NextResponse.json(
+      { error: "Too many rewrites. Try again in a few minutes." },
+      { status: 429, headers: { "Retry-After": String(retryAfter) } }
+    );
+  }
+
+  const MAX_BODY = 400_000;
+  const declaredLen = Number(req.headers.get("content-length") ?? "");
+  if (Number.isFinite(declaredLen) && declaredLen > MAX_BODY) {
+    return NextResponse.json({ error: "Request body too large." }, { status: 413 });
+  }
+  const raw = await readCapped(req, MAX_BODY);
+  if (raw === null) {
+    return NextResponse.json({ error: "Request body too large." }, { status: 413 });
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(raw || "{}");
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const { sections: rawSections, instruction: rawInstruction } = (body ?? {}) as {
+    sections?: unknown;
+    instruction?: unknown;
+  };
+
+  const instruction = typeof rawInstruction === "string" ? rawInstruction.trim() : "";
+  if (!instruction) {
+    return NextResponse.json({ error: "Say what you would like changed." }, { status: 400 });
+  }
+  if (instruction.length > MAX_INSTRUCTION_CHARS) {
+    return NextResponse.json(
+      { error: `Keep the instruction under ${MAX_INSTRUCTION_CHARS} characters.` },
+      { status: 400 }
+    );
+  }
+
+  const parsed = sectionsSchema.safeParse(rawSections);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Those sections are not valid." }, { status: 400 });
+  }
+  if (parsed.data.length === 0) {
+    return NextResponse.json({ error: "There is nothing to rewrite yet." }, { status: 400 });
+  }
+  if (parsed.data.length > MAX_SECTIONS_IN) {
+    return NextResponse.json(
+      { error: `The assistant handles up to ${MAX_SECTIONS_IN} sections at a time.` },
+      { status: 400 }
+    );
+  }
+
+  const result = await rewriteSections(parsed.data, instruction, {
+    apiKey: env.SARVAM_API_KEY as string,
+    model: env.SARVAM_MODEL || undefined,
+    signal: AbortSignal.timeout(60_000),
+  });
+
+  if (!result.ok) {
+    // The instruction and the copy are the user's; only the shape of the failure is ours
+    // to record.
+    logger.warn("edit-site rewrite failed", { status: result.status });
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(
+    { sections: result.sections },
+    { headers: { "Cache-Control": "no-store" } }
+  );
+}

--- a/src/app/api/edit-site/route.ts
+++ b/src/app/api/edit-site/route.ts
@@ -13,6 +13,12 @@ import { MAX_INSTRUCTION_CHARS, MAX_SECTIONS_IN, rewriteSections } from "@/lib/a
  * offers is worse than no button.
  */
 
+// A 105B model rewriting a whole site takes tens of seconds, well past the platform's
+// default function budget. Aborting at 50s means the caller gets this route's own error
+// rather than an opaque gateway timeout.
+export const maxDuration = 60;
+const REQUEST_TIMEOUT_MS = 50_000;
+
 const configured = () => Boolean(env.SARVAM_API_KEY);
 
 export async function GET() {
@@ -116,7 +122,8 @@ export async function POST(req: NextRequest) {
   const result = await rewriteSections(parsed.data, instruction, {
     apiKey: env.SARVAM_API_KEY as string,
     model: env.SARVAM_MODEL || undefined,
-    signal: AbortSignal.timeout(60_000),
+    baseUrl: env.SARVAM_BASE_URL || undefined,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
 
   if (!result.ok) {

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -4,6 +4,18 @@ import SiteFooter from "@/components/SiteFooter";
 
 const ENTRIES = [
   {
+    version: "v1.1.0",
+    date: "September 7, 2026",
+    tag: "Minor",
+    tagColor: "bg-white/8 text-foreground border-white/15",
+    changes: [
+      { type: "new", text: "Copy rewriting in the editor — describe the change you want and the section copy is rewritten from it, in one undo step" },
+      { type: "new", text: "The rewrite touches the words only. Layout, colours, images and button links are left as you set them, and anything that comes back malformed is discarded rather than applied" },
+      { type: "new", text: "Instances without an API key do not show the button, so a fresh clone still runs on an empty environment" },
+      { type: "improved", text: "The privacy page now names the rewrite request as the third thing that can leave your browser, and only when you ask for one" },
+    ],
+  },
+  {
     version: "v1.0.0",
     date: "August 27, 2026",
     tag: "Major",

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -12,13 +12,14 @@ import {
   ArrowLeft, Download, Plus, Trash2, Eye, EyeOff, ChevronUp, ChevronDown,
   Layers, Loader2, AlignLeft, AlignCenter, AlignRight,
   Monitor, Tablet, Smartphone, Music, Volume2, VolumeX, Save,
-  Undo2, Redo2, Copy
+  Undo2, Redo2, Copy, Sparkles
 } from "lucide-react";
 import { useScrollAudio } from "@/lib/useScrollAudio";
+import { AssistantBar, useAssistantAvailable } from "@/components/AssistantBar";
 import Link from "next/link";
 import { toast } from "sonner";
 import dynamic from "next/dynamic";
-import { siteStyleSchema, themeSchema, sectionAnchor, visibleSections as onlyVisible, type EditorSection, type SiteStyle, type Theme } from "@/lib/siteSchema";
+import { siteStyleSchema, themeSchema, sectionAnchor, visibleSections as onlyVisible, type EditorSection, type Section as SchemaSection, type SiteStyle, type Theme } from "@/lib/siteSchema";
 import { templateBySlug, type Template } from "@/lib/templates";
 import { layoutStyle } from "@/lib/layoutStyles";
 import { faviconSvg, notFoundHtml, exportReadme, renderSocialCard, renderTouchIcon } from "@/lib/exportAssets";
@@ -187,6 +188,8 @@ function EditorInner() {
   }, [frameCount]);
   const [showPreview, setShowPreview] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
+  const [assistantOpen, setAssistantOpen] = useState(false);
+  const assistantAvailable = useAssistantAvailable();
   // A ZIP export runs for tens of seconds — a template fetch, a sequential fetch per
   // frame, then compression — behind a single spinner. Name the current stage so the
   // wait reads as progress rather than a hang.
@@ -467,6 +470,23 @@ function EditorInner() {
     setDirty(true);
     syncHistoryFlags();
   }, [syncHistoryFlags]);
+
+  // Only the four copy fields are taken, and each falls back to what is already there,
+  // so the editor keeps its own guarantee that every section carries these as strings.
+  // Applied through commitSections, so a rewrite is one undo away from being gone.
+  const applyAssistantEdit = useCallback((rewritten: SchemaSection[]) => {
+    commitSections(prev => prev.map((s, i) => {
+      const from = rewritten[i];
+      if (!from || s.kind === "spacer") return s;
+      return {
+        ...s,
+        eyebrow: from.eyebrow ?? s.eyebrow,
+        heading: from.heading ?? s.heading,
+        body: from.body ?? s.body,
+        ctaLabel: from.ctaLabel ?? s.ctaLabel,
+      };
+    }));
+  }, [commitSections]);
 
   const undo = useCallback(() => {
     if (!undoStack.current.length) return;
@@ -1013,6 +1033,19 @@ function EditorInner() {
           >
             {showPreview ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
           </Button>
+          {assistantAvailable && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setAssistantOpen(o => !o)}
+              aria-expanded={assistantOpen}
+              title="Rewrite the copy from an instruction"
+              className={`h-7 px-3 text-xs gap-1 border-white/10 ${assistantOpen ? "bg-primary/20 text-primary-ink" : ""}`}
+            >
+              <Sparkles className="w-3.5 h-3.5" />
+              Rewrite
+            </Button>
+          )}
           <Button
             variant="outline"
             size="sm"
@@ -1041,6 +1074,14 @@ function EditorInner() {
           )}
         </div>
       </div>
+
+      {assistantAvailable && assistantOpen && (
+        <AssistantBar
+          sections={sections}
+          onApply={applyAssistantEdit}
+          onClose={() => setAssistantOpen(false)}
+        />
+      )}
 
       <main className="flex flex-col md:flex-row flex-1 overflow-y-auto md:overflow-x-auto md:overflow-y-hidden">
         {/* Left panel: sections list */}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -27,7 +27,7 @@ export default function PrivacyPage() {
           (IndexedDB) on your own device.
         </p>
         <p>
-          Two things do leave your browser, both without identifying you:
+          Three things can leave your browser, none of them identifying you:
         </p>
         <ul>
           <li>
@@ -36,9 +36,16 @@ export default function PrivacyPage() {
             not written to any database or log.
           </li>
           <li>
+            <strong>Rewrite requests, only if you ask for one.</strong> The editor can rewrite
+            your copy from an instruction you type. Doing so sends that instruction and the
+            section text to Sarvam AI, which returns the rewritten words. Nothing is sent
+            unless you press Rewrite, and this instance only offers the button when it is
+            configured with a key. The request is not written to any database or log.
+          </li>
+          <li>
             <strong>Ordinary request logs.</strong> Our host records the usual server access
-            logs, including IP addresses, which we also use to rate-limit the export endpoint
-            so one visitor cannot exhaust it for everyone.
+            logs, including IP addresses, which we also use to rate-limit the export and
+            rewrite endpoints so one visitor cannot exhaust them for everyone.
           </li>
         </ul>
         <p>
@@ -51,6 +58,7 @@ export default function PrivacyPage() {
           <li><strong>Vercel</strong> — hosting. Request logs may be retained under their policy.</li>
           <li><strong>Sentry</strong> — error reports, when enabled. These carry a stack trace, not your content.</li>
           <li><strong>Upstash</strong> — rate limiting, when enabled. It stores a counter keyed by IP.</li>
+          <li><strong>Sarvam AI</strong> — the rewrite assistant, when enabled. It receives the instruction you type and the copy of the site you are editing, and only when you press Rewrite.</li>
           <li><strong>Google Fonts</strong> — templates load webfonts, which discloses your IP to Google. Exported sites do the same unless you self-host the fonts.</li>
         </ul>
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -11,7 +11,7 @@ export default function PrivacyPage() {
       <Navbar />
       <article className="max-w-3xl mx-auto px-6 py-16 prose prose-invert prose-sm">
         <h1>Privacy Policy</h1>
-        <p className="text-muted-foreground">Last updated: August 2026</p>
+        <p className="text-muted-foreground">Last updated: September 2026</p>
 
         <h2>The short version</h2>
         <p>
@@ -22,9 +22,9 @@ export default function PrivacyPage() {
 
         <h2>What we collect</h2>
         <p>
-          Nothing you type into ScrollCraft reaches us. Your sections, copy, colours,
-          uploaded video and audio are held in your browser&apos;s local storage
-          (IndexedDB) on your own device.
+          Your sections, copy, colours, uploaded video and audio are held in your
+          browser&apos;s local storage (IndexedDB) on your own device. Nothing there is
+          sent anywhere on its own.
         </p>
         <p>
           Three things can leave your browser, none of them identifying you:

--- a/src/components/AssistantBar.tsx
+++ b/src/components/AssistantBar.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2, Sparkles, X } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { sectionsSchema, type Section } from "@/lib/siteSchema";
+
+/**
+ * Rewriting the site's copy from one plain-language instruction.
+ *
+ * The result is handed back to the editor and applied through its undo stack, so a
+ * rewrite the user dislikes costs one keystroke to reverse. Nothing is applied unless the
+ * response parses as a section list, because the editor's document is not a place to put
+ * whatever came back.
+ */
+
+const MAX_INSTRUCTION_CHARS = 600;
+
+const SUGGESTIONS = [
+  "Make every heading shorter and punchier",
+  "Rewrite it for a small bakery",
+  "Translate the copy to Hindi",
+];
+
+/**
+ * Whether this instance has an assistant at all.
+ *
+ * `null` until the answer is known, so the editor renders no button rather than one that
+ * flickers away. Self-hosted copies without a key never see the feature.
+ */
+export function useAssistantAvailable(): boolean | null {
+  const [available, setAvailable] = useState<boolean | null>(null);
+  useEffect(() => {
+    let live = true;
+    fetch("/api/edit-site")
+      .then((r) => (r.ok ? r.json() : { available: false }))
+      .then((j) => { if (live) setAvailable(Boolean(j?.available)); })
+      .catch(() => { if (live) setAvailable(false); });
+    return () => { live = false; };
+  }, []);
+  return available;
+}
+
+export function AssistantBar({
+  sections,
+  onApply,
+  onClose,
+}: {
+  sections: Section[];
+  onApply: (next: Section[]) => void;
+  onClose: () => void;
+}) {
+  const [instruction, setInstruction] = useState("");
+  const [busy, setBusy] = useState(false);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => { inputRef.current?.focus(); }, []);
+
+  const run = useCallback(async () => {
+    const text = instruction.trim();
+    if (!text || busy) return;
+    setBusy(true);
+    try {
+      const res = await fetch("/api/edit-site", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sections, instruction: text }),
+      });
+      const json = await res.json().catch(() => null);
+      if (!res.ok) {
+        toast.error(json?.error ?? "The rewrite did not go through.");
+        return;
+      }
+      // The response is validated here as well as on the server. The editor writes
+      // whatever it is given straight into the document and then into an export, and a
+      // proxy, an extension or a stale deploy can all sit between the two.
+      const parsed = sectionsSchema.safeParse(json?.sections);
+      if (!parsed.success || parsed.data.length !== sections.length) {
+        toast.error("That rewrite came back malformed, so nothing changed.");
+        return;
+      }
+      onApply(parsed.data);
+      setInstruction("");
+      toast.success("Copy rewritten. Undo puts it back.");
+    } catch {
+      toast.error("Could not reach the assistant.");
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, instruction, onApply, sections]);
+
+  const over = instruction.length > MAX_INSTRUCTION_CHARS;
+
+  return (
+    <div className="border-b border-white/5 bg-card/40 px-4 py-3">
+      <div className="flex items-start gap-2">
+        <Textarea
+          ref={inputRef}
+          value={instruction}
+          onChange={(e) => setInstruction(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); run(); }
+            if (e.key === "Escape") onClose();
+          }}
+          rows={2}
+          aria-label="Describe the change you want"
+          placeholder="Describe the change, such as: rewrite the whole site for a yoga studio in Pune"
+          className="flex-1 min-h-0 resize-none bg-white/5 border-white/10 text-sm"
+        />
+        <div className="flex flex-col gap-1">
+          <Button
+            onClick={run}
+            disabled={busy || !instruction.trim() || over}
+            size="sm"
+            className="bg-primary hover:bg-primary/90 text-white h-8 px-3 text-xs font-semibold"
+          >
+            {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin mr-1" /> : <Sparkles className="w-3.5 h-3.5 mr-1" />}
+            Rewrite
+          </Button>
+          <Button
+            onClick={onClose}
+            variant="ghost"
+            size="sm"
+            aria-label="Close the assistant"
+            className="h-6 px-2 text-xs text-muted-foreground"
+          >
+            <X className="w-3 h-3 mr-1" /> Close
+          </Button>
+        </div>
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        {SUGGESTIONS.map((s) => (
+          <button
+            key={s}
+            type="button"
+            disabled={busy}
+            onClick={() => setInstruction(s)}
+            className="rounded-full border border-white/10 px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground hover:border-white/25 transition-colors disabled:opacity-40"
+          >
+            {s}
+          </button>
+        ))}
+        <span className={`ml-auto text-[11px] tabular-nums ${over ? "text-destructive" : "text-muted-foreground"}`}>
+          {instruction.length}/{MAX_INSTRUCTION_CHARS}
+        </span>
+      </div>
+      <p className="mt-1.5 text-[11px] text-muted-foreground">
+        It rewrites the words only. Layout, colours, images and button links are left as
+        you set them, and the instruction is sent to the assistant to do it.
+      </p>
+    </div>
+  );
+}

--- a/src/components/AssistantBar.tsx
+++ b/src/components/AssistantBar.tsx
@@ -95,6 +95,9 @@ export function AssistantBar({
 
   return (
     <div className="border-b border-white/5 bg-card/40 px-4 py-3">
+      {/* Capped, because a one-line instruction stretched across a 1440px field reads as
+          a mistake and the note under it becomes a 200-character line. */}
+      <div className="max-w-3xl">
       <div className="flex items-start gap-2">
         <Textarea
           ref={inputRef}
@@ -117,7 +120,7 @@ export function AssistantBar({
             className="bg-primary hover:bg-primary/90 text-white h-8 px-3 text-xs font-semibold"
           >
             {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin mr-1" /> : <Sparkles className="w-3.5 h-3.5 mr-1" />}
-            Rewrite
+            Rewrite copy
           </Button>
           <Button
             onClick={onClose}
@@ -142,14 +145,17 @@ export function AssistantBar({
             {s}
           </button>
         ))}
-        <span className={`ml-auto text-[11px] tabular-nums ${over ? "text-destructive" : "text-muted-foreground"}`}>
-          {instruction.length}/{MAX_INSTRUCTION_CHARS}
-        </span>
+        {instruction.length > 0 && (
+          <span className={`ml-auto text-[11px] tabular-nums ${over ? "text-destructive" : "text-muted-foreground"}`}>
+            {instruction.length}/{MAX_INSTRUCTION_CHARS}
+          </span>
+        )}
       </div>
       <p className="mt-1.5 text-[11px] text-muted-foreground">
-        It rewrites the words only. Layout, colours, images and button links are left as
-        you set them, and the instruction is sent to the assistant to do it.
+        The words only. Layout, colours, images and button links stay as you set them.
+        Your instruction and this site&apos;s copy are sent to the assistant to do it.
       </p>
+      </div>
     </div>
   );
 }

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -1,0 +1,160 @@
+import "server-only";
+
+import { MAX_SECTIONS, sectionsSchema, type Section } from "@/lib/siteSchema";
+
+/**
+ * The editor's assistant: a plain-language instruction in, rewritten copy out.
+ *
+ * The model is not trusted with the document. It is asked for JSON, and whatever comes
+ * back is parsed, validated against the editor's own section schema, and then reduced to
+ * the four copy fields before it reaches the caller. A reply that drops a layout, moves a
+ * section or invents a field cannot damage anything, because only the words are taken.
+ */
+
+const SARVAM_URL = "https://api.sarvam.ai/v1/chat/completions";
+
+/** Bounds on what one request may cost, since credits are finite and per-key. */
+export const MAX_INSTRUCTION_CHARS = 600;
+export const MAX_SECTIONS_IN = 40;
+
+export type AssistantResult =
+  | { ok: true; sections: Section[] }
+  | { ok: false; status: number; error: string };
+
+/** The fields the assistant may touch. Everything else is the editor's to set. */
+const EDITABLE_FIELDS = ["eyebrow", "heading", "body", "ctaLabel"] as const;
+
+export function systemPrompt(): string {
+  return [
+    "You rewrite the copy of a scroll-driven marketing website.",
+    "",
+    "You are given the site's sections as a JSON array and one instruction.",
+    "Reply with ONLY the full updated JSON array. No prose, no commentary.",
+    "",
+    "Rules:",
+    '- Return the same number of objects, in the same order, with the same "kind" values.',
+    `- Only change these fields: ${EDITABLE_FIELDS.join(", ")}.`,
+    "- Never invent statistics, customer counts, review scores, funding rounds or",
+    "  certifications, and never name a real company. Whoever publishes this site has to",
+    "  be able to stand behind every sentence.",
+    '- A section whose kind is "spacer" carries no copy. Return it unchanged.',
+    "- Keep a heading under 80 characters and a body under 300.",
+    "- Answer in the language the instruction is written in, unless it says otherwise.",
+  ].join("\n");
+}
+
+/**
+ * Pull the JSON array out of a completion.
+ *
+ * Models wrap JSON in prose and code fences however firmly you ask them not to, so the
+ * array is located rather than assumed to be the whole reply.
+ */
+export function extractJsonArray(text: string): unknown {
+  const trimmed = text.trim();
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/.exec(trimmed);
+  const body = fenced ? fenced[1].trim() : trimmed;
+  const start = body.indexOf("[");
+  const end = body.lastIndexOf("]");
+  if (start === -1 || end <= start) throw new Error("no JSON array in the reply");
+  return JSON.parse(body.slice(start, end + 1));
+}
+
+/**
+ * Keep the structure the editor owns and take only the copy from the reply.
+ */
+export function mergeCopyOnly(original: Section[], proposed: Section[]): Section[] {
+  return original.map((section, i) => {
+    const from = proposed[i];
+    if (!from || section.kind === "spacer") return section;
+    const merged: Section = { ...section };
+    if (typeof from.eyebrow === "string") merged.eyebrow = from.eyebrow;
+    if (typeof from.heading === "string") merged.heading = from.heading;
+    if (typeof from.body === "string") merged.body = from.body;
+    if (typeof from.ctaLabel === "string") merged.ctaLabel = from.ctaLabel;
+    return merged;
+  });
+}
+
+export function buildRequestBody(sections: Section[], instruction: string, model: string) {
+  return {
+    model,
+    temperature: 0.3,
+    messages: [
+      { role: "system", content: systemPrompt() },
+      {
+        role: "user",
+        content: `Instruction: ${instruction}\n\nSections:\n${JSON.stringify(sections)}`,
+      },
+    ],
+  };
+}
+
+export async function rewriteSections(
+  sections: Section[],
+  instruction: string,
+  opts: { apiKey: string; model?: string; fetchImpl?: typeof fetch; signal?: AbortSignal }
+): Promise<AssistantResult> {
+  const doFetch = opts.fetchImpl ?? fetch;
+
+  let res: Response;
+  try {
+    res = await doFetch(SARVAM_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${opts.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(buildRequestBody(sections, instruction, opts.model ?? "sarvam-105b")),
+      signal: opts.signal,
+    });
+  } catch {
+    return { ok: false, status: 502, error: "Could not reach the assistant. Try again." };
+  }
+
+  if (!res.ok) {
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, status: 502, error: "The assistant is not configured correctly." };
+    }
+    if (res.status === 429) {
+      return { ok: false, status: 429, error: "The assistant is busy. Try again in a minute." };
+    }
+    return { ok: false, status: 502, error: "The assistant could not complete that." };
+  }
+
+  let content: unknown;
+  try {
+    const json = (await res.json()) as { choices?: { message?: { content?: unknown } }[] };
+    content = json?.choices?.[0]?.message?.content;
+  } catch {
+    return { ok: false, status: 502, error: "The assistant returned something unreadable." };
+  }
+  if (typeof content !== "string" || !content.trim()) {
+    return { ok: false, status: 502, error: "The assistant returned nothing." };
+  }
+
+  let proposed: unknown;
+  try {
+    proposed = extractJsonArray(content);
+  } catch {
+    return { ok: false, status: 422, error: "The assistant did not return a usable edit." };
+  }
+
+  const parsed = sectionsSchema.safeParse(proposed);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const where = issue?.path?.length ? issue.path.join(".") : "the section list";
+    return { ok: false, status: 422, error: `The assistant's edit was rejected at ${where}.` };
+  }
+  if (parsed.data.length !== sections.length) {
+    return {
+      ok: false,
+      status: 422,
+      error: "The assistant changed how many sections the site has, so the edit was rejected.",
+    };
+  }
+  if (parsed.data.length > MAX_SECTIONS) {
+    return { ok: false, status: 422, error: "The assistant's edit was too long." };
+  }
+
+  return { ok: true, sections: mergeCopyOnly(sections, parsed.data) };
+}

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -11,7 +11,12 @@ import { MAX_SECTIONS, sectionsSchema, type Section } from "@/lib/siteSchema";
  * section or invents a field cannot damage anything, because only the words are taken.
  */
 
-const SARVAM_URL = "https://api.sarvam.ai/v1/chat/completions";
+export const SARVAM_DEFAULT_BASE_URL = "https://api.sarvam.ai/v1";
+
+/** `<base>/chat/completions`, with any number of trailing slashes on the base. */
+export function completionsUrl(baseUrl?: string): string {
+  return `${(baseUrl || SARVAM_DEFAULT_BASE_URL).replace(/\/+$/, "")}/chat/completions`;
+}
 
 /** Bounds on what one request may cost, since credits are finite and per-key. */
 export const MAX_INSTRUCTION_CHARS = 600;
@@ -92,13 +97,19 @@ export function buildRequestBody(sections: Section[], instruction: string, model
 export async function rewriteSections(
   sections: Section[],
   instruction: string,
-  opts: { apiKey: string; model?: string; fetchImpl?: typeof fetch; signal?: AbortSignal }
+  opts: {
+    apiKey: string;
+    model?: string;
+    baseUrl?: string;
+    fetchImpl?: typeof fetch;
+    signal?: AbortSignal;
+  }
 ): Promise<AssistantResult> {
   const doFetch = opts.fetchImpl ?? fetch;
 
   let res: Response;
   try {
-    res = await doFetch(SARVAM_URL, {
+    res = await doFetch(completionsUrl(opts.baseUrl), {
       method: "POST",
       headers: {
         Authorization: `Bearer ${opts.apiKey}`,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -28,6 +28,12 @@ const envSchema = z.object({
   SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).optional(),
   NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).optional(),
 
+  // Sarvam, for the editor's assistant. Absent, the assistant is simply not offered:
+  // there is no degraded mode and no placeholder, because a rewrite it cannot perform is
+  // worse than a button that is not there.
+  SARVAM_API_KEY: z.string().optional(),
+  SARVAM_MODEL: z.enum(["sarvam-105b", "sarvam-105b-conversations"]).optional(),
+
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
 });
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -33,6 +33,13 @@ const envSchema = z.object({
   // worse than a button that is not there.
   SARVAM_API_KEY: z.string().optional(),
   SARVAM_MODEL: z.enum(["sarvam-105b", "sarvam-105b-conversations"]).optional(),
+  // Sarvam speaks the OpenAI chat-completions shape, so a self-hosted copy can point
+  // this at any gateway that speaks it too. Restricted to http(s) so a value from a
+  // misread `.env` cannot turn into a file: or data: fetch.
+  SARVAM_BASE_URL: z.string().url().refine(
+    (u) => /^https?:\/\//i.test(u),
+    "SARVAM_BASE_URL must be an http(s) URL"
+  ).optional(),
 
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
 });


### PR DESCRIPTION
Describe the change you want in plain language and the editor rewrites the section copy from it. One instruction, one undo step.

The v0.4.0 teardown removed chat editing because it was an AI feature attached to a product that had no keys, no accounts and nothing to configure. This is narrower on purpose, so that stays true: an instance without a key does not show the button, and a fresh clone still runs on an empty environment.

## What it does

- A **Rewrite** button in the editor toolbar opens a bar: an instruction field, three starting suggestions, a character counter and a note saying what is sent where.
- The result goes through `commitSections`, so it lands as a single undo step. The toast says so.
- It rewrites `eyebrow`, `heading`, `body` and `ctaLabel`. Nothing else. Layout, colours, images, button links, scroll heights and visibility are read back from the document, not from the reply, so a model that redirects a call to action or stretches a scroll track changes nothing.
- Spacers are returned untouched.

## Not trusting the reply

The reply is copy, not a document. In order:

1. The completion is located inside whatever prose or code fence the model wrapped it in.
2. It is parsed as JSON, then validated against `sectionsSchema` — the same schema the editor's own document has to satisfy.
3. The section count must match. A reply that drops or adds one is rejected whole.
4. Only the four copy fields are read out of it. Everything else comes from the original.
5. The editor validates the response a second time before applying it, because a proxy, an extension or a stale deploy can sit between the route and the browser.

Anything that fails returns a 422 and the document is left alone.

## Configuration

| Variable | Effect |
|---|---|
| `SARVAM_API_KEY` | Turns the feature on. Absent, `GET /api/edit-site` answers `{"available":false}` and the editor renders no button |
| `SARVAM_MODEL` | `sarvam-105b` (default) or `sarvam-105b-conversations` |
| `SARVAM_BASE_URL` | Any endpoint speaking the OpenAI chat-completions shape. Defaults to Sarvam. Restricted to http(s) |

Rate limited at 10 per five minutes per IP, tighter than export's 30 per minute: an export costs CPU, a rewrite costs credit that runs out for everyone at once. Body capped at 400 KB with the same running-cap reader `export-site` uses, instruction capped at 600 characters, and at most 40 sections per call. `maxDuration = 60` with a 50s abort, so a slow completion returns this route's own error rather than a gateway timeout.

## Verified

**42 new tests**, suite 388 to 432, all passing.

Five guards mutated one at a time to prove the tests bite:

| Mutation | Result |
|---|---|
| return the model's reply instead of merging copy only | 2 failed |
| skip `sectionsSchema` validation of the reply | 2 failed |
| serve the route with no key configured | 3 failed |
| drop the section-count check | 2 failed |
| drop the instruction length cap | 1 failed |

End to end in headless Chrome against the production build, with a local endpoint standing in for Sarvam (`SARVAM_BASE_URL`), driving the real UI:

- **aurabeauty** — 9 sections sent, all 7 non-spacer headings rewritten, spacers untouched, toast shown, `Undo` restored the original list exactly.
- **ledger-fintech** — same, on a second template.
- Request received by the stub carried `Authorization: Bearer <key>` and `model=sarvam-105b`; the reply came back inside a ```json fence and parsed.
- Round trip through the route preserved `ctaHref: "#section-9"` while changing the heading.
- **Unconfigured instance**: `{"available":false}`, `POST` 503, and no button in the DOM.

Screenshotted at 1440x900 and 390x844: no horizontal overflow at either width, and the submit button is hit-testable via `elementFromPoint` once enabled.

`tsc --noEmit` clean, `eslint` clean, production build clean.

**Not verified: the live Sarvam API.** There is no key in this environment, so every assertion above comes from mocked fetch or the local stub. The request shape is built from the published contract at `docs.sarvam.ai/api-reference/chat/chat-completions` — `POST /v1/chat/completions`, bearer auth, OpenAI-shaped response — but nobody has run it against `api.sarvam.ai`. To try it: put a key in `.env` as `SARVAM_API_KEY` and run `npm run dev`.

## Also

- The privacy page said two things leave your browser. It now says three, names the rewrite request as the one that only happens if you ask, lists Sarvam under third-party services, and drops the flat "nothing you type reaches us" that this makes untrue.
- `contactDetails.test.ts` had a test called "promises no AI, which the product does not have". That premise is no longer true, so it is now two tests that check what still matters: the landing, presets, create and about pages must not promise a feature they cannot know is configured, none of them may use the marketing register v0.4.0 removed, and the README must mention the key in the same breath as the rewriting.
- Changelog entry v1.1.0.

## Limits

It rewrites; it does not restructure. Adding, removing or reordering sections stays manual, because section count drives the scroll track and a model that quietly returns eight sections for nine would silently retime the page.
