### PR TITLE
Fix the assistant against the live API: output budget and batching

### DIFF
--- a/src/__tests__/assistant.test.ts
+++ b/src/__tests__/assistant.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   completionsUrl,
+  describeCompletion,
   extractJsonArray,
   mergeCopyOnly,
   rewriteSections,
@@ -167,6 +168,24 @@ describe("rewriteSections", () => {
     expect(res).toMatchObject({ ok: false, status: 502 });
   });
 
+  it("says why an empty completion was empty, so a 502 is diagnosable", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [{ finish_reason: "length", message: { content: "", reasoning_content: "x".repeat(40) } }],
+        usage: { completion_tokens: 512 },
+      }),
+    })) as unknown as typeof fetch;
+    const res = await rewriteSections(DOC, "hi", { ...opts, fetchImpl });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.diagnostic).toMatchObject({
+      finishReason: "length",
+      messageFields: { content: "string(0)", reasoning_content: "string(40)" },
+    });
+  });
+
   it("passes an upstream rate limit through as a rate limit", async () => {
     const fetchImpl = vi.fn(async () => ({ ok: false, status: 429 }) as Response);
     const res = await rewriteSections(DOC, "hi", { ...opts, fetchImpl: fetchImpl as typeof fetch });
@@ -213,6 +232,31 @@ describe("rewriteSections", () => {
     await rewriteSections(DOC, "hi", { apiKey: "k", fetchImpl });
     const init = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
     expect(JSON.parse(String(init.body)).model).toBe("sarvam-105b");
+  });
+});
+
+describe("describeCompletion", () => {
+  it("names the fields the reply carried and how long each was", () => {
+    const d = describeCompletion({
+      choices: [{ finish_reason: "length", message: { content: "", reasoning_content: "abc" } }],
+      usage: { total_tokens: 9 },
+    });
+    expect(d).toEqual({
+      choices: 1,
+      finishReason: "length",
+      messageFields: { content: "string(0)", reasoning_content: "string(3)" },
+      usage: { total_tokens: 9 },
+    });
+  });
+
+  it("carries no copy, only its shape", () => {
+    const secret = "Radiance, redefined.";
+    const d = describeCompletion({ choices: [{ message: { content: secret } }] });
+    expect(JSON.stringify(d)).not.toContain("Radiance");
+  });
+
+  it("survives a reply with no choices at all", () => {
+    expect(describeCompletion({})).toMatchObject({ choices: 0, finishReason: null });
   });
 });
 

--- a/src/__tests__/assistant.test.ts
+++ b/src/__tests__/assistant.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import {
+  BATCH_SIZE,
   MAX_COMPLETION_TOKENS,
   completionsUrl,
   describeCompletion,
@@ -10,17 +11,37 @@ import {
 } from "@/lib/assistant";
 import type { Section } from "@/lib/siteSchema";
 
-function reply(content: string) {
-  return {
+/** A stub that answers every batch with the same content. */
+function fetchReturning(content: string) {
+  return vi.fn(async () => ({
     ok: true,
     status: 200,
-    json: async () => ({ choices: [{ message: { content } }] }),
-  } as unknown as Response;
+    json: async () => ({ choices: [{ finish_reason: "stop", message: { content } }] }),
+  })) as unknown as typeof fetch;
 }
 
-function fetchReturning(content: string) {
-  return vi.fn(async () => reply(content)) as unknown as typeof fetch;
+/** A stub that reads the batch it was sent and rewrites each heading in it. */
+function fetchEchoing(transform: (heading: string) => string) {
+  return vi.fn(async (_url: string, init: RequestInit) => {
+    const sent = JSON.parse(String(init.body));
+    const asked = String(sent.messages[1].content);
+    const headings = [...asked.matchAll(/^Section \d+: (\{.*\})$/gm)].map(
+      (m) => JSON.parse(m[1]).heading ?? ""
+    );
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [
+          { finish_reason: "stop", message: { content: JSON.stringify(headings.map((h) => ({ heading: transform(h) }))) } },
+        ],
+      }),
+    };
+  }) as unknown as typeof fetch;
 }
+
+const calls = (f: typeof fetch) => (f as unknown as ReturnType<typeof vi.fn>).mock.calls;
+const bodyOf = (f: typeof fetch, n = 0) => JSON.parse(String((calls(f)[n][1] as RequestInit).body));
 
 const DOC: Section[] = [
   {
@@ -37,6 +58,13 @@ const DOC: Section[] = [
   },
   { id: "s2", kind: "spacer", scrollHeight: 600 },
 ];
+
+/** Nine sections with two spacers, the shape a real template has. */
+const SITE: Section[] = Array.from({ length: 9 }, (_, i) =>
+  i === 3 || i === 7
+    ? { id: `s${i}`, kind: "spacer" as const, scrollHeight: 600 }
+    : { id: `s${i}`, kind: "text" as const, layout: "left" as const, heading: `Heading ${i}`, ctaHref: "#a" }
+);
 
 const opts = { apiKey: "k" };
 
@@ -89,13 +117,54 @@ describe("mergeCopyOnly", () => {
   });
 });
 
