### PR TITLE
Stop drawing canvas previews that are scrolled out of view

### DIFF
--- a/src/__tests__/stylePreviewOffscreen.test.ts
+++ b/src/__tests__/stylePreviewOffscreen.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * The landing page mounts seven canvases. Measured on production at 4x CPU throttle the
+ * page holds a steady 60fps, so the animation is cheap — but the hero kept drawing while
+ * scrolled 8,388px out of view, which spends a phone's battery on pixels nobody sees.
+ */
+describe("StylePreview stops drawing off-screen", () => {
+  const SRC = readFileSync("src/components/StylePreview.tsx", "utf8");
+
+  it("watches whether the canvas is near the viewport", () => {
+    expect(SRC).toContain("IntersectionObserver");
+    expect(SRC, "the observer is never disconnected").toContain("observer.disconnect()");
+  });
+
+  it("gates the animation loop on visibility as well as the paused prop", () => {
+    expect(SRC).toMatch(/if \(paused \|\| !inView\) return;/);
+  });
+
+  it("re-runs the loop when visibility changes", () => {
+    const deps = /\}, \[paused, inView, durationSec, maxProgress\]\);/.exec(SRC);
+    expect(deps, "inView is missing from the loop's dependencies").toBeTruthy();
+  });
+
+  it("assumes visible until told otherwise, so a browser without the observer still animates", () => {
+    expect(SRC).toMatch(/useState\(true\)/);
+    expect(SRC).toContain('typeof IntersectionObserver === "undefined"');
+  });
+
+  it("still paints a static frame while the loop is stopped", () => {
+    // Otherwise a preview scrolled away and back would come back blank.
+    expect(SRC).toMatch(/if \(!paused && inView\) return;/);
+    expect(SRC).toMatch(/\}, \[paused, inView, style, colors\]\);/);
+  });
+});

--- a/src/components/StylePreview.tsx
+++ b/src/components/StylePreview.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { drawFrame2D, type Style2D } from "@/lib/generate2DFrames";
 
 interface StylePreviewProps {
@@ -35,6 +35,23 @@ export default function StylePreview({
 }: StylePreviewProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const sizeRef = useRef({ w: 1, h: 1 });
+
+  // Whether the canvas is anywhere near the viewport. The landing page's hero kept
+  // drawing at 60fps while scrolled thousands of pixels out of sight, which costs a
+  // phone battery for pixels nobody can see. Starts true so a browser without the
+  // observer, or a canvas measured before layout settles, still animates.
+  const [inView, setInView] = useState(true);
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setInView(entry.isIntersecting),
+      // A margin, so the animation is already running by the time it scrolls in.
+      { rootMargin: "200px" }
+    );
+    observer.observe(canvas);
+    return () => observer.disconnect();
+  }, []);
 
   // The running loop reads its draw options from a ref, so recoloring mid-loop
   // repaints on the next tick instead of tearing the loop down and snapping to p=0.
@@ -72,7 +89,7 @@ export default function StylePreview({
   }, []);
 
   useEffect(() => {
-    if (paused) return;
+    if (paused || !inView) return;
     const ctx = canvasRef.current?.getContext("2d");
     if (!ctx) return;
 
@@ -93,16 +110,16 @@ export default function StylePreview({
 
     rafId = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafId);
-  }, [paused, durationSec, maxProgress]);
+  }, [paused, inView, durationSec, maxProgress]);
 
-  // While paused the loop is not running, so redraw the static frame on restyle.
+  // While the loop is not running, redraw the static frame on restyle.
   useEffect(() => {
-    if (!paused) return;
+    if (!paused && inView) return;
     const ctx = canvasRef.current?.getContext("2d");
     if (!ctx) return;
     const { w, h } = sizeRef.current;
     drawFrame2D(ctx, w, h, 0, { style, color1: colors[0], color2: colors[1], color3: colors[2], frameCount: 1 });
-  }, [paused, style, colors]);
+  }, [paused, inView, style, colors]);
 
   return <canvas ref={canvasRef} className={className} aria-hidden="true" />;
 }


### PR DESCRIPTION
Chased a report that the site loads slowly on a phone. It does not, by any measurement I could take, and I could not reproduce it. What I did find is a real waste of battery, which is what this fixes.

## The waste

The landing page mounts seven canvases. The hero one animates at 60fps and kept animating while scrolled **8,388px out of view**, drawing frames nobody can see for as long as the tab is open.

Measured on production before the fix, by fingerprinting the hero canvas's pixels twice 700ms apart:

```
in view              changed=true   (374529 -> 361020)
scrolled far away    changed=true   (374529 -> 361020)   <- still drawing
```

`StylePreview` now watches its own canvas with an `IntersectionObserver` and runs the loop only while the canvas is within 200px of the viewport. The static frame is still repainted while stopped, so a preview scrolled away and back is never blank. `inView` starts `true`, and the observer is skipped where the API is missing, so a browser without it animates exactly as before.

After, same probe:

```
in view              changed=true    (441330 -> 422842)
scrolled far away    changed=false   (688467 -> 688467)   <- stopped
scrolled back        changed=true    (594841 -> 563216)   <- resumed
```

This also helps the create-flow gallery, which mounts a preview per style.

## What this is not

It is not a speed fix, and the report that prompted it is still unexplained. Measured on an emulated phone at 1.6 Mbps with the CPU throttled 4x and a cold cache, against production:

| Page | TTFB | FCP | Loaded | Total blocking time |
|---|---|---|---|---|
| `/` | 233ms (CDN hit) | 872ms | 1.71s | 0ms |
| `/templates` | | 1.28s | 2.25s | 0ms |
| `/editor` | | 1.45s | 2.85s | 48ms |

380 KiB over 36 requests, no external fonts or scripts in the critical path, and a screenshot at the 1s mark already shows the complete hero. Sustained frame rate on the landing page at 4x throttle is a steady 60fps, median gap 16.7ms, worst frame 17ms, unchanged whether the hero is on screen or not.

Two theories worth recording as ruled out:

- **Black-on-black on WebKit.** The CSS emits `lab()` and `color-mix()`, which need newer Safari. Every one of them sits inside `@supports`, with plain hex declared first (`--background:#010101`), so it degrades correctly.
- **Canvas jank starving the main thread.** Plausible, because per-frame work under 50ms never registers as a long task and so hides from Total Blocking Time. Measured and false: 60fps at 4x throttle.

The landing page does carry 77 KiB more script than a plain page like `/privacy` (282 vs 205 KiB), because `HomeClient` is one 405-line client component supporting an FAQ accordion and a hover state. Splitting it into a server component with client islands would recover maybe 20 to 30 KiB, which is about 0.15s on a 1.6 Mbps connection. Not worth restructuring the landing page for, on these numbers.

## Verified

Suite 448 to 453. Behaviour checked in headless Chrome against a production build, before and after, by canvas pixel fingerprint rather than by reading the source. One mutant: dropping the `!inView` gate fails the test.

`tsc --noEmit` clean, `eslint` clean, production build clean.