+describe("describeCompletion", () => {
+  it("names the fields the reply carried and how long each was", () => {
+    const d = describeCompletion({
+      choices: [{ finish_reason: "length", message: { content: "", reasoning_content: "abc" } }],
+      usage: { total_tokens: 9 },
+    });
+    expect(d).toEqual({
+      choices: 1,
+      finishReason: "length",
+      messageFields: { content: "string(0)", reasoning_content: "string(3)" },
+      usage: { total_tokens: 9 },
+    });
+  });
+
+  it("carries no copy, only its shape", () => {
+    const d = describeCompletion({ choices: [{ message: { content: "Radiance, redefined." } }] });
+    expect(JSON.stringify(d)).not.toContain("Radiance");
+  });
+
+  it("survives a reply with no choices at all", () => {
+    expect(describeCompletion({})).toMatchObject({ choices: 0, finishReason: null });
+  });
+});
+
+describe("completionsUrl", () => {
+  it("defaults to Sarvam", () => {
+    expect(completionsUrl()).toBe("https://api.sarvam.ai/v1/chat/completions");
+    expect(completionsUrl("")).toBe("https://api.sarvam.ai/v1/chat/completions");
+  });
+
+  it("takes a gateway that speaks the same shape", () => {
+    expect(completionsUrl("http://127.0.0.1:8080/v1")).toBe(
+      "http://127.0.0.1:8080/v1/chat/completions"
+    );
+  });
+
+  it("does not double the slash on a base that ends in one", () => {
+    expect(completionsUrl("https://gw.example.com/v1///")).toBe(
+      "https://gw.example.com/v1/chat/completions"
+    );
+  });
+});
+
 describe("rewriteSections", () => {
   it("applies a well formed rewrite", async () => {
     const res = await rewriteSections(DOC, "make it warmer", {
       ...opts,
-      fetchImpl: fetchReturning(
-        JSON.stringify([{ heading: "Warmer heading", body: "Warmer body." }, {}])
-      ),
+      fetchImpl: fetchReturning(JSON.stringify([{ heading: "Warmer heading", body: "Warmer body." }])),
     });
     expect(res.ok).toBe(true);
     if (!res.ok) return;
@@ -119,7 +188,6 @@ describe("rewriteSections", () => {
             scrollHeight: 19_000,
             visible: false,
           },
-          {},
         ])
       ),
     });
@@ -132,10 +200,10 @@ describe("rewriteSections", () => {
     expect(res.sections[0].visible).toBeUndefined();
   });
 
-  it("rejects a reply that changes the section count", async () => {
+  it("rejects a batch that comes back the wrong length", async () => {
     const res = await rewriteSections(DOC, "trim it", {
       ...opts,
-      fetchImpl: fetchReturning(JSON.stringify([{ heading: "Only one" }])),
+      fetchImpl: fetchReturning(JSON.stringify([{ heading: "one" }, { heading: "two" }])),
     });
     expect(res).toMatchObject({ ok: false, status: 422 });
   });
@@ -151,7 +219,7 @@ describe("rewriteSections", () => {
   it("rejects a reply that is JSON but not a section list", async () => {
     const res = await rewriteSections(DOC, "hi", {
       ...opts,
-      fetchImpl: fetchReturning('[{"heading": 42}, {}]'),
+      fetchImpl: fetchReturning('[{"heading": 42}]'),
     });
     expect(res).toMatchObject({ ok: false, status: 422 });
   });
@@ -159,7 +227,7 @@ describe("rewriteSections", () => {
   it("rejects copy that exceeds what the schema allows", async () => {
     const res = await rewriteSections(DOC, "expand", {
       ...opts,
-      fetchImpl: fetchReturning(JSON.stringify([{ heading: "x".repeat(501) }, {}])),
+      fetchImpl: fetchReturning(JSON.stringify([{ heading: "x".repeat(501) }])),
     });
     expect(res).toMatchObject({ ok: false, status: 422 });
   });
@@ -169,16 +237,13 @@ describe("rewriteSections", () => {
     expect(res).toMatchObject({ ok: false, status: 502 });
   });
 
-  // The bug this pins: sarvam-105b reasons first, and on the API's own default of 2048
-  // tokens it spent every one of them thinking and returned a null content. Without an
-  // explicit budget the feature failed on roughly every request.
+  // The bug this pins: sarvam-105b reasons before answering, and on the API's own default
+  // of 2048 tokens it spent every one of them thinking and returned a null content.
   it("asks for an output budget large enough to hold reasoning and the answer", async () => {
-    const fetchImpl = fetchReturning(JSON.stringify([{ heading: "ok" }, {}]));
-    await rewriteSections(DOC, "hi", { apiKey: "k", fetchImpl });
-    const init = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
-    const sent = JSON.parse(String(init.body));
-    expect(sent.max_tokens).toBe(MAX_COMPLETION_TOKENS);
-    expect(sent.max_tokens).toBeGreaterThan(2048);
+    const fetchImpl = fetchReturning(JSON.stringify([{ heading: "ok" }]));
+    await rewriteSections(DOC, "hi", { ...opts, fetchImpl });
+    expect(bodyOf(fetchImpl).max_tokens).toBe(MAX_COMPLETION_TOKENS);
+    expect(bodyOf(fetchImpl).max_tokens).toBeGreaterThan(2048);
   });
 
   it("says the reply was cut off rather than blaming an empty one", async () => {
@@ -251,17 +316,14 @@ describe("rewriteSections", () => {
     expect(res).toMatchObject({ ok: false, status: 502 });
   });
 
-  it("sends the key as a bearer token and the instruction with the sections", async () => {
-    const fetchImpl = fetchReturning(JSON.stringify([{ heading: "ok" }, {}]));
+  it("sends the key as a bearer token, and the instruction with the copy", async () => {
+    const fetchImpl = fetchReturning(JSON.stringify([{ heading: "ok" }]));
     await rewriteSections(DOC, "translate to Hindi", {
       apiKey: "secret-key",
       model: "sarvam-105b-conversations",
       fetchImpl,
     });
-    const [url, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [
-      string,
-      RequestInit,
-    ];
+    const [url, init] = calls(fetchImpl)[0] as [string, RequestInit];
     expect(url).toBe("https://api.sarvam.ai/v1/chat/completions");
     expect((init.headers as Record<string, string>).Authorization).toBe("Bearer secret-key");
     const sent = JSON.parse(String(init.body));
@@ -271,61 +333,118 @@ describe("rewriteSections", () => {
   });
 
   it("defaults to the larger model", async () => {
-    const fetchImpl = fetchReturning(JSON.stringify([{ heading: "ok" }, {}]));
+    const fetchImpl = fetchReturning(JSON.stringify([{ heading: "ok" }]));
     await rewriteSections(DOC, "hi", { apiKey: "k", fetchImpl });
-    const init = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
-    expect(JSON.parse(String(init.body)).model).toBe("sarvam-105b");
+    expect(bodyOf(fetchImpl).model).toBe("sarvam-105b");
   });
 });
 
-describe("describeCompletion", () => {
-  it("names the fields the reply carried and how long each was", () => {
-    const d = describeCompletion({
-      choices: [{ finish_reason: "length", message: { content: "", reasoning_content: "abc" } }],
-      usage: { total_tokens: 9 },
+/**
+ * How the work is divided.
+ *
+ * One call per document did not fit: measured against the live API a single section took
+ * 13-21s and a nine-section site in Hindi ran past the route's 50s abort. These pin the
+ * batching that replaced it.
+ */
+describe("rewriteSections batching", () => {
+  it("never spends a call on a spacer", async () => {
+    const fetchImpl = fetchReturning("[]");
+    const spacersOnly: Section[] = [
+      { id: "a", kind: "spacer", scrollHeight: 600 },
+      { id: "b", kind: "spacer", scrollHeight: 700 },
+    ];
+    const res = await rewriteSections(spacersOnly, "warmer", { ...opts, fetchImpl });
+    expect(res).toEqual({ ok: true, sections: spacersOnly });
+    expect(calls(fetchImpl)).toHaveLength(0);
+  });
+
+  it("splits the sections that do carry copy into batches", async () => {
+    const fetchImpl = fetchEchoing((h) => `New ${h}`);
+    await rewriteSections(SITE, "warmer", { ...opts, fetchImpl });
+    // 9 sections, 2 of them spacers, so 7 to rewrite.
+    expect(calls(fetchImpl)).toHaveLength(Math.ceil(7 / BATCH_SIZE));
+  });
+
+  it("puts every rewritten heading back on the section it came from", async () => {
+    const fetchImpl = fetchEchoing((h) => `New ${h}`);
+    const res = await rewriteSections(SITE, "warmer", { ...opts, fetchImpl });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.sections.map((s) => s.heading)).toEqual([
+      "New Heading 0",
+      "New Heading 1",
+      "New Heading 2",
+      undefined,
+      "New Heading 4",
+      "New Heading 5",
+      "New Heading 6",
+      undefined,
+      "New Heading 8",
+    ]);
+  });
+
+  it("keeps the spacers untouched and in place", async () => {
+    const res = await rewriteSections(SITE, "warmer", {
+      ...opts,
+      fetchImpl: fetchEchoing((h) => `New ${h}`),
     });
-    expect(d).toEqual({
-      choices: 1,
-      finishReason: "length",
-      messageFields: { content: "string(0)", reasoning_content: "string(3)" },
-      usage: { total_tokens: 9 },
-    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.sections[3]).toEqual(SITE[3]);
+    expect(res.sections[7]).toEqual(SITE[7]);
   });
 
-  it("carries no copy, only its shape", () => {
-    const secret = "Radiance, redefined.";
-    const d = describeCompletion({ choices: [{ message: { content: secret } }] });
-    expect(JSON.stringify(d)).not.toContain("Radiance");
+  it("gives every batch the whole site as context, so the wording stays consistent", async () => {
+    const fetchImpl = fetchEchoing((h) => h);
+    await rewriteSections(SITE, "warmer", { ...opts, fetchImpl });
+    for (let i = 0; i < calls(fetchImpl).length; i++) {
+      const prompt = String(bodyOf(fetchImpl, i).messages[1].content);
+      expect(prompt).toContain("Heading 0");
+      expect(prompt).toContain("Heading 8");
+      expect(prompt).toContain("(spacer)");
+    }
   });
 
-  it("survives a reply with no choices at all", () => {
-    expect(describeCompletion({})).toMatchObject({ choices: 0, finishReason: null });
+  // A half-rewritten site is worse than an unchanged one.
+  it("applies nothing at all when one batch fails", async () => {
+    // Every batch but the second answers correctly, so the failure is the upstream 500
+    // and not a mis-shaped stub.
+    let n = 0;
+    const good = fetchEchoing((h) => `New ${h}`);
+    const fetchImpl = vi.fn(async (url: string, init: RequestInit) => {
+      n += 1;
+      if (n === 2) return { ok: false, status: 500 } as Response;
+      return (good as unknown as (u: string, i: RequestInit) => Promise<Response>)(url, init);
+    }) as unknown as typeof fetch;
+    const res = await rewriteSections(SITE, "warmer", { ...opts, fetchImpl });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.status).toBe(502);
+    expect(res.error).toMatch(/could not complete/i);
   });
-});
 
-describe("completionsUrl", () => {
-  it("defaults to Sarvam", () => {
-    expect(completionsUrl()).toBe("https://api.sarvam.ai/v1/chat/completions");
-    expect(completionsUrl("")).toBe("https://api.sarvam.ai/v1/chat/completions");
+  it("rewrites a section count no single call could hold", async () => {
+    const fetchImpl = fetchEchoing((h) => `New ${h}`);
+    const res = await rewriteSections(SITE, "warmer", { ...opts, fetchImpl });
+    expect(res.ok).toBe(true);
+    expect(calls(fetchImpl).length).toBeGreaterThan(1);
   });
 
-  it("takes a gateway that speaks the same shape", () => {
-    expect(completionsUrl("http://127.0.0.1:8080/v1")).toBe(
-      "http://127.0.0.1:8080/v1/chat/completions"
-    );
-  });
-
-  it("does not double the slash on a base that ends in one", () => {
-    expect(completionsUrl("https://gw.example.com/v1///")).toBe(
-      "https://gw.example.com/v1/chat/completions"
-    );
+  it("refuses a site longer than batching can finish in one request", async () => {
+    const fetchImpl = fetchReturning("[]");
+    const huge = Array.from({ length: 25 }, (_, i) => ({ id: `s${i}`, kind: "text" as const, heading: "h" }));
+    const res = await rewriteSections(huge, "warmer", { ...opts, fetchImpl });
+    expect(res).toMatchObject({ ok: false, status: 400 });
+    expect(calls(fetchImpl)).toHaveLength(0);
   });
 });
 
 describe("systemPrompt", () => {
   it("forbids inventing the claims a site owner would have to defend", () => {
-    const prompt = systemPrompt();
-    expect(prompt).toMatch(/never invent statistics/i);
-    expect(prompt).toMatch(/spacer/i);
+    expect(systemPrompt()).toMatch(/never invent statistics/i);
+  });
+
+  it("tells the model to answer with the array and stop", () => {
+    expect(systemPrompt()).toMatch(/do not explain yourself/i);
   });
 });

--- a/src/__tests__/assistant.test.ts
+++ b/src/__tests__/assistant.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import {
+  MAX_COMPLETION_TOKENS,
   completionsUrl,
   describeCompletion,
   extractJsonArray,
@@ -166,6 +167,48 @@ describe("rewriteSections", () => {
   it("reports an empty completion rather than wiping the copy", async () => {
     const res = await rewriteSections(DOC, "hi", { ...opts, fetchImpl: fetchReturning("   ") });
     expect(res).toMatchObject({ ok: false, status: 502 });
+  });
+
+  // The bug this pins: sarvam-105b reasons first, and on the API's own default of 2048
+  // tokens it spent every one of them thinking and returned a null content. Without an
+  // explicit budget the feature failed on roughly every request.
+  it("asks for an output budget large enough to hold reasoning and the answer", async () => {
+    const fetchImpl = fetchReturning(JSON.stringify([{ heading: "ok" }, {}]));
+    await rewriteSections(DOC, "hi", { apiKey: "k", fetchImpl });
+    const init = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+    const sent = JSON.parse(String(init.body));
+    expect(sent.max_tokens).toBe(MAX_COMPLETION_TOKENS);
+    expect(sent.max_tokens).toBeGreaterThan(2048);
+  });
+
+  it("says the reply was cut off rather than blaming an empty one", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [{ finish_reason: "length", message: { content: null, reasoning_content: "x".repeat(6683) } }],
+        usage: { completion_tokens: 2048 },
+      }),
+    })) as unknown as typeof fetch;
+    const res = await rewriteSections(DOC, "hi", { ...opts, fetchImpl });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error).toMatch(/too long/i);
+    expect(res.error).not.toMatch(/returned nothing/i);
+  });
+
+  it("reports a refusal as a refusal, not as a broken reply", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [{ finish_reason: "stop", message: { content: null, refusal: "I cannot help with that." } }],
+      }),
+    })) as unknown as typeof fetch;
+    const res = await rewriteSections(DOC, "hi", { ...opts, fetchImpl });
+    expect(res).toMatchObject({ ok: false, status: 422 });
+    if (res.ok) return;
+    expect(res.error).toMatch(/declined/i);
   });
 
   it("says why an empty completion was empty, so a 502 is diagnosable", async () => {

--- a/src/__tests__/editSiteRoute.test.ts
+++ b/src/__tests__/editSiteRoute.test.ts
@@ -70,10 +70,7 @@ describe("assistant availability", () => {
 
 describe("POST /api/edit-site input handling", () => {
   it("rewrites the copy and leaves the structure alone", async () => {
-    vi.stubGlobal(
-      "fetch",
-      completion(JSON.stringify([{ heading: "After", body: "New copy." }, {}]))
-    );
+    vi.stubGlobal("fetch", completion(JSON.stringify([{ heading: "After", body: "New copy." }])));
     const res = await POST(post({ sections: SECTIONS, instruction: "make it warmer" }));
     expect(res.status).toBe(200);
     const { sections } = await res.json();
@@ -113,7 +110,7 @@ describe("POST /api/edit-site input handling", () => {
     expect(res.status).toBe(400);
   });
 
-  it("rejects more sections than one call should carry", async () => {
+  it("rejects more sections than one request should carry", async () => {
     const many = Array.from({ length: 41 }, (_, i) => ({ id: `s${i}`, heading: "h" }));
     const spy = completion("[]");
     vi.stubGlobal("fetch", spy);
@@ -143,8 +140,9 @@ describe("POST /api/edit-site upstream failures", () => {
     expect(await res.json()).not.toHaveProperty("sections");
   });
 
-  it("does not apply an edit that drops a section", async () => {
-    vi.stubGlobal("fetch", completion(JSON.stringify([{ heading: "Only one" }])));
+  it("does not apply an edit that answers with the wrong number of sections", async () => {
+    // One text section and a spacer, so exactly one object is asked for and expected.
+    vi.stubGlobal("fetch", completion(JSON.stringify([{ heading: "one" }, { heading: "two" }])));
     const res = await POST(post({ sections: SECTIONS, instruction: "shorter" }));
     expect(res.status).toBe(422);
   });

--- a/src/app/api/edit-site/route.ts
+++ b/src/app/api/edit-site/route.ts
@@ -129,7 +129,7 @@ export async function POST(req: NextRequest) {
   if (!result.ok) {
     // The instruction and the copy are the user's; only the shape of the failure is ours
     // to record.
-    logger.warn("edit-site rewrite failed", { status: result.status });
+    logger.warn("edit-site rewrite failed", { status: result.status, ...result.diagnostic });
     return NextResponse.json({ error: result.error }, { status: result.status });
   }
 

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -24,7 +24,38 @@ export const MAX_SECTIONS_IN = 40;
 
 export type AssistantResult =
   | { ok: true; sections: Section[] }
-  | { ok: false; status: number; error: string };
+  | { ok: false; status: number; error: string; diagnostic?: Record<string, unknown> };
+
+/** The upstream shape, as much of it as this module reads. */
+type Completion = {
+  choices?: {
+    finish_reason?: unknown;
+    message?: Record<string, unknown>;
+  }[];
+  usage?: Record<string, unknown>;
+};
+
+/**
+ * Why a completion could not be used, in field names and lengths only.
+ *
+ * A 502 saying "the assistant returned nothing" is unactionable on its own: it cannot
+ * distinguish a model that stopped early from one that put its answer in a field this
+ * code does not read. None of the copy itself goes in here.
+ */
+export function describeCompletion(json: Completion): Record<string, unknown> {
+  const choice = json?.choices?.[0];
+  const message = choice?.message ?? {};
+  const fields: Record<string, string> = {};
+  for (const [key, value] of Object.entries(message)) {
+    fields[key] = typeof value === "string" ? `string(${value.length})` : typeof value;
+  }
+  return {
+    choices: Array.isArray(json?.choices) ? json.choices.length : 0,
+    finishReason: choice?.finish_reason ?? null,
+    messageFields: fields,
+    usage: json?.usage ?? null,
+  };
+}
 
 /** The fields the assistant may touch. Everything else is the editor's to set. */
 const EDITABLE_FIELDS = ["eyebrow", "heading", "body", "ctaLabel"] as const;
@@ -132,22 +163,32 @@ export async function rewriteSections(
     return { ok: false, status: 502, error: "The assistant could not complete that." };
   }
 
-  let content: unknown;
+  let json: Completion;
   try {
-    const json = (await res.json()) as { choices?: { message?: { content?: unknown } }[] };
-    content = json?.choices?.[0]?.message?.content;
+    json = (await res.json()) as Completion;
   } catch {
     return { ok: false, status: 502, error: "The assistant returned something unreadable." };
   }
+  const content = json?.choices?.[0]?.message?.content;
   if (typeof content !== "string" || !content.trim()) {
-    return { ok: false, status: 502, error: "The assistant returned nothing." };
+    return {
+      ok: false,
+      status: 502,
+      error: "The assistant returned nothing.",
+      diagnostic: describeCompletion(json),
+    };
   }
 
   let proposed: unknown;
   try {
     proposed = extractJsonArray(content);
   } catch {
-    return { ok: false, status: 422, error: "The assistant did not return a usable edit." };
+    return {
+      ok: false,
+      status: 422,
+      error: "The assistant did not return a usable edit.",
+      diagnostic: describeCompletion(json),
+    };
   }
 
   const parsed = sectionsSchema.safeParse(proposed);

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -20,7 +20,22 @@ export function completionsUrl(baseUrl?: string): string {
 
 /** Bounds on what one request may cost, since credits are finite and per-key. */
 export const MAX_INSTRUCTION_CHARS = 600;
-export const MAX_SECTIONS_IN = 40;
+
+/**
+ * How the work is divided.
+ *
+ * One call per whole document does not fit in a request. sarvam-105b reasons before it
+ * answers, and measured against the live API a single section took 13-21s while a
+ * nine-section site in Hindi ran past 50s and was aborted. Sections are therefore
+ * rewritten a few at a time, in parallel, so wall time tracks the batch rather than the
+ * length of the site. Spacers carry no copy and are never sent at all.
+ *
+ * MAX_SECTIONS_IN follows from the rest: BATCH_SIZE * CONCURRENCY sections per wave, and
+ * two waves inside the route's own time budget.
+ */
+export const BATCH_SIZE = 3;
+export const CONCURRENCY = 4;
+export const MAX_SECTIONS_IN = 24;
 
 /**
  * Output budget for one completion.
@@ -75,21 +90,33 @@ export function systemPrompt(): string {
   return [
     "You rewrite the copy of a scroll-driven marketing website.",
     "",
-    "You are given the site's sections as a JSON array and one instruction.",
-    "Reply with ONLY the full updated JSON array. No prose, no commentary.",
+    "You are given one instruction, the whole site's copy for context, and the numbered",
+    "sections you must rewrite. Reply with ONLY a JSON array holding one object per",
+    "section you were asked to rewrite, in the order they were given. No prose.",
     "",
     "Rules:",
-    '- Return the same number of objects, in the same order, with the same "kind" values.',
-    `- Only change these fields: ${EDITABLE_FIELDS.join(", ")}.`,
+    `- Only these fields: ${EDITABLE_FIELDS.join(", ")}. Omit a field to leave it alone.`,
     "- Never invent statistics, customer counts, review scores, funding rounds or",
     "  certifications, and never name a real company. Whoever publishes this site has to",
     "  be able to stand behind every sentence.",
-    '- A section whose kind is "spacer" carries no copy. Return it unchanged.',
     "- Keep a heading under 80 characters and a body under 300.",
     "- Answer in the language the instruction is written in, unless it says otherwise.",
+    "- The context is there so your wording stays consistent across the whole site.",
+    "  Rewrite only the sections you were asked for.",
     "",
     "Do not explain yourself or think out loud. Emit the array and stop.",
   ].join("\n");
+}
+
+/** The copy of the whole site, so a batch stays consistent with the sections around it. */
+function siteContext(sections: Section[]): string {
+  return sections
+    .map((s, i) =>
+      s.kind === "spacer"
+        ? `${i}. (spacer)`
+        : `${i}. ${[s.eyebrow, s.heading, s.body, s.ctaLabel].filter(Boolean).join(" / ")}`
+    )
+    .join("\n");
 }
 
 /**
@@ -124,7 +151,15 @@ export function mergeCopyOnly(original: Section[], proposed: Section[]): Section
   });
 }
 
-export function buildRequestBody(sections: Section[], instruction: string, model: string) {
+export function buildRequestBody(
+  sections: Section[],
+  batch: { index: number; section: Section }[],
+  instruction: string,
+  model: string
+) {
+  const asked = batch
+    .map(({ index, section }) => `Section ${index}: ${JSON.stringify(copyOf(section))}`)
+    .join("\n");
   return {
     model,
     temperature: 0.3,
@@ -133,23 +168,38 @@ export function buildRequestBody(sections: Section[], instruction: string, model
       { role: "system", content: systemPrompt() },
       {
         role: "user",
-        content: `Instruction: ${instruction}\n\nSections:\n${JSON.stringify(sections)}`,
+        content:
+          `Instruction: ${instruction}\n\n` +
+          `The whole site, for context:\n${siteContext(sections)}\n\n` +
+          `Rewrite these ${batch.length} section(s), and return exactly ${batch.length} object(s):\n${asked}`,
       },
     ],
   };
 }
 
-export async function rewriteSections(
+/** Just the four fields the model is allowed to see itself changing. */
+function copyOf(section: Section): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (section.eyebrow) out.eyebrow = section.eyebrow;
+  if (section.heading) out.heading = section.heading;
+  if (section.body) out.body = section.body;
+  if (section.ctaLabel) out.ctaLabel = section.ctaLabel;
+  return out;
+}
+
+type Batch = { index: number; section: Section }[];
+
+type BatchResult =
+  | { ok: true; copy: Section[] }
+  | { ok: false; status: number; error: string; diagnostic?: Record<string, unknown> };
+
+/** One call: a few sections in, the same number of copy objects out. */
+async function rewriteBatch(
   sections: Section[],
+  batch: Batch,
   instruction: string,
-  opts: {
-    apiKey: string;
-    model?: string;
-    baseUrl?: string;
-    fetchImpl?: typeof fetch;
-    signal?: AbortSignal;
-  }
-): Promise<AssistantResult> {
+  opts: RewriteOptions
+): Promise<BatchResult> {
   const doFetch = opts.fetchImpl ?? fetch;
 
   let res: Response;
@@ -160,7 +210,9 @@ export async function rewriteSections(
         Authorization: `Bearer ${opts.apiKey}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(buildRequestBody(sections, instruction, opts.model ?? "sarvam-105b")),
+      body: JSON.stringify(
+        buildRequestBody(sections, batch, instruction, opts.model ?? "sarvam-105b")
+      ),
       signal: opts.signal,
     });
   } catch {
@@ -183,6 +235,7 @@ export async function rewriteSections(
   } catch {
     return { ok: false, status: 502, error: "The assistant returned something unreadable." };
   }
+
   const choice = json?.choices?.[0];
   const content = choice?.message?.content;
   if (typeof content !== "string" || !content.trim()) {
@@ -220,16 +273,84 @@ export async function rewriteSections(
     const where = issue?.path?.length ? issue.path.join(".") : "the section list";
     return { ok: false, status: 422, error: `The assistant's edit was rejected at ${where}.` };
   }
-  if (parsed.data.length !== sections.length) {
+  if (parsed.data.length !== batch.length) {
     return {
       ok: false,
       status: 422,
-      error: "The assistant changed how many sections the site has, so the edit was rejected.",
+      error: "The assistant rewrote the wrong number of sections, so the edit was rejected.",
     };
   }
-  if (parsed.data.length > MAX_SECTIONS) {
-    return { ok: false, status: 422, error: "The assistant's edit was too long." };
+
+  return { ok: true, copy: parsed.data };
+}
+
+/** Run `jobs` with at most `limit` in flight, preserving order. */
+async function pooled<T>(jobs: (() => Promise<T>)[], limit: number): Promise<T[]> {
+  const out = new Array<T>(jobs.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, jobs.length) }, async () => {
+    for (;;) {
+      const i = next++;
+      if (i >= jobs.length) return;
+      out[i] = await jobs[i]();
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
+export type RewriteOptions = {
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+};
+
+export async function rewriteSections(
+  sections: Section[],
+  instruction: string,
+  opts: RewriteOptions
+): Promise<AssistantResult> {
+  if (sections.length > MAX_SECTIONS || sections.length > MAX_SECTIONS_IN) {
+    return { ok: false, status: 400, error: "That is more sections than one rewrite can carry." };
   }
 
-  return { ok: true, sections: mergeCopyOnly(sections, parsed.data) };
+  // Spacers render nothing, so sending them would spend a call to be told so.
+  const targets = sections
+    .map((section, index) => ({ index, section }))
+    .filter(({ section }) => section.kind !== "spacer");
+  if (targets.length === 0) return { ok: true, sections };
+
+  const batches: Batch[] = [];
+  for (let i = 0; i < targets.length; i += BATCH_SIZE) {
+    batches.push(targets.slice(i, i + BATCH_SIZE));
+  }
+
+  const results = await pooled(
+    batches.map((batch) => () => rewriteBatch(sections, batch, instruction, opts)),
+    CONCURRENCY
+  );
+
+  // A half-rewritten site is worse than an unchanged one, so one bad batch fails the
+  // whole edit and the editor's document is left exactly as it was.
+  const failure = results.find((r) => !r.ok);
+  if (failure && !failure.ok) return failure;
+
+  const byIndex = new Map<number, Section>();
+  results.forEach((result, b) => {
+    if (!result.ok) return;
+    batches[b].forEach(({ index }, withinBatch) => {
+      const from = result.copy[withinBatch];
+      if (from) byIndex.set(index, from);
+    });
+  });
+
+  return {
+    ok: true,
+    sections: sections.map((section, i) => {
+      const from = byIndex.get(i);
+      return from ? mergeCopyOnly([section], [from])[0] : section;
+    }),
+  };
 }

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -22,6 +22,17 @@ export function completionsUrl(baseUrl?: string): string {
 export const MAX_INSTRUCTION_CHARS = 600;
 export const MAX_SECTIONS_IN = 40;
 
+/**
+ * Output budget for one completion.
+ *
+ * sarvam-105b reasons before it answers, and the API's own default of 2048 was not enough
+ * to hold the reasoning and the rewritten JSON together: every request finished with
+ * `finish_reason: "length"`, 2048 tokens of `reasoning_content` and a null `content`. A
+ * cap only bills what the model actually generates, so this is set well clear of the
+ * whole document rather than tuned tightly.
+ */
+export const MAX_COMPLETION_TOKENS = 16_384;
+
 export type AssistantResult =
   | { ok: true; sections: Section[] }
   | { ok: false; status: number; error: string; diagnostic?: Record<string, unknown> };
@@ -76,6 +87,8 @@ export function systemPrompt(): string {
     '- A section whose kind is "spacer" carries no copy. Return it unchanged.',
     "- Keep a heading under 80 characters and a body under 300.",
     "- Answer in the language the instruction is written in, unless it says otherwise.",
+    "",
+    "Do not explain yourself or think out loud. Emit the array and stop.",
   ].join("\n");
 }
 
@@ -115,6 +128,7 @@ export function buildRequestBody(sections: Section[], instruction: string, model
   return {
     model,
     temperature: 0.3,
+    max_tokens: MAX_COMPLETION_TOKENS,
     messages: [
       { role: "system", content: systemPrompt() },
       {
@@ -169,14 +183,23 @@ export async function rewriteSections(
   } catch {
     return { ok: false, status: 502, error: "The assistant returned something unreadable." };
   }
-  const content = json?.choices?.[0]?.message?.content;
+  const choice = json?.choices?.[0];
+  const content = choice?.message?.content;
   if (typeof content !== "string" || !content.trim()) {
-    return {
-      ok: false,
-      status: 502,
-      error: "The assistant returned nothing.",
-      diagnostic: describeCompletion(json),
-    };
+    const diagnostic = describeCompletion(json);
+    const refusal = choice?.message?.refusal;
+    if (typeof refusal === "string" && refusal.trim()) {
+      return { ok: false, status: 422, error: "The assistant declined that instruction.", diagnostic };
+    }
+    if (choice?.finish_reason === "length") {
+      return {
+        ok: false,
+        status: 502,
+        error: "That was too long for the assistant to finish. Try fewer sections at once.",
+        diagnostic,
+      };
+    }
+    return { ok: false, status: 502, error: "The assistant returned nothing.", diagnostic };
   }
 
   let proposed: unknown;


### PR DESCRIPTION
#379 shipped the assistant with the live API unverified, because there was no key. There is one now, and the feature was broken against the real thing. This fixes it.

## What was wrong

`sarvam-105b` reasons before it answers, and the API's own default output cap is 2048 tokens. Almost every request spent all 2048 of them thinking and returned nothing:

```
finishReason: "length"
messageFields: { content: "object", refusal: "object",
                 reasoning_content: "string(6683)", role: "string(9)" }
usage: { completion_tokens: 2048, prompt_tokens: 254 }
```

`content` was null. The user got "The assistant returned nothing." after 13 seconds of waiting, on every instruction, in every language. The one call that worked during #379's verification simply finished reasoning inside the budget and was luck.

Second problem, only visible once the first was fixed: one call per document does not fit in a request. Measured on production, a single section took 13 to 21 seconds. A nine-section template in Hindi ran past the route's 50 second abort and failed at 53 seconds.

## What changed

**An explicit output budget.** `max_tokens: 16384`, well clear of the whole document. A cap only bills what the model generates, so this is set generously rather than tuned. The system prompt also tells the model not to think out loud.

**Batched, parallel rewriting.** Sections are rewritten `BATCH_SIZE = 3` at a time with `CONCURRENCY = 4`, so wall time tracks the batch rather than the length of the site. Spacers carry no copy and are no longer sent at all, which on a nine-section template drops seven calls to three. Every batch still receives the whole site's copy as read-only context, so wording stays consistent across batches, and Sarvam caches the shared prefix (`cached_tokens: 192` observed).

`MAX_SECTIONS_IN` drops from 40 to 24, which is what two waves of batches actually fit inside the request budget. The old 40 was arbitrary.

**A half-rewritten site is never applied.** One failing batch fails the whole edit, so the editor's document is left exactly as it was.

**Failures now say which failure they are.** Truncation reports "too long to finish, try fewer sections" instead of "returned nothing", and a `refusal` reports as a declined instruction. On any failure the route logs the upstream shape: `finish_reason`, the message field names with their lengths, and usage. Field names and lengths only, never the copy. Without this the original bug was undiagnosable from a 502.

## Verified

Against the real `api.sarvam.ai`, through production:

| | before | after |
|---|---|---|
| One section, English | `content: null`, 13s | rewritten, 13s |
| One section, Hindi | `content: null` | `हर अकाउंट, एक लेजर` |
| One section, Marathi | `content: null` | `प्रत्येक खाते, एक लेजर` |
| Nine sections, Hindi, in the browser | aborted at 53.2s | all 8 non-spacer sections rewritten, 34.2s |

The nine-section run drove the real UI on `scrollcraft-gilt.vercel.app`: typed the instruction, clicked Rewrite copy, waited for the toast, then clicked Undo. Screenshot after the undo shows every heading back in English and the Content panel holding the original copy, so the whole rewrite is still one undo step.

Suite 436 to 448. Two mutants killed:

| Mutation | Result |
|---|---|
| drop `max_tokens`, back to the API default | 1 failed |
| treat a truncated reply as merely empty | 1 failed |

New tests pin the batching directly: spacers cost no call, seven copy sections become three batches, each rewritten heading lands back on the section it came from, spacers stay untouched and in place, every batch gets the whole site as context, one failing batch applies nothing, and a 25 section site is refused before any call is made.

`tsc --noEmit` clean, `eslint` clean, production build clean.

## Still true, and worth saying

34 seconds is a long time to watch a spinner. It is the reasoning, not the network: three batches run in parallel and the slowest one sets the pace. Shrinking it means either a non-reasoning model or a slimmer reply protocol, neither of which belongs in a fix for a broken feature.

Unrelated, seen while reading the logs: `Rate limit backend unavailable, using in-memory fallback` on Upstash, `no response within 2000ms`. Pre-existing and it degrades correctly, but it is real.
